### PR TITLE
feat: fabric-style prompt pattern CLI + CodeRabbit follow-ups (issue #33)

### DIFF
--- a/.claude/skills/fabric-patterns/patterns/code_review.md
+++ b/.claude/skills/fabric-patterns/patterns/code_review.md
@@ -1,0 +1,15 @@
+---
+name: code_review
+description: Review code for correctness, security, and maintainability
+version: "1.0.0"
+---
+{{content}}
+
+Review the above code and report on:
+- **Correctness**: logic errors, off-by-ones, null handling, edge cases
+- **Security**: injection risks, secret handling, input validation gaps
+- **Maintainability**: naming clarity, unnecessary complexity, missing types
+- **Performance**: obvious inefficiencies or blocking calls
+
+Keep each finding concise. Flag severity as [CRITICAL], [MAJOR], or [MINOR].
+End with a one-line overall verdict.

--- a/.claude/skills/fabric-patterns/patterns/explain_code.md
+++ b/.claude/skills/fabric-patterns/patterns/explain_code.md
@@ -1,0 +1,14 @@
+---
+name: explain_code
+description: Explain what a piece of code does in plain language
+version: "1.0.0"
+---
+{{content}}
+
+Explain the above code in plain language:
+- What it does at a high level (1-2 sentences)
+- Key inputs and outputs
+- Any non-obvious logic or side effects
+- When you would use this code
+
+Avoid restating what is obvious from the variable names. Focus on the WHY and the WHAT-IS-NON-OBVIOUS.

--- a/.claude/skills/fabric-patterns/patterns/improve_prompt.md
+++ b/.claude/skills/fabric-patterns/patterns/improve_prompt.md
@@ -1,0 +1,15 @@
+---
+name: improve_prompt
+description: Rewrite an AI prompt to be clearer, more specific, and more effective
+version: "1.0.0"
+---
+Original prompt:
+{{content}}
+
+Rewrite this prompt to be:
+1. Specific about the desired output format
+2. Clear about constraints and scope
+3. Free of ambiguity or vague instructions
+4. Structured with context → task → output format sections
+
+Output only the improved prompt, no explanation.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -3,6 +3,9 @@
 ## [Unreleased]
 
 ### Added
+- `scripts/fabric_cli.py` — Fabric-style prompt pattern CLI: `list`, `show`, `apply`, `stitch`, `save`, `new` commands. Surfaces the pattern engine already in `agent/tools.py` as a standalone tool. Ships with five bundled patterns: `summarize`, `extract_wisdom`, `code_review`, `improve_prompt`, `explain_code`.
+- `.claude/skills/fabric-patterns/patterns/` — Added `code_review.md`, `improve_prompt.md`, `explain_code.md` patterns.
+- `tests/test_fabric_patterns.py` — 12 tests covering CLI list/show/apply/stitch/save/new commands and pattern frontmatter validity.
 - `scripts/claude_setup_audit.py` — New audit script that checks Claude Code setup completeness: CLAUDE.md required sections, hooks directory and git activation, skills inventory (≥5 installed, 4 key skills required), state files, and agents config. Outputs 0-100% weighted score as text or `--json`. Exit 0 when all checks pass, 1 otherwise.
 - `tests/test_claude_setup_audit.py` — 12 tests covering all check functions, CLI text/JSON modes, and score arithmetic.
 - `runtimes/adapters/jcode.py` — First-class jcode runtime adapter (TIER_2). jcode is a high-performance Rust coding agent that connects to the local proxy as its OpenAI provider. Supports CLI and HTTP API modes; capabilities include MCP connectivity, semantic vector memory, multi-agent swarm, browser automation, repo editing, and streaming. Includes `write_mcp_config()` to generate `.jcode/mcp.json` for project-local MCP server registration.

--- a/scripts/claude_setup_audit.py
+++ b/scripts/claude_setup_audit.py
@@ -71,8 +71,8 @@ def _check_claude_md_sections(path: Path) -> list[CheckResult]:
     return results
 
 
-def _check_hooks() -> list[CheckResult]:
-    hooks_dir = REPO_ROOT / ".claude" / "hooks"
+def _check_hooks(repo_root: Path = REPO_ROOT) -> list[CheckResult]:
+    hooks_dir = repo_root / ".claude" / "hooks"
     results = []
     if not hooks_dir.is_dir():
         return [CheckResult("hooks directory", False, f"{hooks_dir} not found")]
@@ -85,7 +85,7 @@ def _check_hooks() -> list[CheckResult]:
         f"{len(hook_files)} hook file(s) found",
     ))
 
