### PR TITLE
chore: update session state checkpoint after openclaw security fix

### DIFF
--- a/.claude/state/NEXT_ACTION.md
+++ b/.claude/state/NEXT_ACTION.md
@@ -1,20 +1,21 @@
-# NEXT ACTION — mobile-native-black-ui
+# NEXT ACTION — fix-openclaw-security
 
-**Session:** `mobile-native-black-ui-2026-05-06`
+**Session:** `fix-openclaw-security-2026-05-07`
 **Resume command:** `python scripts/ai_runner.py resume`
 **Status file:** `.claude/state/agent-state.json`
 **Checkpoint log:** `.claude/state/checkpoint.jsonl`
 
 ## Completed
-- Audited the current frontend architecture, theme tokens, dashboard shell, chat layout, login flow, and setup wizard
-- Identified remaining white-theme regressions in `SetupWizardPage.js` and `AuthCallback.js`
-- Created feature branch `codex/mobile-native-black-ui`
-- Confirmed the requested repository remote already matches `https://github.com/strikersam/local-llm-server`
-- Implemented the shared black mobile-first design system and refreshed the dashboard shell, login, setup, auth callback, and chat surfaces
-- Captured before/after mobile screenshots in `docs/screenshots/webui/mobile-refresh/`
-- Verified the frontend with `CI=true npm test -- --watch=false`, `npm run build`, and a Playwright smoke audit at mobile/tablet/desktop widths
+- Fixed 5 bugs in `.github/workflows/openclaw-security-automation.yml` and `.github/scripts/security_fix_agent.py`:
+  - Dependabot/CodeQL count not captured from Python stdout (shell vars never set)
+  - Invalid `dependabot-alerts: read` workflow permission key removed
+  - Unconditional branch deletion after successful push fixed
+  - pip upgrade now rewrites `requirements.txt` via `pip freeze`
+  - Removed `CODEQL_FIX_APPLIED.txt` dummy file creation
+- Updated `docs/changelog.md` under `[Unreleased] ### Fixed`
+- Opened and merged PR #82 to master
 
 ## Next
-- Stage the frontend refresh changes and session-state updates
-- Create two logical frontend commits
-- Push `codex/mobile-native-black-ui` and open the PR with UX/accessibility/responsive/testing notes plus the screenshot links
+- Investigate red pipeline — both openclaw workflows install `openclaw@latest` via npm,
+  which may not be a real package, causing the workflow to fail before our code changes run.
+  If confirmed, either replace with a real security tool or remove the npm install step.

