### PR TITLE
fix: restore Setup Wizard checkbox visibility + regression tests

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -3,6 +3,11 @@
 ## [Unreleased]
 
 ### Fixed
+- `frontend/src/index.css` — Setup Wizard checkboxes were invisible again: changed `appearance: revert` to `appearance: auto` on `input[type="checkbox"]` and `input[type="radio"]`. `revert` is fragile under layered cascade rules in some browsers; `auto` is the explicit W3C standard value that tells the browser to render the native control. Also added `cursor: pointer` for usability.
+- `tests/test_frontend_deployment_guards.py` — Added five regression guard tests that verify: (1) the checkbox appearance override rule exists in `index.css`, (2) that it does not set `appearance: none`, (3) that it uses `appearance: auto`, (4) that all Step 1 provider checkboxes are bound to state variables in `SetupWizardPage.js`, and (5) that Step 3 runtime checkboxes are rendered.
+- `frontend/src/__tests__/setupWizard.test.js` — Added three DOM-level checkbox rendering tests: all Step 1 provider checkboxes render in the DOM; the Nvidia NIM checkbox is checked by default; all Step 3 runtime checkboxes render in the DOM.
+
+### Fixed
 - `agent/models.py` — `VerificationResult.issues` now coerces LLM-returned dicts to strings via `@field_validator`; previously crashed the agent loop with Pydantic `ValidationError: Input should be a valid string … input_type=dict` whenever the verifier returned structured objects.
 - `agent/loop.py` — analyze/github-type steps now call `_synthesize_answer()` after tool-call observations are gathered; `_build_summary()` surfaces these answers as the main response text instead of the useless `"Goal: X | Applied steps: Y/Z"` line; added `Files modified: N` to the meta line so the summary accurately reflects actual file edits.
 - `agent/loop.py` — `_build_rich_report()` added: generates a full markdown execution report (per-step status icons, files changed, synthesized answers for analysis steps, issues) used as the task discussion comment — eliminates "tasks complete but nothing happened" confusion.

--- a/frontend/src/__tests__/setupWizard.test.js
+++ b/frontend/src/__tests__/setupWizard.test.js
@@ -89,6 +89,46 @@ describe('SetupWizardPage rendering', () => {
     expect(heading).toBeInTheDocument();
   });
 
