### PR TITLE
docs: overhaul README — unified WebUI as hero, SEO, real screenshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,51 +1,139 @@
+<div align="center">
+
 # LLM Relay
 
-> **Route, run, and control LLMs on your own hardware, not someone else's meter.**
+**Self-hosted AI infrastructure — run frontier models on your hardware, route to any provider, control everything from one dashboard.**
 
-A self-hosted, open-source AI platform that gives you everything Emergent, Lovable, and Claude Code offer — on your infrastructure, with zero vendor lock-in.
+[![Stars](https://img.shields.io/github/stars/strikersam/local-llm-server?style=flat-square&color=yellow)](https://github.com/strikersam/local-llm-server/stargazers)
+[![Forks](https://img.shields.io/github/forks/strikersam/local-llm-server?style=flat-square&color=blue)](https://github.com/strikersam/local-llm-server/network)
+[![License](https://img.shields.io/badge/license-Open%20Source-green?style=flat-square)](LICENSE)
+[![Python](https://img.shields.io/badge/python-3.11%2B-blue?style=flat-square&logo=python)](https://www.python.org/)
+[![FastAPI](https://img.shields.io/badge/FastAPI-async-009688?style=flat-square&logo=fastapi)](https://fastapi.tiangolo.com/)
+[![Docker](https://img.shields.io/badge/Docker-Compose-2496ED?style=flat-square&logo=docker)](https://www.docker.com/)
+[![Ollama](https://img.shields.io/badge/Ollama-local%20LLMs-black?style=flat-square)](https://ollama.com/)
 
-![LLM Relay Dashboard](https://static.prod-images.emergentagent.com/jobs/6bf7aa0e-927a-4851-95e4-78f9c580e21a/images/6d1e1a17e7631bc5783700099b8bd99b3256c85b7d78807597ae8cea63ae6ad4.png)
+*Drop-in OpenAI-compatible proxy + agent platform + admin dashboard. Works with Cursor, Claude Code, Aider, Continue, and every tool that speaks the OpenAI API.*
 
----
-
-## What Is LLM Relay?
-
-LLM Relay is a **unified dashboard** that replaces the patchwork of tools you're juggling today. One interface to:
-
-- **Route** requests to any LLM — local Ollama, HuggingFace, OpenRouter, or any OpenAI-compatible API
-- **Run** an AI agent that builds a compounding knowledge wiki (Karpathy's LLM Wiki pattern)
-- **Control** who accesses what — API key management, Langfuse observability, activity audit trail
-
-No subscriptions. No metered API calls on someone else's bill. Your hardware, your data, your rules.
+</div>
 
 ---
 
-## Features
+![Admin Dashboard](docs/screenshots/admin-dashboard-healthy.png)
 
-### Core
+---
 
-| Feature | What It Does |
-|---------|-------------|
-| **Agent Chat** | LLM-powered chat with wiki context. Supports all configured providers. Quick prompts to get started. |
-| **Knowledge Wiki** | Full CRUD markdown wiki with search, tags, cross-references. AI-maintained. |
-| **Source Ingestion** | Upload files, paste URLs, raw text. AI auto-summarizes into structured knowledge. |
-| **Wiki Lint** | AI health check that finds orphan pages, missing refs, stale content. |
+## Why LLM Relay?
+
+Every serious AI developer eventually hits the same wall: **API bills that grow with every experiment, models you can't run privately, and a tangle of tools that don't talk to each other.**
+
+LLM Relay replaces all of that with one self-hosted platform. Point your existing AI coding tools at `http://localhost:8000` — they won't know the difference. Your data never leaves your machine. Your costs drop dramatically.
+
+> **Real numbers from production:** Running DeepSeek-R1 671B locally costs ~$0.19/day in electricity. The equivalent API spend would be $12.84 — a **96.7% reduction**. At 1,842 requests over 30 days, that's real money back in your pocket.
+
+![Langfuse Cost Analysis](docs/screenshots/langfuse-cost-dashboard.png)
+
+---
+
+## What Makes This Different
+
+Most "local LLM" projects give you a bare Ollama wrapper. LLM Relay gives you an **entire AI operations platform**:
+
+| | LLM Relay | Bare Ollama | Paid API |
+|---|---|---|---|
+| OpenAI-compatible API | ✅ | ✅ | ✅ |
+| Multi-provider routing | ✅ | ❌ | ❌ |
+| AI agent with memory | ✅ | ❌ | ❌ |
+| Knowledge wiki | ✅ | ❌ | ❌ |
+| Background task queue | ✅ | ❌ | ❌ |
+| Telegram bot control | ✅ | ❌ | ❌ |
+| Langfuse observability | ✅ | ❌ Partial | ✅ |
+| Cost tracking | ✅ | ❌ | ✅ |
+| Multi-agent swarms | ✅ | ❌ | ❌ |
+| Browser automation | ✅ | ❌ | ❌ |
+| Zero vendor lock-in | ✅ | ✅ | ❌ |
+| Zero ongoing API cost | ✅ | ✅ | ❌ |
+
+---
+
+## Core Features
+
+### Agent Chat + Knowledge Wiki
+
+A full-stack AI agent backed by a structured knowledge base. The agent reads from and writes to a searchable markdown wiki — so knowledge compounds across sessions instead of vanishing when the chat ends.
+
+![Agent UI](docs/screenshots/webui-app.png)
+
+- **Agent Chat** — LLM-powered sessions with full wiki context injection. Supports all configured providers with quick-start prompts.
+- **Knowledge Wiki** — Full CRUD markdown wiki with search, tags, and cross-references. AI-maintained.
+- **Source Ingestion** — Upload files, paste URLs, or raw text. The AI auto-summarizes into structured wiki entries.
+- **Wiki Lint** — AI health check that surfaces orphan pages, missing references, and stale content.
+
+---
+
+### Telegram Bot Control
+
+Control your entire AI stack from your phone. No browser required.
+
+![Telegram Bot](docs/screenshots/telegram-bot-commands.png)
+
+Send commands from anywhere:
+- `/status` — Check Ollama, proxy, and tunnel health + loaded models
+- `/cost` — Real-time electricity cost estimate and hardware amortisation
+- `/models` — List loaded models with VRAM usage
+- `/restart tunnel` — Restart your Cloudflare tunnel and get the new URL
+- `/agent Fix the typo in README` — Dispatch an agent task with confirmation prompt
+
+The bot asks for confirmation before any destructive action, so you never accidentally trigger something from your pocket.
+
+---
+
+### Admin Dashboard
+
+One dashboard to manage every layer of your self-hosted AI stack.
+
+![Admin Dashboard](docs/screenshots/admin-dashboard-healthy.png)
+
+- **Service Controls** — Start/stop/restart Ollama, the OpenAI proxy, and the Cloudflare tunnel — each independently, with live PID display.
+- **Public URL** — Your current Cloudflare tunnel URL, ready to paste into Cursor or any other tool.
+- **API Key Management** — Issue per-user keys with department labels, rotate or revoke with one click. Keys are hashed at rest.
+- **Langfuse Diagnostic** — One-click connection test to verify your observability stack is reachable.
+
+---
+
+### Langfuse Observability
+
+Full tracing for every LLM call — latency, token counts, cost, and per-user attribution.
+
+![Langfuse Trace Detail](docs/screenshots/langfuse-trace-detail.png)
+![Langfuse Cost Dashboard](docs/screenshots/langfuse-cost-dashboard.png)
+
+- Token usage and estimated cost per request
+- Per-user and per-department spend breakdowns
+- Model comparison: see exactly how much each model costs vs. the API equivalent
+- Activity audit trail with category filters (chat, wiki, ingest, keys, auth)
+
+---
+
+### API Key Management
+
+![API Keys](docs/screenshots/admin-keys-section.png)
+
+Issue scoped keys to team members or external tools. Keys carry department metadata for cost attribution in Langfuse. Rotate or revoke any key without restarting the server.
 
 ---
 
 ### Agent Modes
 
-These control *how* the agent operates — think of them as gears on a gearbox.
+Four gears for how the agent operates.
 
-| Feature | What It Does |
-|---------|-------------|
-| **Background Agent** | The agent runs continuously in the background, watching for events. It processes tasks from webhooks, the scheduler, and the watchdog without you opening a chat window. Submit a task to the queue and the agent handles it whenever the worker is free. |
-| **Multi-Agent Swarms** | One coordinator agent breaks a big task into subtasks and hands each one to a worker agent. Workers run in parallel (up to `max_concurrent`), report back, and the coordinator assembles the result. Good for large codebases, parallel research, or anything too big for one agent in one shot. |
-| **Self-Resuming Agents** | The agent saves a memory snapshot before it shuts down and reloads it on restart — picking up exactly where it left off without you having to re-explain the project. Pairs with `POST /agent/memory/{session_id}/snapshot`. |
-| **Voice Commands** | Submit base64-encoded audio to the agent and get a text transcript back. Supports a Whisper-compatible REST API (`WHISPER_BASE_URL` env var) or local `openai-whisper` for fully offline transcription. |
+| Mode | What It Does |
+|------|-------------|
+| **Background Agent** | Runs continuously. Processes tasks from the queue without a chat window — submit and forget. |
+| **Multi-Agent Swarms** | One coordinator breaks a big task into subtasks, dispatches them to parallel workers, and assembles the result. Ideal for large codebases or parallel research. |
+| **Self-Resuming Agents** | Saves a memory snapshot before shutdown, restores it on restart — no re-explaining the project. |
+| **Voice Commands** | Submit base64 audio, get text back. Supports Whisper API or fully local `openai-whisper`. |
 
-**API — Agent Modes**
-
+**Agent API**
 ```
 POST   /agent/coordinate                        Run N workers in parallel under one coordinator
 POST   /agent/background/tasks                  Submit a task to the background queue
@@ -63,129 +151,58 @@ Set the agent loose on a schedule or hook it into your existing event pipeline.
 
 | Feature | What It Does |
 |---------|-------------|
-| **Scheduled Jobs** | Create cron-based schedules for any agent instruction — "run wiki lint every Monday at 9 am", "summarise open GitHub issues daily". Jobs store their last-run timestamp and run count. External webhooks can fire jobs immediately via `/trigger`. |
-| **Automation Playbooks** | Pre-write a multi-step automation as a named playbook. Each step is an agent instruction. Invoke the whole playbook by name and it runs every step in order. Track runs with start/finish timestamps. |
-| **Resource Watchdog** | Point the watchdog at any URL or file. When it detects a content change (via SHA-256 hash comparison), it fires your registered callback. No polling loops to write yourself — just register and start. |
-
-**API — Automation**
+| **Scheduled Jobs** | Cron-based schedules for any agent instruction. "Run wiki lint every Monday at 9 am", "summarise open GitHub issues daily". External webhooks can fire jobs immediately via `/trigger`. |
+| **Automation Playbooks** | Pre-write a multi-step automation as a named playbook. Each step is an agent instruction. Invoke the whole playbook by name and every step runs in order. |
+| **Resource Watchdog** | Point the watchdog at any URL or file. When it detects a content change (SHA-256 hash), it fires your registered callback. No polling loops to write yourself. |
 
 ```
 POST   /agent/scheduler/jobs                    Create a scheduled job (cron expression)
-GET    /agent/scheduler/jobs                    List all jobs
-GET    /agent/scheduler/jobs/{job_id}           Get a job
 POST   /agent/scheduler/jobs/{job_id}/trigger   Fire a job immediately (webhook-style)
-DELETE /agent/scheduler/jobs/{job_id}           Delete a job
-
-POST   /agent/playbooks                         Register a playbook
-GET    /agent/playbooks                         List playbooks (filter by ?tag=)
-GET    /agent/playbooks/{id}                    Get a playbook
-DELETE /agent/playbooks/{id}                    Delete a playbook
 POST   /agent/playbooks/{id}/run                Start a playbook run
-GET    /agent/playbooks/{id}/runs               List runs for a playbook
-
 POST   /agent/watchdog/resources                Start watching a URL or file
-GET    /agent/watchdog/resources                List watched resources
-DELETE /agent/watchdog/resources/{id}           Stop watching
-POST   /agent/watchdog/resources/{id}/check     Check a resource right now
 ```
 
 ---
 
 ### Memory & Context
 
-The agent stays useful over long tasks and long sessions.
+The agent stays coherent over long tasks and long sessions.
 
 | Feature | What It Does |
 |---------|-------------|
-| **Session Memory** | Save a snapshot of the agent's current session state to disk. On restart the agent restores its history, last plan, and result from the snapshot — no external database needed, no re-explaining the project from scratch. |
-| **Smart Context Compression** | Three strategies when conversation history gets too long: **reactive** (drop oldest non-system messages until under the token threshold), **micro** (remove exact duplicates and near-empty messages), **inspect** (return statistics without modifying anything). |
-| **Conversation Surgery** | Remove specific messages from session history by index without wiping everything. Good for cutting out a bad exchange, an outdated instruction, or a confusing tangent. |
-
-**API — Memory & Context**
+| **Session Memory** | Save agent state to disk — history, last plan, last result. Restart and continue without re-explaining. No external database needed. |
+| **Smart Context Compression** | Three strategies when history gets too long: **reactive** (drop oldest non-system messages), **micro** (remove duplicates and near-empty messages), **inspect** (stats only, no mutation). |
+| **Conversation Surgery** | Remove specific messages by index without wiping the session. Cut a bad exchange or an outdated instruction without losing everything else. |
 
 ```
 POST   /agent/memory/{session_id}/snapshot      Save session state to disk
 GET    /agent/memory/{session_id}               Restore saved state
-GET    /agent/memory                            List all snapshots
-DELETE /agent/memory/{session_id}               Delete a snapshot
-
 POST   /agent/context/compress                  Compress messages (strategy: reactive|micro|inspect)
-POST   /agent/context/inspect                   Get token stats for a message list
-
-POST   /agent/sessions/{id}/snip                Remove messages by index from session history
-```
-
----
-
-### Intelligence & Planning
-
-Make the agent think harder before it acts.
-
-| Feature | What It Does |
-|---------|-------------|
-| **Adaptive Permissions** | Analyses the session transcript and infers the appropriate permission level: `read_only`, `read_write`, or `full_access`. Signals include write-intent words (create, edit, commit) and risky words (sudo, exec, destroy). The agent can use this to avoid asking for approval on actions the session has already authorised. |
-| **Token Spend Caps** | Set a maximum token budget per session. Record prompt and completion token counts; when the total reaches the cap a `BudgetExceededError` is raised. Set `cap=0` for unlimited. Useful for metered cloud backends. |
-
-**API — Intelligence**
-
-```
-GET    /agent/sessions/{id}/permissions         Infer permission level from session history
-PUT    /agent/budget/{session_id}               Set a token cap  {"cap": 50000}
-GET    /agent/budget/{session_id}               Get current usage and remaining budget
-GET    /agent/budget                            List all session budgets
+POST   /agent/sessions/{id}/snip                Remove messages by index
 ```
 
 ---
 
 ### Developer Tooling
 
-Utilities that make building on top of LLM Relay easier.
-
 | Feature | What It Does |
 |---------|-------------|
-| **Terminal Panel** | Captures the full rendered terminal buffer via `tmux capture-pane`, or falls back to running a command and capturing stdout+stderr. The agent can read interactive prompts, progress bars, and coloured output — not just raw stdout. |
-| **Skill Library** | Automatically indexes every `SKILL.md` found under `.claude/skills/`. Supports keyword search across name, description, and full content. MCP-hosted skill packs can be registered via the API and are searchable alongside local skills. |
-| **AI Commit Tracking** | Every git commit the agent makes can be tagged with `Agent-Session`, `Agent-Model`, `Agent-Tool`, and `Agent-Timestamp` git trailers. Browse attributed commits via `/agent/commits` to trace which AI session wrote which change. |
-| **Project Scaffolding** | Three built-in project templates (`python-library`, `fastapi-service`, `cli-tool`) plus support for loading custom templates from JSON files. Apply a template to a directory in one API call. |
-| **Browser Automation** | Controls a real Chromium browser via Playwright. Navigate pages, click, fill forms, take screenshots, evaluate JavaScript. Install Playwright to activate; runs in stub mode (graceful failures) when not installed. |
-
-**API — Dev Tooling**
+| **Terminal Panel** | Captures the full rendered terminal buffer via `tmux capture-pane` — interactive prompts, progress bars, and coloured output. Not just raw stdout. |
+| **Skill Library** | Indexes every `SKILL.md` under `.claude/skills/`. Keyword search across name, description, and content. MCP-hosted skill packs register via API. |
+| **AI Commit Tracking** | Tags every agent git commit with session ID, model, tool, and timestamp as git trailers. Browse attributed commits via `/agent/commits`. |
+| **Project Scaffolding** | Three built-in templates (`python-library`, `fastapi-service`, `cli-tool`) plus custom JSON templates. Apply to a directory in one API call. |
+| **Browser Automation** | Controls real Chromium via Playwright. Navigate, click, fill forms, screenshot, run JavaScript. Graceful stubs when Playwright isn't installed. |
+| **Adaptive Permissions** | Infers the right permission level (`read_only`, `read_write`, `full_access`) from the session transcript. Avoids re-asking for actions already authorised. |
+| **Token Budget Caps** | Set a max token spend per session. Raises `BudgetExceededError` at the cap. Set `cap=0` for unlimited. |
 
 ```
 GET    /agent/terminal/snapshot                 Capture current terminal buffer
-POST   /agent/terminal/run                      Run a command and capture full output
-
-GET    /agent/skills                            List skills (filter by ?source=local|mcp)
+POST   /agent/terminal/run                      Run a command, capture full output
 GET    /agent/skills/search?q=...               Search skills by keyword
-POST   /agent/skills/mcp                        Register an MCP-hosted skill
-
-GET    /agent/commits?limit=10                  List recent AI-attributed commits
-
-GET    /agent/scaffolding/templates             List available project templates
-POST   /agent/scaffolding/apply                 Scaffold a new project from a template
-
-POST   /agent/browser/start                     Start a browser session
-POST   /agent/browser/stop                      Stop the browser session
-POST   /agent/browser/action                    Execute a browser action (navigate|click|fill|screenshot|evaluate|get_state)
+GET    /agent/commits?limit=10                  List AI-attributed commits
+POST   /agent/scaffolding/apply                 Scaffold a project from a template
+POST   /agent/browser/action                    Browser action (navigate|click|fill|screenshot|evaluate)
 ```
-
----
-
-### Infrastructure
-
-| Feature | What It Does |
-|---------|-------------|
-| **Providers** | Add/configure/test LLM backends. Switch between local Ollama, HuggingFace, OpenRouter, custom endpoints. Set a default with one click. |
-| **Models Hub** | Pull/delete Ollama models. View cloud model references. One-line model downloads. |
-| **API Keys** | Issue/revoke API keys for external tools — Cursor, Claude Code, Aider, Continue. Hashed storage. |
-
-### System
-
-| Feature | What It Does |
-|---------|-------------|
-| **Observability** | Langfuse integration — token usage, cost tracking, latency metrics, per-user attribution. |
-| **Activity Log** | Complete audit trail with category filtering (chat, wiki, ingest, provider, keys, auth). |
-| **Health Dashboard** | Real-time status for MongoDB, Ollama, Langfuse. ngrok domain display. |
 
 ---
 
@@ -212,16 +229,16 @@ POST   /agent/browser/action                    Execute a browser action (naviga
                            │        │        │
                            │  ┌─────┤  ┌─────┘
                            │  ▼     │  ▼
-                           │Langfuse│ ngrok
-                           │(Trace) │(Tunnel)
+                           │Langfuse│ Cloudflare
+                           │(Trace) │  Tunnel
                            └────────┘
 ```
 
-Three-layer knowledge architecture (Karpathy LLM Wiki pattern):
+**Knowledge architecture — three layers:**
 
-1. **Raw Sources** — Files, URLs, text ingested and AI-processed
-2. **Wiki** — LLM-maintained markdown knowledge base
-3. **Agent** — Query, lint, cross-reference, expand
+1. **Raw Sources** — Files, URLs, and text ingested and processed by the AI
+2. **Wiki** — LLM-maintained structured markdown knowledge base
+3. **Agent** — Query, lint, cross-reference, and expand knowledge on demand
 
 ---
 
@@ -236,8 +253,8 @@ cd local-llm-server
 cp .env.example .env   # edit with your settings
 
 docker compose up -d                      # core services
-docker compose --profile public up -d     # + ngrok tunnel
-docker compose --profile full up -d       # + proxy for Cursor/Claude Code
+docker compose --profile public up -d     # + Cloudflare tunnel
+docker compose --profile full up -d       # + OpenAI proxy for Cursor/Claude Code
 ```
 
 Open **http://localhost:3000** and log in.
@@ -249,38 +266,64 @@ Email:    admin@llmwiki.local
 Password: WikiAdmin2026!
 ```
 
-Change these in `.env` before deploying publicly.
+> Change these in `.env` before exposing to the internet.
 
 ---
 
-## Optional Feature Dependencies
+## Connecting External Tools
 
-Some features require additional packages. All degrade gracefully when not installed.
+The proxy is fully OpenAI-compatible. Any tool that accepts a custom base URL works out of the box.
 
-| Feature | Install command | Env var |
-|---------|-----------------|---------|
-| Browser Automation | `pip install playwright && playwright install chromium` | — |
-| Voice (Whisper API) | — | `WHISPER_BASE_URL=http://localhost:9000` |
-| Voice (local Whisper) | `pip install openai-whisper` | — |
-| Voice recording | `pip install pyaudio` | — |
-| Scheduled Jobs (cron) | `pip install apscheduler` *(bundled)* | — |
+### Cursor IDE
+```
+Settings → Models → OpenAI API Key:
+  API Key:  <from API Keys page>
+  Base URL: https://your-domain.trycloudflare.com/v1
+  Model:    qwen3-coder:30b
+```
+
+### Claude Code CLI
+```bash
+export ANTHROPIC_BASE_URL=https://your-domain.trycloudflare.com
+export ANTHROPIC_API_KEY=sk-relay-...
+claude
+```
+
+### Aider
+```bash
+aider --openai-api-base https://your-domain.trycloudflare.com/v1 \
+      --openai-api-key sk-relay-...
+```
+
+### Continue (VS Code / JetBrains)
+```json
+{
+  "models": [{
+    "title": "Local LLM",
+    "provider": "openai",
+    "model": "qwen3-coder:30b",
+    "apiBase": "https://your-domain.trycloudflare.com/v1",
+    "apiKey": "sk-relay-..."
+  }]
+}
+```
 
 ---
 
 ## Provider Setup
 
 ### Ollama (Local — zero cost)
-Runs as a Docker service. Models auto-downloaded.
+Runs as a Docker service. Models auto-downloaded on first pull.
 
 ```bash
-# Pull additional models via dashboard or CLI
+# Pull models via dashboard or CLI
 docker exec llm-wiki-ollama ollama pull qwen3-coder:30b
-docker exec llm-wiki-ollama ollama pull deepseek-r1:32b
+docker exec llm-wiki-ollama ollama pull deepseek-r1:671b
 ```
 
 ### HuggingFace Inference API
-Go to **Providers** → **Add Provider**:
-- Type: OpenAI Compatible
+Go to **Providers → Add Provider**:
+- Type: `OpenAI Compatible`
 - Base URL: `https://api-inference.huggingface.co/v1`
 - API Key: your HuggingFace token
 - Model: `meta-llama/Llama-3.2-3B-Instruct`
@@ -289,34 +332,23 @@ Go to **Providers** → **Add Provider**:
 - Base URL: `https://openrouter.ai/api/v1`
 - API Key: your OpenRouter key
 
-### Remote Ollama (another machine)
-- Type: Ollama
+### Remote Ollama (another machine on your network)
+- Type: `Ollama`
 - Base URL: `http://192.168.1.100:11434`
 
 ---
 
-## Connecting External Tools
+## Optional Feature Dependencies
 
-### Cursor IDE
-```
-Settings → Models → OpenAI API Key:
-  API Key: <from API Keys page>
-  Base URL: https://your-domain.ngrok-free.dev/v1
-  Model: qwen3-coder:30b
-```
+All features degrade gracefully — nothing crashes if a dependency isn't installed.
 
-### Claude Code CLI
-```bash
-export ANTHROPIC_BASE_URL=https://your-domain.ngrok-free.dev
-export ANTHROPIC_API_KEY=sk-relay-...
-claude
-```
-
-### Aider
-```bash
-aider --openai-api-base https://your-domain.ngrok-free.dev/v1 \
-      --openai-api-key sk-relay-...
-```
+| Feature | Install | Env var |
+|---------|---------|---------|
+| Browser Automation | `pip install playwright && playwright install chromium` | — |
+| Voice (Whisper API) | — | `WHISPER_BASE_URL=http://localhost:9000` |
+| Voice (local Whisper) | `pip install openai-whisper` | — |
+| Voice recording | `pip install pyaudio` | — |
+| Scheduled Jobs | `pip install apscheduler` *(bundled)* | — |
 
 ---
 
@@ -324,12 +356,12 @@ aider --openai-api-base https://your-domain.ngrok-free.dev/v1 \
 
 | Service | Port | Description |
 |---------|------|-------------|
-| **Frontend** | 3000 | Unified React dashboard |
-| **Backend** | 8001 | FastAPI API server |
-| **Proxy** | 8000 | OpenAI/Anthropic-compat proxy (Cursor/Claude Code) |
+| **Frontend** | 3000 | React dashboard — chat, wiki, admin |
+| **Backend** | 8001 | FastAPI — all API endpoints |
+| **Proxy** | 8000 | OpenAI/Anthropic-compatible proxy |
 | **MongoDB** | 27017 | Document store |
 | **Ollama** | 11434 | Local LLM runtime |
-| **ngrok** | — | Public tunnel (optional) |
+| **Cloudflare Tunnel** | — | Public HTTPS endpoint (optional) |
 
 ---
 
@@ -442,23 +474,23 @@ aider --openai-api-base https://your-domain.ngrok-free.dev/v1 \
 | Frontend | React 18, Tailwind CSS, React Router, React Markdown, Lucide |
 | Backend | Python 3.11, FastAPI, Motor (async MongoDB), PyJWT, bcrypt, httpx |
 | Database | MongoDB 7 |
-| LLM Runtime | Ollama (local) / Any OpenAI-compatible API |
+| LLM Runtime | Ollama (local) + any OpenAI-compatible API |
 | Observability | Langfuse |
-| Tunnel | ngrok |
+| Tunnel | Cloudflare Tunnel |
 | Containers | Docker Compose |
-
-## Synthesized From
-
-| Source | Key Pattern Adopted |
-|--------|-------------------|
-| [Karpathy LLM Wiki](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f) | Three-layer knowledge architecture |
-| [Docker Sandboxes](https://www.docker.com/blog/docker-sandboxes-run-agents-in-yolo-mode-safely/) | Isolated, safe agent execution |
-| [Multi-Agent AI](https://www.infoworld.com/article/4154335/multi-agent-ai-is-the-new-microservices.html) | Simple agent design, avoid over-engineering |
-| [Claw Code](https://github.com/ultraworkers/claw-code) | CLI agent patterns, session management, provider routing |
-| [Claude Code Token Analyzer](https://gist.github.com/kieranklaassen/7b2ebb39cbbb78cc2831497605d76cc6) | Usage tracking, cost awareness |
 
 ---
 
 ## License
 
 Open source. Use it, fork it, ship it.
+
+---
+
+<div align="center">
+
+**If this saves you money or unblocks your workflow, a star helps others find it.**
+
+[![Star this repo](https://img.shields.io/github/stars/strikersam/local-llm-server?style=social)](https://github.com/strikersam/local-llm-server/stargazers)
+
+</div>

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # LLM Relay
 
-**Self-hosted AI infrastructure — run frontier models on your hardware, route to any provider, control everything from one dashboard.**
+**A complete self-hosted AI platform — unified dashboard, multi-provider LLM routing, AI agent with memory, knowledge wiki, Telegram bot control, and full Langfuse observability.**
 
 [![Stars](https://img.shields.io/github/stars/strikersam/local-llm-server?style=flat-square&color=yellow)](https://github.com/strikersam/local-llm-server/stargazers)
 [![Forks](https://img.shields.io/github/forks/strikersam/local-llm-server?style=flat-square&color=blue)](https://github.com/strikersam/local-llm-server/network)
@@ -12,23 +12,29 @@
 [![Docker](https://img.shields.io/badge/Docker-Compose-2496ED?style=flat-square&logo=docker)](https://www.docker.com/)
 [![Ollama](https://img.shields.io/badge/Ollama-local%20LLMs-black?style=flat-square)](https://ollama.com/)
 
-*Drop-in OpenAI-compatible proxy + agent platform + admin dashboard. Works with Cursor, Claude Code, Aider, Continue, and every tool that speaks the OpenAI API.*
+*Drop-in OpenAI-compatible proxy — point Cursor, Claude Code, Aider, or Continue at it and everything just works. Your hardware. Your data. Zero API bills.*
 
 </div>
 
 ---
 
-![Admin Dashboard](docs/screenshots/admin-dashboard-healthy.png)
+## The Unified Interface
+
+One dark-themed dashboard for everything: chat with your AI agent, manage providers and workspaces, run commands, and control access — all without touching a terminal.
+
+![LLM Relay Unified UI](docs/screenshots/webui-app.png)
+
+> The agent knows your workspace, remembers context across sessions, and executes tasks directly in your project. Hit **New session**, paste your API key, pick a model, and start building.
 
 ---
 
 ## Why LLM Relay?
 
-Every serious AI developer eventually hits the same wall: **API bills that grow with every experiment, models you can't run privately, and a tangle of tools that don't talk to each other.**
+Every serious AI developer eventually hits the same wall: API bills that compound with every experiment, models you can't run privately, and a pile of tools that don't talk to each other.
 
-LLM Relay replaces all of that with one self-hosted platform. Point your existing AI coding tools at `http://localhost:8000` — they won't know the difference. Your data never leaves your machine. Your costs drop dramatically.
+LLM Relay replaces that with a single self-hosted platform. Your existing tools — Cursor, Claude Code, Aider, Continue — keep working without changes. The data never leaves your machine. And the cost difference is stark:
 
-> **Real numbers from production:** Running DeepSeek-R1 671B locally costs ~$0.19/day in electricity. The equivalent API spend would be $12.84 — a **96.7% reduction**. At 1,842 requests over 30 days, that's real money back in your pocket.
+> **Real production numbers:** DeepSeek-R1 671B locally costs ~$0.19/day in electricity. The API equivalent: $12.84 — a **96.7% reduction** across 1,842 requests.
 
 ![Langfuse Cost Analysis](docs/screenshots/langfuse-cost-dashboard.png)
 
@@ -36,18 +42,16 @@ LLM Relay replaces all of that with one self-hosted platform. Point your existin
 
 ## What Makes This Different
 
-Most "local LLM" projects give you a bare Ollama wrapper. LLM Relay gives you an **entire AI operations platform**:
-
 | | LLM Relay | Bare Ollama | Paid API |
 |---|---|---|---|
 | OpenAI-compatible API | ✅ | ✅ | ✅ |
+| Unified web dashboard | ✅ | ❌ | ❌ |
 | Multi-provider routing | ✅ | ❌ | ❌ |
 | AI agent with memory | ✅ | ❌ | ❌ |
 | Knowledge wiki | ✅ | ❌ | ❌ |
 | Background task queue | ✅ | ❌ | ❌ |
 | Telegram bot control | ✅ | ❌ | ❌ |
-| Langfuse observability | ✅ | ❌ Partial | ✅ |
-| Cost tracking | ✅ | ❌ | ✅ |
+| Cost tracking + attribution | ✅ | ❌ | ✅ |
 | Multi-agent swarms | ✅ | ❌ | ❌ |
 | Browser automation | ✅ | ❌ | ❌ |
 | Zero vendor lock-in | ✅ | ✅ | ❌ |
@@ -55,70 +59,73 @@ Most "local LLM" projects give you a bare Ollama wrapper. LLM Relay gives you an
 
 ---
 
-## Core Features
+## Features
 
-### Agent Chat + Knowledge Wiki
+### Providers, Workspaces & Command Runner
 
-A full-stack AI agent backed by a structured knowledge base. The agent reads from and writes to a searchable markdown wiki — so knowledge compounds across sessions instead of vanishing when the chat ends.
+The admin panel in the unified UI lets you wire up any LLM backend, point the agent at your codebase, and run commands — all from the same interface.
 
-![Agent UI](docs/screenshots/webui-app.png)
+![Unified Admin Panel](docs/screenshots/webui-admin.png)
 
-- **Agent Chat** — LLM-powered sessions with full wiki context injection. Supports all configured providers with quick-start prompts.
-- **Knowledge Wiki** — Full CRUD markdown wiki with search, tags, and cross-references. AI-maintained.
-- **Source Ingestion** — Upload files, paste URLs, or raw text. The AI auto-summarizes into structured wiki entries.
-- **Wiki Lint** — AI health check that surfaces orphan pages, missing references, and stale content.
+- **Providers** — Add any OpenAI-compatible endpoint: local Ollama, HuggingFace, OpenRouter, or a remote machine. Test the connection in one click.
+- **Workspaces** — Bind the agent to a directory on disk. The agent reads, writes, and searches only within that scope.
+- **Command Runner** — Execute shell commands (e.g. `git status`, `pytest`) directly from the dashboard and capture the full output.
 
 ---
 
 ### Telegram Bot Control
 
-Control your entire AI stack from your phone. No browser required.
+Control your entire AI stack from your phone — no browser, no VPN needed.
 
 ![Telegram Bot](docs/screenshots/telegram-bot-commands.png)
 
-Send commands from anywhere:
-- `/status` — Check Ollama, proxy, and tunnel health + loaded models
-- `/cost` — Real-time electricity cost estimate and hardware amortisation
-- `/models` — List loaded models with VRAM usage
-- `/restart tunnel` — Restart your Cloudflare tunnel and get the new URL
-- `/agent Fix the typo in README` — Dispatch an agent task with confirmation prompt
+| Command | What It Does |
+|---------|-------------|
+| `/status` | Ollama, proxy, and tunnel health + models loaded and VRAM usage |
+| `/cost` | Real-time electricity estimate and hardware amortisation breakdown |
+| `/models` | List every loaded model with size |
+| `/restart tunnel` | Restart the Cloudflare tunnel and return the new public URL |
+| `/agent Fix the typo in README` | Dispatch an agent task — confirms before executing |
 
-The bot asks for confirmation before any destructive action, so you never accidentally trigger something from your pocket.
-
----
-
-### Admin Dashboard
-
-One dashboard to manage every layer of your self-hosted AI stack.
-
-![Admin Dashboard](docs/screenshots/admin-dashboard-healthy.png)
-
-- **Service Controls** — Start/stop/restart Ollama, the OpenAI proxy, and the Cloudflare tunnel — each independently, with live PID display.
-- **Public URL** — Your current Cloudflare tunnel URL, ready to paste into Cursor or any other tool.
-- **API Key Management** — Issue per-user keys with department labels, rotate or revoke with one click. Keys are hashed at rest.
-- **Langfuse Diagnostic** — One-click connection test to verify your observability stack is reachable.
+The bot prompts for confirmation before any write or restart action, so nothing fires accidentally from your pocket.
 
 ---
 
 ### Langfuse Observability
 
-Full tracing for every LLM call — latency, token counts, cost, and per-user attribution.
+Full distributed tracing for every LLM call — latency, token counts, per-request cost, and per-user attribution.
 
-![Langfuse Trace Detail](docs/screenshots/langfuse-trace-detail.png)
-![Langfuse Cost Dashboard](docs/screenshots/langfuse-cost-dashboard.png)
+![Langfuse Traces](docs/screenshots/langfuse-traces-list.png)
 
-- Token usage and estimated cost per request
-- Per-user and per-department spend breakdowns
-- Model comparison: see exactly how much each model costs vs. the API equivalent
+- Per-request cost in dollars, visible per user and per department
+- Model comparison: see exactly what local inference saves vs. the cloud equivalent
+- Latency breakdown across every span in the call chain
 - Activity audit trail with category filters (chat, wiki, ingest, keys, auth)
 
 ---
 
-### API Key Management
+### Service Controls & API Key Management
 
-![API Keys](docs/screenshots/admin-keys-section.png)
+The admin control plane lets you start, stop, and restart each service independently, manage your Cloudflare tunnel, and issue scoped API keys — all without SSH.
 
-Issue scoped keys to team members or external tools. Keys carry department metadata for cost attribution in Langfuse. Rotate or revoke any key without restarting the server.
+![Admin Dashboard](docs/screenshots/admin-dashboard-healthy.png)
+
+- **Service controls** — Start/stop/restart Ollama, the proxy, and the tunnel independently. Live PID and URL display.
+- **Public URL** — Your current Cloudflare tunnel URL, always visible and ready to paste into Cursor or any other tool.
+- **API keys** — Issue per-user keys with department labels for cost attribution. Keys are hashed at rest. Rotate or revoke without restarting the server.
+
+![API Key Created](docs/screenshots/admin-key-created.png)
+
+---
+
+### Agent Chat + Knowledge Wiki
+
+The agent is backed by a structured knowledge base. It reads from and writes to a searchable markdown wiki — so knowledge compounds across sessions instead of vanishing when the chat ends.
+
+- **Agent Chat** — Persistent sessions with full wiki context injection. All configured providers available. Quick-start prompts included.
+- **Knowledge Wiki** — Full CRUD markdown wiki with search, tags, and cross-references. AI-maintained.
+- **Source Ingestion** — Upload files, paste URLs, or raw text. The AI auto-summarises into structured wiki entries.
+- **Wiki Lint** — AI health check that surfaces orphan pages, missing references, and stale content.
 
 ---
 
@@ -128,10 +135,10 @@ Four gears for how the agent operates.
 
 | Mode | What It Does |
 |------|-------------|
-| **Background Agent** | Runs continuously. Processes tasks from the queue without a chat window — submit and forget. |
-| **Multi-Agent Swarms** | One coordinator breaks a big task into subtasks, dispatches them to parallel workers, and assembles the result. Ideal for large codebases or parallel research. |
-| **Self-Resuming Agents** | Saves a memory snapshot before shutdown, restores it on restart — no re-explaining the project. |
-| **Voice Commands** | Submit base64 audio, get text back. Supports Whisper API or fully local `openai-whisper`. |
+| **Background Agent** | Runs continuously. Processes tasks from the queue without a chat window open — submit and forget. |
+| **Multi-Agent Swarms** | One coordinator breaks a big task into subtasks, dispatches them to parallel workers (up to `max_concurrent`), and assembles the result. Ideal for large codebases or parallel research. |
+| **Self-Resuming Agents** | Saves a full memory snapshot before shutdown and restores it on restart — picks up exactly where it left off without re-explaining the project. |
+| **Voice Commands** | Submit base64-encoded audio, get a text transcript back. Supports Whisper API or fully local `openai-whisper` for offline transcription. |
 
 **Agent API**
 ```
@@ -147,13 +154,13 @@ GET    /agent/voice/status                      Check microphone and Whisper ava
 
 ### Automation & Scheduling
 
-Set the agent loose on a schedule or hook it into your existing event pipeline.
+Set the agent on a schedule or hook it into your existing event pipeline.
 
 | Feature | What It Does |
 |---------|-------------|
-| **Scheduled Jobs** | Cron-based schedules for any agent instruction. "Run wiki lint every Monday at 9 am", "summarise open GitHub issues daily". External webhooks can fire jobs immediately via `/trigger`. |
-| **Automation Playbooks** | Pre-write a multi-step automation as a named playbook. Each step is an agent instruction. Invoke the whole playbook by name and every step runs in order. |
-| **Resource Watchdog** | Point the watchdog at any URL or file. When it detects a content change (SHA-256 hash), it fires your registered callback. No polling loops to write yourself. |
+| **Scheduled Jobs** | Cron-based schedules for any agent instruction — "run wiki lint every Monday", "summarise open GitHub issues daily". Webhooks can fire jobs immediately via `/trigger`. |
+| **Automation Playbooks** | Pre-write a multi-step automation as a named playbook. Each step is an agent instruction. Invoke by name — every step runs in order. Runs are timestamped. |
+| **Resource Watchdog** | Point at any URL or file. When content changes (SHA-256 hash comparison), fires your registered callback. No polling loop to write yourself. |
 
 ```
 POST   /agent/scheduler/jobs                    Create a scheduled job (cron expression)
@@ -170,9 +177,9 @@ The agent stays coherent over long tasks and long sessions.
 
 | Feature | What It Does |
 |---------|-------------|
-| **Session Memory** | Save agent state to disk — history, last plan, last result. Restart and continue without re-explaining. No external database needed. |
-| **Smart Context Compression** | Three strategies when history gets too long: **reactive** (drop oldest non-system messages), **micro** (remove duplicates and near-empty messages), **inspect** (stats only, no mutation). |
-| **Conversation Surgery** | Remove specific messages by index without wiping the session. Cut a bad exchange or an outdated instruction without losing everything else. |
+| **Session Memory** | Snapshot agent state (history, last plan, last result) to disk. Restart and continue — no external database, no re-explaining. |
+| **Smart Context Compression** | Three strategies when history grows too long: **reactive** (drop oldest non-system messages), **micro** (remove duplicates and near-empty messages), **inspect** (stats only, no mutation). |
+| **Conversation Surgery** | Remove specific messages by index without wiping the session — cut a bad exchange or an outdated instruction without losing everything else. |
 
 ```
 POST   /agent/memory/{session_id}/snapshot      Save session state to disk
@@ -187,12 +194,12 @@ POST   /agent/sessions/{id}/snip                Remove messages by index
 
 | Feature | What It Does |
 |---------|-------------|
-| **Terminal Panel** | Captures the full rendered terminal buffer via `tmux capture-pane` — interactive prompts, progress bars, and coloured output. Not just raw stdout. |
-| **Skill Library** | Indexes every `SKILL.md` under `.claude/skills/`. Keyword search across name, description, and content. MCP-hosted skill packs register via API. |
+| **Terminal Panel** | Captures the full rendered terminal buffer via `tmux capture-pane` — interactive prompts, progress bars, coloured output. Not just raw stdout. |
+| **Skill Library** | Indexes every `SKILL.md` under `.claude/skills/`. Keyword search across name, description, and content. MCP-hosted skill packs register via the API. |
 | **AI Commit Tracking** | Tags every agent git commit with session ID, model, tool, and timestamp as git trailers. Browse attributed commits via `/agent/commits`. |
 | **Project Scaffolding** | Three built-in templates (`python-library`, `fastapi-service`, `cli-tool`) plus custom JSON templates. Apply to a directory in one API call. |
-| **Browser Automation** | Controls real Chromium via Playwright. Navigate, click, fill forms, screenshot, run JavaScript. Graceful stubs when Playwright isn't installed. |
-| **Adaptive Permissions** | Infers the right permission level (`read_only`, `read_write`, `full_access`) from the session transcript. Avoids re-asking for actions already authorised. |
+| **Browser Automation** | Controls real Chromium via Playwright — navigate, click, fill forms, screenshot, run JavaScript. Graceful stubs when Playwright isn't installed. |
+| **Adaptive Permissions** | Infers `read_only`, `read_write`, or `full_access` from the session transcript. Avoids re-asking for actions already authorised. |
 | **Token Budget Caps** | Set a max token spend per session. Raises `BudgetExceededError` at the cap. Set `cap=0` for unlimited. |
 
 ```
@@ -211,9 +218,9 @@ POST   /agent/browser/action                    Browser action (navigate|click|f
 ```
                         ┌──────────────────────────────┐
                         │    React Dashboard (3000)     │
-                        │  Login | Dashboard | Chat     │
-                        │  Wiki | Sources | Providers   │
-                        │  Models | Keys | Observability│
+                        │  Login | Agent Chat | Wiki    │
+                        │  Sources | Admin | Providers  │
+                        │  Workspaces | Keys | Traces   │
                         └──────────────┬───────────────┘
                                        │
                         ┌──────────────┴───────────────┐
@@ -257,7 +264,7 @@ docker compose --profile public up -d     # + Cloudflare tunnel
 docker compose --profile full up -d       # + OpenAI proxy for Cursor/Claude Code
 ```
 
-Open **http://localhost:3000** and log in.
+Open **http://localhost:3000** — the unified dashboard loads immediately.
 
 ### Default Credentials
 
@@ -272,26 +279,26 @@ Password: WikiAdmin2026!
 
 ## Connecting External Tools
 
-The proxy is fully OpenAI-compatible. Any tool that accepts a custom base URL works out of the box.
+The proxy speaks the OpenAI API. Any tool that accepts a custom base URL works without modification.
 
 ### Cursor IDE
 ```
 Settings → Models → OpenAI API Key:
   API Key:  <from API Keys page>
-  Base URL: https://your-domain.trycloudflare.com/v1
+  Base URL: https://your-tunnel.trycloudflare.com/v1
   Model:    qwen3-coder:30b
 ```
 
 ### Claude Code CLI
 ```bash
-export ANTHROPIC_BASE_URL=https://your-domain.trycloudflare.com
+export ANTHROPIC_BASE_URL=https://your-tunnel.trycloudflare.com
 export ANTHROPIC_API_KEY=sk-relay-...
 claude
 ```
 
 ### Aider
 ```bash
-aider --openai-api-base https://your-domain.trycloudflare.com/v1 \
+aider --openai-api-base https://your-tunnel.trycloudflare.com/v1 \
       --openai-api-key sk-relay-...
 ```
 
@@ -302,7 +309,7 @@ aider --openai-api-base https://your-domain.trycloudflare.com/v1 \
     "title": "Local LLM",
     "provider": "openai",
     "model": "qwen3-coder:30b",
-    "apiBase": "https://your-domain.trycloudflare.com/v1",
+    "apiBase": "https://your-tunnel.trycloudflare.com/v1",
     "apiKey": "sk-relay-..."
   }]
 }
@@ -313,26 +320,24 @@ aider --openai-api-base https://your-domain.trycloudflare.com/v1 \
 ## Provider Setup
 
 ### Ollama (Local — zero cost)
-Runs as a Docker service. Models auto-downloaded on first pull.
+Runs as a Docker service. Models download on first pull.
 
 ```bash
-# Pull models via dashboard or CLI
 docker exec llm-wiki-ollama ollama pull qwen3-coder:30b
 docker exec llm-wiki-ollama ollama pull deepseek-r1:671b
 ```
 
 ### HuggingFace Inference API
-Go to **Providers → Add Provider**:
+**Providers → Add Provider:**
 - Type: `OpenAI Compatible`
 - Base URL: `https://api-inference.huggingface.co/v1`
 - API Key: your HuggingFace token
-- Model: `meta-llama/Llama-3.2-3B-Instruct`
 
 ### OpenRouter
 - Base URL: `https://openrouter.ai/api/v1`
 - API Key: your OpenRouter key
 
-### Remote Ollama (another machine on your network)
+### Remote Ollama (another machine)
 - Type: `Ollama`
 - Base URL: `http://192.168.1.100:11434`
 
@@ -340,7 +345,7 @@ Go to **Providers → Add Provider**:
 
 ## Optional Feature Dependencies
 
-All features degrade gracefully — nothing crashes if a dependency isn't installed.
+All features degrade gracefully — nothing crashes when a dependency isn't installed.
 
 | Feature | Install | Env var |
 |---------|---------|---------|
@@ -356,7 +361,7 @@ All features degrade gracefully — nothing crashes if a dependency isn't instal
 
 | Service | Port | Description |
 |---------|------|-------------|
-| **Frontend** | 3000 | React dashboard — chat, wiki, admin |
+| **Frontend** | 3000 | Unified React dashboard |
 | **Backend** | 8001 | FastAPI — all API endpoints |
 | **Proxy** | 8000 | OpenAI/Anthropic-compatible proxy |
 | **MongoDB** | 27017 | Document store |
@@ -384,7 +389,7 @@ All features degrade gracefully — nothing crashes if a dependency isn't instal
 
 | Method | Endpoint | Description |
 |--------|----------|-------------|
-| POST | `/api/chat/send` | Send message to wiki agent |
+| POST | `/api/chat/send` | Send message to agent |
 | GET | `/api/chat/sessions` | List sessions |
 | GET | `/api/chat/sessions/:id` | Get session |
 | DELETE | `/api/chat/sessions/:id` | Delete session |


### PR DESCRIPTION
## What changed

Complete README overhaul across two commits.

### Screenshots
- **Hero** swapped from old light-themed admin panel → unified dark WebUI (`webui-app.png`) — the actual centrepiece
- Added `webui-admin.png` to showcase providers, workspaces, and command runner in the unified UI
- Added `langfuse-traces-list.png` showing per-user cost rows in Langfuse
- Replaced `admin-keys-section.png` with `admin-key-created.png` (cleaner flow)
- Removed `api-models-response` and `api-health-response` screenshots (raw JSON, not useful)

### Content
- Removed "Synthesized From" table and all Karpathy attribution
- Updated subtitle to reflect the full platform scope (not just proxy + tunnel)
- Added competitive comparison table: LLM Relay vs bare Ollama vs paid API
- Led with real cost numbers ($0.19 vs $12.84 / 96.7% savings) from actual Langfuse data
- Elevated Telegram bot section with command table
- Added Continue IDE config alongside Cursor/Claude Code/Aider
- Added badges row and star CTA footer

### SEO
- Natural placement of: "self-hosted AI platform", "OpenAI-compatible proxy", "local LLM server", "zero vendor lock-in", "multi-provider routing"