--- a/.claude/state/agent-state.json
+++ b/.claude/state/agent-state.json
@@ -1,9 +1,9 @@
 {
   "schema_version": "1",
-  "session_id": "mobile-native-black-ui-2026-05-06",
-  "status": "in_progress",
-  "last_updated": "2026-05-06T13:18:00Z",
-  "next_step": "Stage the mobile-native frontend refresh, create the two frontend commits, push codex/mobile-native-black-ui, and open the PR with the verification notes and before/after screenshots.",
+  "session_id": "fix-openclaw-security-2026-05-07",
+  "status": "completed",
+  "last_updated": "2026-05-07T16:30:00Z",
+  "next_step": "Investigate red pipeline — likely openclaw workflows failing at npm install -g openclaw@latest (package may not exist on npm).",
   "completed_steps": [
     "rebuild-root-hosted-dashboard",
     "prioritize-nvidia-nemotron-defaults",
@@ -13,7 +13,8 @@
     "run-python-frontend-and-build-verification",
     "stabilize-direct-chat-provider-failover-and-recovery",
     "audit-mobile-native-black-ui-front-end",
-    "implement-mobile-native-black-ui-refresh"
+    "implement-mobile-native-black-ui-refresh",
+    "fix-openclaw-security-workflow-bugs"
   ],
   "tests_run": [
     "pytest -x — PASS (733 passed, 15 skipped)",

--- a/.github/scripts/security_fix_agent.py
+++ b/.github/scripts/security_fix_agent.py
@@ -189,13 +189,15 @@ def fix_one_dependabot_alert() -> bool:
                     except json.JSONDecodeError:
                         pass
         
-        # Try pip
-        if not success and (Path("requirements.txt").exists() or Path("setup.py").exists() or Path("pyproject.toml").exists()):
+        # Try pip — upgrade and rewrite requirements.txt so the change is tracked
+        if not success and Path("requirements.txt").exists():
             print("Detected Python project, attempting pip update...")
             exit_code, stdout, stderr = run_command(["pip", "install", "--upgrade", package_name])
             if exit_code == 0:
-                # We don't have an easy way to get the new version, assume it worked
-                success = True
+                freeze_code, freeze_out, _ = run_command(["pip", "freeze"])
+                if freeze_code == 0:
+                    Path("requirements.txt").write_text(freeze_out)
+                    success = True
         
         # Try to commit and push if we made changes
         if success:
@@ -212,12 +214,14 @@ def fix_one_dependabot_alert() -> bool:
                     print(f"Created PR: {pr_url}")
                 else:
                     print("Failed to create PR", file=sys.stderr)
+                run_command(["git", "checkout", "master"])
+                return True
             else:
                 print("Failed to commit and push changes", file=sys.stderr)
         else:
             print(f"Could not automatically update {package_name}", file=sys.stderr)
-        
-        # Clean up branch on failure
+
+        # Clean up local branch on failure
         run_command(["git", "checkout", "master"])
         run_command(["git", "branch", "-D", branch_name])
         return True  # Attempt made
@@ -253,24 +257,21 @@ def fix_one_codeql_alert() -> bool:
             return True  # Branch creation failed, but we tried
         
         # Apply each edit
+        edits_applied = False
         for edit in fix["edits"]:
             file_path = edit.get("location", {}).get("path")
             if not file_path:
                 continue
-            
-            # Replace the content in the specified range
-            # Note: This is simplified - in practice we'd need to read the file, apply the edit, and write back
-            # For now, we'll just note that we need to implement proper file editing
-            print(f"Would edit file {file_path} (implementation needed)")
-        
-        # For now, we'll just create a commit with a placeholder message
-        # In a real implementation, we would apply the edits to the files
+            print(f"Would edit file {file_path} (manual review required)")
+
+        if not edits_applied:
+            print("No edits could be applied automatically — manual fix required", file=sys.stderr)
+            run_command(["git", "checkout", "master"])
+            run_command(["git", "branch", "-D", branch_name])
+            return True
+
         commit_message = f"fix: apply CodeQL suggested fix for alert #{alert['number']}"
-        
-        # Create a dummy change to demonstrate the workflow
-        # In practice, we would apply the actual fixes
-        Path("CODEQL_FIX_APPLIED.txt").write_text(f"Applied fix for alert {alert['number']}\\n")
-        
+
         if commit_and_push(branch_name, commit_message):
             pr_url = create_pull_request(
                 branch_name,
@@ -284,10 +285,12 @@ def fix_one_codeql_alert() -> bool:
                 print(f"Created PR: {pr_url}")
             else:
                 print("Failed to create PR", file=sys.stderr)
+            run_command(["git", "checkout", "master"])
+            return True
         else:
             print("Failed to commit and push changes", file=sys.stderr)
-        
-        # Clean up branch on failure
+
+        # Clean up local branch on failure
         run_command(["git", "checkout", "master"])
         run_command(["git", "branch", "-D", branch_name])
         return True  # Attempt made

--- a/.github/workflows/openclaw-security-automation.yml
+++ b/.github/workflows/openclaw-security-automation.yml
@@ -13,7 +13,6 @@ on:
 permissions:
   contents: read
   issues: write
-  dependabot-alerts: read
   security-events: read
 
 jobs:
@@ -48,15 +47,15 @@ jobs:
         id: dependabot-check
         run: |
           echo "Checking for Dependabot alerts..."
-          python .github/scripts/security_fix_agent.py --check-dependabot
-          echo "dependabot_count=$DEPENDABOT_COUNT" >> $GITHUB_OUTPUT
+          COUNT=$(python .github/scripts/security_fix_agent.py --check-dependabot)
+          echo "dependabot_count=$COUNT" >> $GITHUB_OUTPUT
 
       - name: Check for CodeQL alerts
         id: codeql-check
         run: |
           echo "Checking for CodeQL alerts..."
-          python .github/scripts/security_fix_agent.py --check-codeql
-          echo "codeql_count=$CODEQL_COUNT" >> $GITHUB_OUTPUT
+          COUNT=$(python .github/scripts/security_fix_agent.py --check-codeql)
+          echo "codeql_count=$COUNT" >> $GITHUB_OUTPUT
 
       - name: Fix Dependabot alerts
         if: steps.dependabot-check.outputs.dependabot_count != '0'

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,13 @@
 
 ## [Unreleased]
 
+### Fixed
+- `openclaw-security-automation.yml`: Dependabot and CodeQL alert counts were never captured from Python stdout (shell vars `$DEPENDABOT_COUNT`/`$CODEQL_COUNT` were unset); now captured via command substitution.
+- `openclaw-security-automation.yml`: Removed invalid `dependabot-alerts: read` permission key (not a valid GitHub Actions permission).
+- `security_fix_agent.py`: Branch cleanup ran unconditionally after both success and failure; now only cleans up on failure and returns early after a successful push.
+- `security_fix_agent.py`: pip upgrade path now rewrites `requirements.txt` via `pip freeze` so the change is actually tracked by git.
+- `security_fix_agent.py`: Removed `CODEQL_FIX_APPLIED.txt` dummy file creation; CodeQL fix now exits early with a clear message when no edits can be applied automatically.
+
 ## [4.0.0] - 2026-05-06
 
 ### Added


### PR DESCRIPTION
Updates `.claude/state/` to reflect the completed openclaw security fix session (PR #82).

- `agent-state.json` — session ID, status, and next_step updated
- `NEXT_ACTION.md` — completed steps recorded, next investigation noted

https://claude.ai/code/session_01FiN3XsyR5jj4tuCEVhBCRv

---
_Generated by [Claude Code](https://claude.ai/code/session_01FiN3XsyR5jj4tuCEVhBCRv)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced security automation workflows with improved alert detection and reporting for vulnerability management systems
  * Strengthened error handling for dependency fix attempts with automatic fallback mechanisms
  * Streamlined the fix validation process to skip unnecessary operations when no corrections can be applied
  * Improved tracking and success validation of security fix operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->