+  // ── Checkbox visibility regression guard ──────────────────────────────────
+  // Regression: global `appearance:none` in index.css was hiding native
+  // checkboxes. These tests verify the checkbox elements exist in the DOM so
+  // any future CSS change that removes them is caught immediately.
+
+  test('step 1 provider checkboxes are rendered in the DOM', async () => {
+    mockHealthyBackend();
+    mockSetupState({ current_step: 1 });
+    renderWizard();
+    await screen.findByRole('heading', { name: /provider setup/i });
+
+    // Every provider card should have a visible checkbox role element
+    const checkboxes = screen.getAllByRole('checkbox');
+    expect(checkboxes.length).toBeGreaterThanOrEqual(2);
+  });
+
+  test('Nvidia NIM checkbox is checked by default on step 1', async () => {
+    mockHealthyBackend();
+    mockSetupState({ current_step: 1 });
+    renderWizard();
+    await screen.findByRole('heading', { name: /provider setup/i });
+
+    // Nvidia NIM is the recommended default — must start checked
+    const nvidiaLabel = screen.getByText(/nvidia nim/i).closest('label');
+    const nvidiaCheckbox = nvidiaLabel.querySelector('input[type="checkbox"]');
+    expect(nvidiaCheckbox).toBeInTheDocument();
+    expect(nvidiaCheckbox.checked).toBe(true);
+  });
+
+  test('step 3 runtime checkboxes are all rendered in the DOM', async () => {
+    mockHealthyBackend();
+    mockSetupState({ current_step: 3 });
+    renderWizard();
+    await screen.findByRole('heading', { name: /runtime configuration/i });
+
+    // All 3 runtimes (Hermes, OpenCode, Aider) must have checkbox controls
+    const checkboxes = screen.getAllByRole('checkbox');
+    expect(checkboxes.length).toBeGreaterThanOrEqual(3);
+  });
+
   test('shows all 5 step labels in sidebar', async () => {
     mockHealthyBackend();
     mockSetupState();

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -75,8 +75,13 @@ input, textarea, select {
 }
 
 input[type="checkbox"], input[type="radio"] {
-  -webkit-appearance: revert;
-  appearance: revert;
+  /* Restore native rendering that the global appearance:none above removes.
+     Use `auto` (not `revert`) — `auto` is an explicit instruction to the
+     browser to render the element with its default native control; `revert`
+     can silently lose to layered cascade rules in some browsers. */
+  -webkit-appearance: auto;
+  appearance: auto;
+  cursor: pointer;
 }
 
 input::placeholder, textarea::placeholder {

--- a/tests/test_frontend_deployment_guards.py
+++ b/tests/test_frontend_deployment_guards.py
@@ -31,3 +31,86 @@ def test_settings_oauth_origin_uses_current_backend_configuration() -> None:
     settings = _read("frontend/src/pages/SettingsPage.js")
     assert "function getBackendOrigin()" in settings
     assert "const backendOrigin = getBackendOrigin();" in settings
+
+
+# ── Setup Wizard checkbox visibility regression guards ──────────────────────
+# These tests prevent the recurring regression where global `appearance:none`
+# on <input> hides native checkboxes in the Setup Wizard.
+
+def test_index_css_restores_checkbox_appearance() -> None:
+    """index.css must override appearance:none for checkboxes/radios."""
+    css = _read("frontend/src/index.css")
+    # The override block must exist
+    assert 'input[type="checkbox"]' in css, (
+        "index.css is missing the input[type='checkbox'] override; "
+        "native checkboxes will be invisible due to global appearance:none."
+    )
+
+
+def test_index_css_checkbox_override_is_not_none() -> None:
+    """The checkbox appearance override must NOT set appearance:none (that would keep them hidden)."""
+    css = _read("frontend/src/index.css")
+    lines = css.splitlines()
+    in_checkbox_block = False
+    for line in lines:
+        if 'input[type="checkbox"]' in line:
+            in_checkbox_block = True
+        stripped = line.strip()
+        if in_checkbox_block and "appearance" in stripped and not stripped.startswith("/*") and not stripped.startswith("*"):
+            assert "none" not in stripped, (
+                f"Checkbox block sets appearance:none — checkboxes will be invisible. "
+                f"Offending line: {stripped!r}"
+            )
+        if in_checkbox_block and stripped == "}":
+            break
+
+
+def test_index_css_checkbox_uses_auto_appearance() -> None:
+    """The checkbox appearance override must use 'auto' to request native rendering.
+
+    'revert' is fragile under layered cascade rules; 'auto' is the explicit,
+    standards-compliant value that tells the browser to render a native checkbox.
+    """
+    css = _read("frontend/src/index.css")
+    lines = css.splitlines()
+    in_checkbox_block = False
+    found_auto = False
+    for line in lines:
+        if 'input[type="checkbox"]' in line:
+            in_checkbox_block = True
+        if in_checkbox_block and "appearance" in line and "auto" in line:
+            found_auto = True
+        if in_checkbox_block and line.strip() == "}":
+            break
+    assert found_auto, (
+        "Checkbox appearance override does not use 'appearance: auto'. "
+        "Use 'appearance: auto' (not 'revert') so checkboxes render natively "
+        "across all browsers and cascade configurations."
+    )
+
+
+def test_setup_wizard_renders_checkbox_inputs_for_all_providers() -> None:
+    """SetupWizardPage must render <input type='checkbox'> for each provider toggle."""
+    wizard = _read("frontend/src/pages/SetupWizardPage.js")
+    # Provider checkboxes (Step 1) — one per provider
+    providers = ["useNvidiaNim", "useOllama", "useOpenAI", "useAnthropic", "useGoogle", "useAzure", "useCopilot"]
+    for state_var in providers:
+        assert f"checked={{{state_var}}}" in wizard, (
+            f"Setup Wizard Step 1 is missing a checkbox bound to {state_var}; "
+            f"the {state_var} provider toggle will not be shown to the user."
+        )
+
+
+def test_setup_wizard_step3_renders_runtime_checkboxes() -> None:
+    """Step 3 runtime config must render checkboxes for each runtime."""
+    wizard = _read("frontend/src/pages/SetupWizardPage.js")
+    for runtime_var in ["enableHermes", "enableOpenCode", "enableAider"]:
+        assert runtime_var in wizard, (
+            f"Setup Wizard Step 3 is missing runtime variable {runtime_var}; "
+            f"that runtime's checkbox will not render."
+        )
+    # The runtime list map must use input type checkbox
+    assert 'input type="checkbox"' in wizard or "type=\"checkbox\"" in wizard, (
+        "Step 3 runtime list does not render <input type='checkbox'>; "
+        "users will not see runtime selection checkboxes."
+    )


### PR DESCRIPTION
## Summary

- **`frontend/src/index.css`** — Changed `appearance: revert` to `appearance: auto` on `input[type="checkbox"]` and `input[type="radio"]`. The global `appearance: none` on all `<input>` elements was hiding native checkboxes; `revert` is fragile under layered cascade rules in some browsers — `auto` is the explicit W3C standard value that reliably restores native control rendering. Also added `cursor: pointer`.
- **`tests/test_frontend_deployment_guards.py`** — Five new Python regression guards: verifies the override rule exists, does not use `none`, uses `auto`, all Step 1 provider checkboxes are bound to state, and Step 3 runtime checkboxes are rendered.
- **`frontend/src/__tests__/setupWizard.test.js`** — Three DOM-level tests: Step 1 provider checkboxes render in the DOM, Nvidia NIM is checked by default, Step 3 runtime checkboxes render in the DOM.

## Test plan

- [ ] Open Setup Wizard Step 1 — all provider cards (Nvidia NIM, Ollama, OpenAI, Anthropic, Google, Azure, Copilot) show visible, clickable checkboxes
- [ ] Open Step 3 — Hermes, OpenCode, Aider runtime checkboxes are visible and toggleable
- [ ] Open Step 5 — policy checkboxes (Never paid, Require approval, Langfuse) are visible
- [ ] `pytest tests/test_frontend_deployment_guards.py` — all 9 tests pass
- [ ] If JS deps installed: `npm test` in `frontend/` — new checkbox DOM tests pass

https://claude.ai/code/session_01NnjKJcWUyai5Pt26Q4LYqm

---
_Generated by [Claude Code](https://claude.ai/code/session_01NnjKJcWUyai5Pt26Q4LYqm)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed CSS styling for checkbox and radio input controls to properly render with native appearance and pointer cursor.

* **Tests**
  * Added automated regression test coverage for checkbox visibility and rendering behavior in the Setup Wizard interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->