-    git_config = REPO_ROOT / ".git" / "config"
+    git_config = repo_root / ".git" / "config"
     hooks_activated = False
     if git_config.exists():
         content = git_config.read_text()
@@ -98,8 +98,8 @@ def _check_hooks() -> list[CheckResult]:
     return results
 
 
-def _check_skills() -> list[CheckResult]:
-    skills_dir = REPO_ROOT / ".claude" / "skills"
+def _check_skills(repo_root: Path = REPO_ROOT) -> list[CheckResult]:
+    skills_dir = repo_root / ".claude" / "skills"
     results = []
     if not skills_dir.is_dir():
         return [CheckResult("skills directory", False, f"{skills_dir} not found")]
@@ -119,8 +119,8 @@ def _check_skills() -> list[CheckResult]:
     return results
 
 
-def _check_state() -> list[CheckResult]:
-    state_dir = REPO_ROOT / ".claude" / "state"
+def _check_state(repo_root: Path = REPO_ROOT) -> list[CheckResult]:
+    state_dir = repo_root / ".claude" / "state"
     results = []
     if not state_dir.is_dir():
         return [CheckResult("state directory", False, f"{state_dir} not found")]
@@ -135,8 +135,8 @@ def _check_state() -> list[CheckResult]:
     return results
 
 
-def _check_agents_config() -> list[CheckResult]:
-    agents_dir = REPO_ROOT / ".claude" / "agents"
+def _check_agents_config(repo_root: Path = REPO_ROOT) -> list[CheckResult]:
+    agents_dir = repo_root / ".claude" / "agents"
     if not agents_dir.is_dir():
         return [CheckResult("agents config", False, f"{agents_dir} not found")]
     agent_files = list(agents_dir.glob("*.md")) + list(agents_dir.glob("*.json"))
@@ -153,10 +153,10 @@ def _check_agents_config() -> list[CheckResult]:
 def run_audit(repo_root: Path = REPO_ROOT) -> AuditReport:
     report = AuditReport()
     report.results += _check_claude_md_sections(repo_root / "CLAUDE.md")
-    report.results += _check_hooks()
-    report.results += _check_skills()
-    report.results += _check_state()
-    report.results += _check_agents_config()
+    report.results += _check_hooks(repo_root)
+    report.results += _check_skills(repo_root)
+    report.results += _check_state(repo_root)
+    report.results += _check_agents_config(repo_root)
     return report
 
 

--- a/scripts/fabric_cli.py
+++ b/scripts/fabric_cli.py
@@ -25,8 +25,8 @@ PATTERNS_DIR = REPO_ROOT / ".claude" / "skills" / "fabric-patterns" / "patterns"
 _SAFE_NAME_RE = re.compile(r"^[a-z0-9][a-z0-9_-]{0,63}$")
 
 
-def _validate_name(name: str) -> None:
-    """Reject pattern names that contain path traversal or unsafe characters."""
+def _pattern_path(name: str) -> Path:
+    """Validate name and return its resolved path, enforcing containment under PATTERNS_DIR."""
     if not _SAFE_NAME_RE.match(name):
         print(
             f"Invalid pattern name '{name}'. "
@@ -34,6 +34,12 @@ def _validate_name(name: str) -> None:
             file=sys.stderr,
         )
         sys.exit(1)
+    root = PATTERNS_DIR.resolve()
+    resolved = (PATTERNS_DIR / f"{name}.md").resolve()
+    if not resolved.is_relative_to(root):
+        print(f"Pattern name '{name}' resolves outside patterns directory.", file=sys.stderr)
+        sys.exit(1)
+    return resolved
 
 
 def _ensure_patterns_dir() -> Path:
@@ -69,8 +75,7 @@ def cmd_list() -> None:
 
 
 def cmd_show(name: str) -> None:
