### PR TITLE
fix(ci): resolve octal escape error in openclaw-security-automation workflow

### DIFF
--- a/.github/workflows/openclaw-security-automation.yml
+++ b/.github/workflows/openclaw-security-automation.yml
@@ -2,7 +2,7 @@ name: OpenClaw Security Automation
 
 on:
   schedule:
-    - cron: '0 * * * *'  # Hourly
+    - cron: '0 * * * *' # Hourly
   workflow_dispatch:
   push:
     branches: [master]
@@ -48,15 +48,15 @@ jobs:
         id: dependabot-check
         run: |
           echo "Checking for Dependabot alerts..."
-          python .github/scripts/security_fix_agent.py --check-dependabot
-          echo "dependabot_count=$DEPENDABOT_COUNT" >> $GITHUB_OUTPUT
+          count=$(python .github/scripts/security_fix_agent.py --check-dependabot)
+          echo "dependabot_count=$count" >> $GITHUB_OUTPUT
 
       - name: Check for CodeQL alerts
         id: codeql-check
         run: |
           echo "Checking for CodeQL alerts..."
-          python .github/scripts/security_fix_agent.py --check-codeql
-          echo "codeql_count=$CODEQL_COUNT" >> $GITHUB_OUTPUT
+          count=$(python .github/scripts/security_fix_agent.py --check-codeql)
+          echo "codeql_count=$count" >> $GITHUB_OUTPUT
 
       - name: Fix Dependabot alerts
         if: steps.dependabot-check.outputs.dependabot_count != '0'
@@ -83,31 +83,32 @@ jobs:
           script: |
             const dependabotCount = parseInt("${{ steps.dependabot-check.outputs.dependabot_count }}") || 0;
             const codeqlCount = parseInt("${{ steps.codeql-check.outputs.codeql_count }}") || 0;
-            
+            const repository = "${{ github.repository }}";
+            const commitSha = "${{ github.sha }}";
+            const timestamp = "${{ steps.timestamp.outputs.timestamp }}";
             if (dependabotCount > 0 || codeqlCount > 0) {
-              const issueTitle = `🔧 OpenClaw Security Automation Report`;
-              const issueBody = `
-              ## Security Automation Summary
-              
-              The OpenClaw security automation workflow has completed.
-              
-              #### Findings:
-              - Dependabot alerts: \`${dependabotCount}\`
-              - CodeQL alerts: \`${codeqlCount}\`
-              
-              #### Actions Taken:
-              - Automated fixes attempted for all detectable issues
-              - Manual review may be required for complex fixes
-              
-              #### Workflow Details:
-              - Workflow: OpenClaw Security Automation
-              - Repository: \${{ github.repository }}
-              - Commit: \${{ github.sha }}
-              - Timestamp: ${steps.timestamp.outputs.timestamp}
-              
-              For more details, check the workflow run logs.
-              `;
-              
+              const issueTitle = "\u{1F527} OpenClaw Security Automation Report";
+              const issueBody = [
+                "## Security Automation Summary",
+                "",
+                "The OpenClaw security automation workflow has completed.",
+                "",
+                "#### Findings:",
+                "- Dependabot alerts: `" + dependabotCount + "`",
+                "- CodeQL alerts: `" + codeqlCount + "`",
+                "",
+                "#### Actions Taken:",
+                "- Automated fixes attempted for all detectable issues",
+                "- Manual review may be required for complex fixes",
+                "",
+                "#### Workflow Details:",
+                "- Workflow: OpenClaw Security Automation",
+                "- Repository: " + repository,
+                "- Commit: " + commitSha,
+                "- Timestamp: " + timestamp,
+                "",
+                "For more details, check the workflow run logs.",
+              ].join("\n");
               await github.rest.issues.create({
                 owner: context.repo.owner,
                 repo: context.repo.repo,

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+- `.github/workflows/openclaw-security-automation.yml` — fixed `SyntaxError: Octal escape sequences are not allowed in template strings` in the "Create summary issue" step by replacing JS template literal interpolation with string concatenation for GitHub context values (`github.repository`, `github.sha`), and by using `\u{1F527}` Unicode escape instead of raw emoji for the issue title. Also fixed step output propagation: the Python script's alert count is now captured via `$(python ...)` command substitution instead of referencing an unset `$DEPENDABOT_COUNT` / `$CODEQL_COUNT` environment variable, so the summary issue step correctly receives the alert counts.
+
+
 ## [4.0.0] - 2026-05-06
 
 ### Added


### PR DESCRIPTION
## Summary

Fixes the `SyntaxError: Octal escape sequences are not allowed in template strings` error in the OpenClaw Security Automation workflow that prevented the "Create summary issue" step from running.

### Root Cause

The `actions/github-script@v7` step used a JavaScript template literal containing `\${{ github.repository }}` and `\${{ github.sha }}`. After GitHub Actions expression expansion, these become backslash-prefixed values (e.g., `\67b29d8...` when the commit SHA starts with `6`). In a JS template literal, `\6` is interpreted as an octal escape sequence, which Node.js 22 rejects with a SyntaxError.

### Changes

1. **Fix octal escape error**: Replace the JS template literal with string concatenation. GitHub context values (`github.repository`, `github.sha`, `steps.timestamp.outputs.timestamp`) are now assigned to `const` variables using double-quoted strings before being concatenated into the issue body via `Array.join("\n")`.

2. **Fix emoji handling**: Use `\u{1F527}` Unicode escape for the wrench emoji instead of raw UTF-8 bytes in the template literal.

3. **Fix step output propagation**: The Python security script prints alert counts to stdout, but the workflow steps referenced unset environment variables `$DEPENDABOT_COUNT` and `$CODEQL_COUNT`. Fixed by capturing the script output with command substitution and writing that to `$GITHUB_OUTPUT`.

### Testing

- YAML syntax validated with pyyaml
- JavaScript logic verified with Node.js (simulated GitHub expression expansion)
- No code changes - only workflow YAML and changelog, so existing test suite is unaffected

### Task Reference

Task ID: 907b0cf7-b89c-4b32-b0f4-9e51f8e2e1fd