### PR TITLE
fix: Tasks 401 and Gemini 400 Bad Request

### DIFF
--- a/backend/llm_providers.py
+++ b/backend/llm_providers.py
@@ -4,6 +4,7 @@ import logging
 import re
 from dataclasses import dataclass
 from typing import Any
+from urllib.parse import urlparse
 
 import httpx
 
@@ -27,12 +28,15 @@ def normalize_base_url(base_url: str) -> str:
 def openai_compat_url(base_url: str, path: str) -> str:
     """Build an OpenAI-compatible URL for a provider base URL.
 
-    Supports base URLs either with or without a trailing /v1.
+    Supports base URLs either with or without a trailing /v1. URLs that
+    already carry a non-root path (e.g. /v1beta/openai for Google Gemini)
+    are used as-is; bare hosts get /v1 appended.
     """
     base = normalize_base_url(base_url)
     if not path.startswith("/"):
         path = "/" + path
-    if base.endswith("/v1"):
+    parsed = urlparse(base)
+    if parsed.path and parsed.path != "/":
         return f"{base}{path}"
     return f"{base}/v1{path}"
 

--- a/backend/server.py
+++ b/backend/server.py
@@ -21,6 +21,7 @@ from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel, Field
 from motor.motor_asyncio import AsyncIOMotorClient
 from bson import ObjectId
+from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.middleware.sessions import SessionMiddleware
 
 from backend.llm_providers import (
@@ -725,6 +726,33 @@ app.add_middleware(
 
 client = AsyncIOMotorClient(MONGO_URL)
 db = client[DB_NAME]
+
+
+class JWTUserStateMiddleware(BaseHTTPMiddleware):
+    """Populate request.state.user from a valid Bearer JWT.
+
+    Task and agent routers read request.state.user directly (rather than
+    using Depends(get_current_user)), so this middleware bridges the gap.
+    """
+
+    async def dispatch(self, request: Request, call_next):
+        auth = request.headers.get("Authorization", "")
+        if auth.startswith("Bearer "):
+            token = auth[7:].strip()
+            try:
+                payload = jwt.decode(token, JWT_SECRET, algorithms=[JWT_ALGORITHM])
+                if payload.get("type") == "access":
+                    user = await db.users.find_one({"_id": ObjectId(payload["sub"])})
+                    if user:
+                        user["_id"] = str(user["_id"])
+                        user.pop("password_hash", None)
+                        request.state.user = user
+            except Exception:
+                pass
+        return await call_next(request)
+
+
+app.add_middleware(JWTUserStateMiddleware)
 
 _BOOTSTRAP_DONE = False
 _BOOTSTRAP_LOCK = asyncio.Lock()

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -10,6 +10,8 @@
 
 ### Fixed
 - **Login throws "something went wrong" after CRISPY agent seeding commit** — `seed_default_providers` was accidentally removed when `seed_default_agents` was added; its body was merged into the new function leaving `ensure_bootstrap` calling a non-existent function. Restored `seed_default_providers` as a standalone async function.
+- **Tasks page returns 401 for authenticated users** — `tasks/api.py` reads `request.state.user` but `backend/server.py` never populated it. Added `JWTUserStateMiddleware` to the backend app that decodes the Bearer JWT and writes the user dict to `request.state.user`, matching the pattern used in `proxy.py`.
+- **Agent chat returns 400 Bad Request when using Google Gemini** — `openai_compat_url()` unconditionally appended `/v1` to any base URL that didn't already end with `/v1`. Google's OpenAI-compat endpoint is `https://generativelanguage.googleapis.com/v1beta/openai` (no trailing `/v1`), so the helper was building an invalid double-versioned path. Fixed by parsing the URL: if the base already carries a non-root path it is used as-is; otherwise `/v1` is appended.
 
 ## [2.2.0] — 2026-04-25
 

--- a/tests/test_backend_llm_providers.py
+++ b/tests/test_backend_llm_providers.py
@@ -24,6 +24,18 @@ def test_openai_compat_url_does_not_double_v1():
     )
 
 
+def test_openai_compat_url_google_gemini_does_not_inject_v1():
+    # Google's OpenAI-compat surface is at /v1beta/openai — adding /v1 would
+    # produce an invalid double-version path and a 400 from the API.
+    assert (
+        openai_compat_url(
+            "https://generativelanguage.googleapis.com/v1beta/openai",
+            "/chat/completions",
+        )
+        == "https://generativelanguage.googleapis.com/v1beta/openai/chat/completions"
+    )
+
+
 @pytest.mark.anyio
 async def test_chat_completion_text_sends_auth_header_and_parses_content():
     seen: dict[str, str] = {}


### PR DESCRIPTION
Bug 1 — Tasks page always returned 401 for authenticated users.
tasks/api.py reads request.state.user, but backend/server.py had no
middleware to populate it. Added JWTUserStateMiddleware that decodes the
Bearer token and writes the user dict to request.state.user.

Bug 2 — Agent chat returned 400 Bad Request when a Google Gemini
provider was selected. openai_compat_url() appended /v1 to any base URL
not ending with "/v1". Google's OpenAI-compat endpoint already contains
a full path (/v1beta/openai), so the helper was building an invalid URL
like .../v1beta/openai/v1/chat/completions. Fixed by using urlparse:
URLs with a non-root path are used as-is; bare hosts still get /v1.

Added regression test for the Google Gemini URL case.

https://claude.ai/code/session_01LzZ8AfPzqnXrs9PcH2nnCg