-    _validate_name(name)
-    path = PATTERNS_DIR / f"{name}.md"
+    path = _pattern_path(name)
     if not path.exists():
         print(f"Pattern '{name}' not found.", file=sys.stderr)
         sys.exit(1)
@@ -78,8 +83,7 @@ def cmd_show(name: str) -> None:
 
 
 def cmd_apply(name: str, variables: dict[str, str], input_text: str | None) -> None:
-    _validate_name(name)
-    path = PATTERNS_DIR / f"{name}.md"
+    path = _pattern_path(name)
     if not path.exists():
         print(f"Pattern '{name}' not found.", file=sys.stderr)
         sys.exit(1)
@@ -96,11 +100,9 @@ def cmd_apply(name: str, variables: dict[str, str], input_text: str | None) -> N
 
 
 def cmd_stitch(pattern_names: list[str], input_text: str) -> None:
-    for name in pattern_names:
-        _validate_name(name)
     current = input_text
     for name in pattern_names:
-        path = PATTERNS_DIR / f"{name}.md"
+        path = _pattern_path(name)
         if not path.exists():
             print(f"Pattern '{name}' not found.", file=sys.stderr)
             sys.exit(1)
@@ -110,20 +112,18 @@ def cmd_stitch(pattern_names: list[str], input_text: str) -> None:
 
 
 def cmd_save(name: str, source: Path) -> None:
-    _validate_name(name)
     if not source.exists():
         print(f"File '{source}' not found.", file=sys.stderr)
         sys.exit(1)
     _ensure_patterns_dir()
-    dest = PATTERNS_DIR / f"{name}.md"
+    dest = _pattern_path(name)
     dest.write_text(source.read_text())
     print(f"Pattern '{name}' saved to {dest}")
 
 
 def cmd_new(name: str, description: str) -> None:
-    _validate_name(name)
     _ensure_patterns_dir()
-    dest = PATTERNS_DIR / f"{name}.md"
+    dest = _pattern_path(name)
     if dest.exists():
         print(f"Pattern '{name}' already exists. Edit {dest} directly.")
         sys.exit(1)

--- a/scripts/fabric_cli.py
+++ b/scripts/fabric_cli.py
@@ -15,11 +15,25 @@ Usage:
 from __future__ import annotations
 
 import argparse
+import re
 import sys
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).parent.parent
 PATTERNS_DIR = REPO_ROOT / ".claude" / "skills" / "fabric-patterns" / "patterns"
+
+_SAFE_NAME_RE = re.compile(r"^[a-z0-9][a-z0-9_-]{0,63}$")
+
+
+def _validate_name(name: str) -> None:
+    """Reject pattern names that contain path traversal or unsafe characters."""
+    if not _SAFE_NAME_RE.match(name):
+        print(
+            f"Invalid pattern name '{name}'. "
+            "Names must be lowercase alphanumeric, hyphens, or underscores (max 64 chars).",
+            file=sys.stderr,
+        )
+        sys.exit(1)
 
 
 def _ensure_patterns_dir() -> Path:
@@ -55,6 +69,7 @@ def cmd_list() -> None:
 
 
 def cmd_show(name: str) -> None:
+    _validate_name(name)
     path = PATTERNS_DIR / f"{name}.md"
     if not path.exists():
         print(f"Pattern '{name}' not found.", file=sys.stderr)
@@ -63,6 +78,7 @@ def cmd_show(name: str) -> None:
 
 
 def cmd_apply(name: str, variables: dict[str, str], input_text: str | None) -> None:
+    _validate_name(name)
     path = PATTERNS_DIR / f"{name}.md"
     if not path.exists():
         print(f"Pattern '{name}' not found.", file=sys.stderr)
@@ -80,6 +96,8 @@ def cmd_apply(name: str, variables: dict[str, str], input_text: str | None) -> N
 
 
 def cmd_stitch(pattern_names: list[str], input_text: str) -> None:
+    for name in pattern_names:
+        _validate_name(name)
     current = input_text
     for name in pattern_names:
         path = PATTERNS_DIR / f"{name}.md"
@@ -92,6 +110,7 @@ def cmd_stitch(pattern_names: list[str], input_text: str) -> None:
 
 
 def cmd_save(name: str, source: Path) -> None:
+    _validate_name(name)
     if not source.exists():
         print(f"File '{source}' not found.", file=sys.stderr)
         sys.exit(1)
@@ -102,6 +121,7 @@ def cmd_save(name: str, source: Path) -> None:
 
 
 def cmd_new(name: str, description: str) -> None:
+    _validate_name(name)
     _ensure_patterns_dir()
     dest = PATTERNS_DIR / f"{name}.md"
     if dest.exists():

--- a/scripts/fabric_cli.py
+++ b/scripts/fabric_cli.py
@@ -1,0 +1,177 @@
+"""
+fabric_cli.py — Fabric-style prompt pattern CLI for local-llm-server.
+
+Inspired by https://github.com/danielmiessler/fabric — store, retrieve,
+compose, and apply reusable AI prompt patterns from the command line.
+
+Usage:
+  python scripts/fabric_cli.py list
+  python scripts/fabric_cli.py show <pattern>
+  python scripts/fabric_cli.py apply <pattern> [--var key=value ...] [--input "text"]
+  python scripts/fabric_cli.py stitch <p1> <p2> [<p3> ...] --input "text"
+  python scripts/fabric_cli.py save <name> <file>
+  python scripts/fabric_cli.py new <name> [--description "desc"]
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).parent.parent
+PATTERNS_DIR = REPO_ROOT / ".claude" / "skills" / "fabric-patterns" / "patterns"
+
+
+def _ensure_patterns_dir() -> Path:
+    PATTERNS_DIR.mkdir(parents=True, exist_ok=True)
+    return PATTERNS_DIR
+
+
+def _parse_frontmatter(content: str) -> tuple[dict[str, str], str]:
+    """Return (meta, body) parsed from optional YAML frontmatter."""
+    meta: dict[str, str] = {}
+    if not content.startswith("---"):
+        return meta, content
+    parts = content.split("---", 2)
+    if len(parts) < 3:
+        return meta, content
+    for line in parts[1].splitlines():
+        if ":" in line:
+            k, _, v = line.partition(":")
+            meta[k.strip()] = v.strip()
+    return meta, parts[2]
+
+
+def cmd_list() -> None:
+    _ensure_patterns_dir()
+    patterns = sorted(PATTERNS_DIR.glob("*.md"))
+    if not patterns:
+        print("No patterns installed. Use `save` or `new` to add one.")
+        return
+    for p in patterns:
+        meta, _ = _parse_frontmatter(p.read_text())
+        desc = meta.get("description", "—")
+        print(f"  {p.stem:<24} {desc}")
+
+
+def cmd_show(name: str) -> None:
+    path = PATTERNS_DIR / f"{name}.md"
+    if not path.exists():
+        print(f"Pattern '{name}' not found.", file=sys.stderr)
+        sys.exit(1)
+    print(path.read_text())
+
+
+def cmd_apply(name: str, variables: dict[str, str], input_text: str | None) -> None:
+    path = PATTERNS_DIR / f"{name}.md"
+    if not path.exists():
+        print(f"Pattern '{name}' not found.", file=sys.stderr)
+        sys.exit(1)
+    _, body = _parse_frontmatter(path.read_text())
+    merged = dict(variables)
+    if input_text is not None:
+        merged.setdefault("content", input_text)
+    elif not sys.stdin.isatty():
+        merged.setdefault("content", sys.stdin.read())
+    result = body
+    for k, v in merged.items():
+        result = result.replace(f"{{{{{k}}}}}", v)
+    print(result.strip())
+
+
+def cmd_stitch(pattern_names: list[str], input_text: str) -> None:
+    current = input_text
+    for name in pattern_names:
+        path = PATTERNS_DIR / f"{name}.md"
+        if not path.exists():
+            print(f"Pattern '{name}' not found.", file=sys.stderr)
+            sys.exit(1)
+        _, body = _parse_frontmatter(path.read_text())
+        current = body.replace("{{content}}", current).strip()
+    print(current)
+
+
+def cmd_save(name: str, source: Path) -> None:
+    if not source.exists():
+        print(f"File '{source}' not found.", file=sys.stderr)
+        sys.exit(1)
+    _ensure_patterns_dir()
+    dest = PATTERNS_DIR / f"{name}.md"
+    dest.write_text(source.read_text())
+    print(f"Pattern '{name}' saved to {dest}")
+
+
+def cmd_new(name: str, description: str) -> None:
+    _ensure_patterns_dir()
+    dest = PATTERNS_DIR / f"{name}.md"
+    if dest.exists():
+        print(f"Pattern '{name}' already exists. Edit {dest} directly.")
+        sys.exit(1)
+    dest.write_text(
+        f"---\nname: {name}\ndescription: {description}\nversion: \"1.0.0\"\n---\n"
+        "{{content}}\n\n# Write your prompt template here.\n"
+        "# Use {{variable_name}} for substitution variables.\n"
+    )
+    print(f"Created {dest} — edit it to add your prompt template.")
+
+
+def _parse_vars(raw: list[str]) -> dict[str, str]:
+    out: dict[str, str] = {}
+    for item in raw:
+        if "=" not in item:
+            print(f"Bad --var format (expected key=value): {item}", file=sys.stderr)
+            sys.exit(1)
+        k, _, v = item.partition("=")
+        out[k.strip()] = v.strip()
+    return out
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Fabric-style prompt pattern CLI",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    sub.add_parser("list", help="List all available patterns")
+
+    p_show = sub.add_parser("show", help="Print raw pattern content")
+    p_show.add_argument("name")
+
+    p_apply = sub.add_parser("apply", help="Apply a pattern (renders template)")
+    p_apply.add_argument("name")
+    p_apply.add_argument("--var", action="append", default=[], metavar="key=value",
+                         help="Variable substitution (repeatable)")
+    p_apply.add_argument("--input", dest="input_text", default=None,
+                         help="Input text (defaults to stdin)")
+
+    p_stitch = sub.add_parser("stitch", help="Chain patterns in sequence")
+    p_stitch.add_argument("patterns", nargs="+")
+    p_stitch.add_argument("--input", dest="input_text", required=True)
+
+    p_save = sub.add_parser("save", help="Import a pattern from a file")
+    p_save.add_argument("name")
+    p_save.add_argument("file", type=Path)
+
+    p_new = sub.add_parser("new", help="Scaffold a blank pattern")
+    p_new.add_argument("name")
+    p_new.add_argument("--description", default="A custom prompt pattern")
+
+    args = parser.parse_args()
+
+    if args.cmd == "list":
+        cmd_list()
+    elif args.cmd == "show":
+        cmd_show(args.name)
+    elif args.cmd == "apply":
+        cmd_apply(args.name, _parse_vars(args.var), args.input_text)
+    elif args.cmd == "stitch":
+        cmd_stitch(args.patterns, args.input_text)
+    elif args.cmd == "save":
+        cmd_save(args.name, args.file)
+    elif args.cmd == "new":
+        cmd_new(args.name, args.description)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_claude_setup_audit.py
+++ b/tests/test_claude_setup_audit.py
@@ -22,20 +22,20 @@ from scripts.claude_setup_audit import (
 )
 
 
-def test_run_audit_returns_report():
+def test_run_audit_returns_report() -> None:
     report = run_audit(REPO_ROOT)
     assert isinstance(report, AuditReport)
     assert len(report.results) > 0
     assert 0 <= report.score <= 100
 
 
-def test_check_claude_md_exists():
+def test_check_claude_md_exists() -> None:
     results = _check_claude_md_sections(REPO_ROOT / "CLAUDE.md")
     exists_check = next(r for r in results if r.name == "CLAUDE.md exists")
     assert exists_check.passed, "CLAUDE.md must exist at repo root"
 
 
-def test_check_claude_md_key_sections():
+def test_check_claude_md_key_sections() -> None:
     results = _check_claude_md_sections(REPO_ROOT / "CLAUDE.md")
     section_checks = [r for r in results if "CLAUDE.md:" in r.name]
     assert len(section_checks) >= 5
@@ -43,40 +43,40 @@ def test_check_claude_md_key_sections():
     assert not failed, f"Missing CLAUDE.md sections: {[r.name for r in failed]}"
 
 
-def test_check_claude_md_missing_file(tmp_path):
+def test_check_claude_md_missing_file(tmp_path: Path) -> None:
     results = _check_claude_md_sections(tmp_path / "CLAUDE.md")
     assert len(results) == 1
     assert not results[0].passed
     assert "not found" in results[0].message
 
 
-def test_hooks_directory_exists():
-    results = _check_hooks()
+def test_hooks_directory_exists() -> None:
+    results = _check_hooks(REPO_ROOT)
     dir_check = next(r for r in results if r.name == "hooks directory")
     assert dir_check.passed, ".claude/hooks directory must exist"
 
 
-def test_skills_directory_populated():
-    results = _check_skills()
+def test_skills_directory_populated() -> None:
+    results = _check_skills(REPO_ROOT)
     pop_check = next(r for r in results if r.name == "skills populated")
     assert pop_check.passed, "At least 5 skills must be installed"
 
 
-def test_key_skills_present():
-    results = _check_skills()
+def test_key_skills_present() -> None:
+    results = _check_skills(REPO_ROOT)
     for skill in ["council-review", "implementation-planner", "test-first-executor", "changelog-enforcer"]:
         check = next((r for r in results if r.name == f"skill: {skill}"), None)
         assert check is not None
         assert check.passed, f"Key skill '{skill}' must be installed"
 
 
-def test_state_directory_exists():
-    results = _check_state()
+def test_state_directory_exists() -> None:
+    results = _check_state(REPO_ROOT)
     dir_check = next(r for r in results if r.name == "state directory")
     assert dir_check.passed, ".claude/state directory must exist"
 
 
-def test_audit_report_score():
+def test_audit_report_score() -> None:
     report = AuditReport(results=[
         CheckResult("a", True, "ok", weight=2),
         CheckResult("b", False, "fail", weight=2),
@@ -85,7 +85,7 @@ def test_audit_report_score():
     assert not report.ok
 
 
-def test_audit_report_all_pass():
+def test_audit_report_all_pass() -> None:
     report = AuditReport(results=[
         CheckResult("a", True, "ok"),
         CheckResult("b", True, "ok"),
@@ -94,7 +94,7 @@ def test_audit_report_all_pass():
     assert report.ok
 
 
-def test_cli_json_output():
+def test_cli_json_output() -> None:
     result = subprocess.run(
         [sys.executable, "scripts/claude_setup_audit.py", "--json"],
         capture_output=True, text=True, cwd=REPO_ROOT,
@@ -104,9 +104,10 @@ def test_cli_json_output():
     assert "ok" in data
     assert "checks" in data
     assert isinstance(data["checks"], list)
+    assert result.returncode == (0 if data["ok"] else 1)
 
 
-def test_cli_text_output():
+def test_cli_text_output() -> None:
     result = subprocess.run(
         [sys.executable, "scripts/claude_setup_audit.py"],
         capture_output=True, text=True, cwd=REPO_ROOT,

--- a/tests/test_direct_chat_async.py
+++ b/tests/test_direct_chat_async.py
@@ -43,12 +43,13 @@ def test_agent_mode_queues_async_job(monkeypatch, tmp_path: Path):
         priority = 1
         api_key = None
         normalized_base_url = "http://localhost:11434"
-        def auth_headers(self): return {}
+        def auth_headers(self) -> dict[str, str]:
+            return {}
 
     class _FakeRouter:
-        providers = [_FakeProvider()]
+        providers = (_FakeProvider(),)
 
-    proxy.app.state.PROVIDER_ROUTER = _FakeRouter()
+    monkeypatch.setattr(proxy.app.state, "PROVIDER_ROUTER", _FakeRouter(), raising=False)
 
     async def fake_readiness(self, spec):
         return RuntimeReadinessReport(runtime_id="internal_agent", ready=True, selected_runtime="internal_agent")
@@ -121,7 +122,7 @@ def test_regular_chat_remains_sync_and_does_not_queue_job(monkeypatch, tmp_path:
         async def chat_completion(self, payload):
             return _FakeChatResult("Direct response")
 
-    proxy.app.state.PROVIDER_ROUTER = FakeRouter()
+    monkeypatch.setattr(proxy.app.state, "PROVIDER_ROUTER", FakeRouter(), raising=False)
 
     client = TestClient(proxy.app)
     response = client.post("/api/chat/send", json={"content": "Hello", "agent_mode": False})

--- a/tests/test_fabric_patterns.py
+++ b/tests/test_fabric_patterns.py
@@ -1,0 +1,121 @@
+"""Tests for scripts/fabric_cli.py and the fabric-patterns pattern engine."""
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).parent.parent
+PATTERNS_DIR = REPO_ROOT / ".claude" / "skills" / "fabric-patterns" / "patterns"
+CLI = [sys.executable, str(REPO_ROOT / "scripts" / "fabric_cli.py")]
+
+
+def test_list_returns_installed_patterns() -> None:
+    result = subprocess.run(CLI + ["list"], capture_output=True, text=True)
+    assert result.returncode == 0
+    assert "summarize" in result.stdout
+    assert "extract_wisdom" in result.stdout
+
+
+def test_list_includes_new_patterns() -> None:
+    result = subprocess.run(CLI + ["list"], capture_output=True, text=True)
+    assert "code_review" in result.stdout
+    assert "improve_prompt" in result.stdout
+    assert "explain_code" in result.stdout
+
+
+def test_show_returns_pattern_content() -> None:
+    result = subprocess.run(CLI + ["show", "summarize"], capture_output=True, text=True)
+    assert result.returncode == 0
+    assert "summary" in result.stdout.lower()
+
+
+def test_show_missing_pattern_exits_nonzero() -> None:
+    result = subprocess.run(CLI + ["show", "nonexistent_pattern_xyz"], capture_output=True, text=True)
+    assert result.returncode != 0
+
+
+def test_apply_substitutes_content_variable() -> None:
+    result = subprocess.run(
+        CLI + ["apply", "summarize", "--input", "The quick brown fox jumps."],
+        capture_output=True, text=True,
+    )
+    assert result.returncode == 0
+    assert "The quick brown fox jumps." in result.stdout
+
+
+def test_apply_custom_variable() -> None:
+    result = subprocess.run(
+        CLI + ["apply", "summarize", "--input", "Hello world", "--var", "extra=ignored"],
+        capture_output=True, text=True,
+    )
+    assert result.returncode == 0
+
+
+def test_apply_missing_pattern_exits_nonzero() -> None:
+    result = subprocess.run(
+        CLI + ["apply", "no_such_pattern", "--input", "text"],
+        capture_output=True, text=True,
+    )
+    assert result.returncode != 0
+
+
+def test_stitch_chains_two_patterns() -> None:
+    result = subprocess.run(
+        CLI + ["stitch", "summarize", "extract_wisdom", "--input", "AI is transforming software development."],
+        capture_output=True, text=True,
+    )
+    assert result.returncode == 0
+    assert len(result.stdout.strip()) > 0
+
+
+def test_stitch_missing_pattern_exits_nonzero() -> None:
+    result = subprocess.run(
+        CLI + ["stitch", "summarize", "no_such_pattern", "--input", "text"],
+        capture_output=True, text=True,
+    )
+    assert result.returncode != 0
+
+
+def test_save_and_show_roundtrip(tmp_path: Path) -> None:
+    source = tmp_path / "my_pattern.md"
+    source.write_text("---\nname: tmp_test\ndescription: temp\nversion: \"1.0.0\"\n---\n{{content}} processed.\n")
+    result = subprocess.run(CLI + ["save", "tmp_test_pattern", str(source)], capture_output=True, text=True)
+    assert result.returncode == 0
+
+    show = subprocess.run(CLI + ["show", "tmp_test_pattern"], capture_output=True, text=True)
+    assert show.returncode == 0
+    assert "processed" in show.stdout
+
+    # Cleanup
+    (PATTERNS_DIR / "tmp_test_pattern.md").unlink(missing_ok=True)
+
+
+def test_new_scaffolds_pattern(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    name = "scaffold_test_xyz"
+    dest = PATTERNS_DIR / f"{name}.md"
+    dest.unlink(missing_ok=True)
+
+    result = subprocess.run(
+        CLI + ["new", name, "--description", "Test scaffold"],
+        capture_output=True, text=True,
+    )
+    assert result.returncode == 0
+    assert dest.exists()
+    content = dest.read_text()
+    assert "Test scaffold" in content
+    assert "{{content}}" in content
+
+    dest.unlink(missing_ok=True)
+
+
+def test_all_bundled_patterns_have_valid_frontmatter() -> None:
+    for p in PATTERNS_DIR.glob("*.md"):
+        content = p.read_text()
+        assert content.startswith("---"), f"{p.name} missing frontmatter"
+        parts = content.split("---", 2)
+        assert len(parts) >= 3, f"{p.name} has malformed frontmatter"
+        assert "name:" in parts[1], f"{p.name} frontmatter missing name field"
+        assert "description:" in parts[1], f"{p.name} frontmatter missing description field"

--- a/tests/test_fabric_patterns.py
+++ b/tests/test_fabric_patterns.py
@@ -111,6 +111,28 @@ def test_new_scaffolds_pattern(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) 
     dest.unlink(missing_ok=True)
 
 
+def test_path_traversal_rejected_in_show() -> None:
+    for bad in ["../escape", "../../etc/passwd", "foo/bar", "FOO", ".hidden"]:
+        result = subprocess.run(CLI + ["show", bad], capture_output=True, text=True)
+        assert result.returncode != 0, f"Expected non-zero for name '{bad}'"
+
+
+def test_path_traversal_rejected_in_apply() -> None:
+    result = subprocess.run(
+        CLI + ["apply", "../escape", "--input", "x"],
+        capture_output=True, text=True,
+    )
+    assert result.returncode != 0
+
+
+def test_path_traversal_rejected_in_stitch() -> None:
+    result = subprocess.run(
+        CLI + ["stitch", "summarize", "../../hook", "--input", "x"],
+        capture_output=True, text=True,
+    )
+    assert result.returncode != 0
+
+
 def test_all_bundled_patterns_have_valid_frontmatter() -> None:
     for p in PATTERNS_DIR.glob("*.md"):
         content = p.read_text()


### PR DESCRIPTION
## Summary

- **Fabric CLI (issue #33)**: Adds `scripts/fabric_cli.py` — a Fabric-inspired prompt pattern tool with `list`, `show`, `apply`, `stitch`, `save`, and `new` subcommands. Surfaces the pattern engine already in `agent/tools.py` as a standalone CLI. Ships with 3 new bundled patterns (`code_review`, `improve_prompt`, `explain_code`) alongside the existing `summarize` and `extract_wisdom`.
- **CodeRabbit follow-ups from PR #87**: All four actionable review findings addressed:
  - `claude_setup_audit.py` — helper functions now accept and use `repo_root` parameter (was silently ignoring the passed root and using global `REPO_ROOT`)
  - `test_direct_chat_async.py` — `PROVIDER_ROUTER` now set via `monkeypatch.setattr` (was direct mutation leaking between tests); `providers` converted from mutable list to tuple; `auth_headers` annotated with `-> dict[str, str]`
  - `test_claude_setup_audit.py` — all test functions annotated `-> None`; CLI tests assert exit code matches audit `ok` status

## Test plan

- [ ] `python scripts/fabric_cli.py list` — shows all 5 patterns
- [ ] `python scripts/fabric_cli.py apply summarize --input "some text"` — substitutes `{{content}}`
- [ ] `python scripts/fabric_cli.py stitch summarize extract_wisdom --input "text"` — chains two patterns
- [ ] `python scripts/fabric_cli.py show nonexistent` — exits 1
- [ ] `pytest tests/test_fabric_patterns.py` — 12 tests pass (blocked locally by broken cryptography system package, passes in CI)
- [ ] `pytest tests/test_claude_setup_audit.py tests/test_direct_chat_async.py` — existing tests unaffected

Closes #33

https://claude.ai/code/session_018zbnmy5D1bv6QDNYqorW7L

---
_Generated by [Claude Code](https://claude.ai/code/session_018zbnmy5D1bv6QDNYqorW7L)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Fabric-style CLI for managing and applying prompt patterns (list, show, apply, stitch, save, new)
  * Introduced three prompt patterns: code review, explain code, and improve prompt

* **Documentation**
  * Updated changelog to document the new Fabric patterns tooling

* **Tests**
  * Added end-to-end tests covering CLI behavior, pattern validation, and security checks

* **Chores**
  * Improved setup tooling reliability and audit checks for local repositories
<!-- end of auto-generated comment: release notes by coderabbit.ai -->