### PR TITLE
fix: restore seed_default_providers to fix login crash

### DIFF
--- a/backend/server.py
+++ b/backend/server.py
@@ -832,6 +832,7 @@ async def seed_default_agents() -> None:
         log.info("Seeded CRISPY agent: %s (%s)", profile.name, profile.model)
 
 
+async def seed_default_providers():
     defaults = [
         {
             "provider_id": "ollama-local",

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,6 +8,11 @@
 
 ## [Unreleased]
 
+## [2.2.1] — 2026-04-25
+
+### Fixed
+- **Login throws "something went wrong" after CRISPY agent seeding commit** — `seed_default_providers` was accidentally removed when `seed_default_agents` was added; its body was merged into the new function leaving `ensure_bootstrap` calling a non-existent function. Restored `seed_default_providers` as a standalone async function.
+
 ## [2.2.0] — 2026-04-25
 
 ### Fixed

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,8 +8,6 @@
 
 ## [Unreleased]
 
-## [2.2.1] — 2026-04-25
-
 ### Fixed
 - **Login throws "something went wrong" after CRISPY agent seeding commit** — `seed_default_providers` was accidentally removed when `seed_default_agents` was added; its body was merged into the new function leaving `ensure_bootstrap` calling a non-existent function. Restored `seed_default_providers` as a standalone async function.
 


### PR DESCRIPTION
## Summary

- `seed_default_providers` was accidentally deleted in commit `775106d` — its body was merged into `seed_default_agents`, leaving `ensure_bootstrap` calling a non-existent function
- `ensure_bootstrap` is called on every `POST /api/auth/login`, so the `NameError` surfaced as a 500 → "something went wrong" on the login page
- Restored `async def seed_default_providers():` as a standalone function (one-line fix)

## Test plan

- [ ] Start the server and confirm login succeeds with admin credentials
- [ ] Confirm both CRISPY agents and default providers are seeded on first boot
- [ ] Confirm pipeline tests pass in CI

https://claude.ai/code/session_01P978msYJEx7zFVHoTXQeCB

---
_Generated by [Claude Code](https://claude.ai/code/session_01P978msYJEx7zFVHoTXQeCB)_