### PR TITLE
fix: remove Vercel integration and fix CI test collection

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,6 +8,11 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **Vercel deployments removed**: Added `vercel.json` with `github.enabled: false` to disable Vercel's GitHub integration and stop failing deployment statuses.
+- **pytest collection fixed**: Added `pytest.ini` restricting test discovery to `tests/` — prevents root-level integration scripts (`backend_test.py`, `backend_test_iteration3.py`) from breaking CI.
+
 ### Added — persistent memory
 
 - **Persistent agent memory** (`agent/user_memory.py`): SQLite-backed `UserMemoryStore` lets agents save and recall per-user key/value facts across sessions and server restarts.  New `save_memory` / `recall_memory` tools are available to the agent executor.

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+testpaths = tests

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,6 @@
+{
+  "github": {
+    "enabled": false,
+    "silent": true
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `vercel.json` with `github.enabled: false` to stop the Vercel GitHub App from creating failing deployment statuses on every push
- Adds `pytest.ini` restricting test discovery to `tests/` — prevents root-level `backend_test.py` scripts from breaking CI with missing dependencies

## Test plan

- [x] All 223 existing tests pass locally (`pytest -x`)
- [x] `vercel.json` disables Vercel GitHub integration going forward
- [x] `pytest.ini` confines pytest to `tests/` directory

https://claude.ai/code/session_01MbKdKJkKvQ8n1LYEQYvfxo