### PR TITLE
fix(agent): repair AgentRunner indentation regressions causing import/test failures

### DIFF
--- a/agent/loop.py
+++ b/agent/loop.py
@@ -411,6 +411,7 @@ class AgentRunner:
         )
 
         for remaining in range(15, 0, -1):
+            try:
                 # Observation masking: pass truncated older observations to
                 # keep the tool-selection prompt lean.  Recent observations are
                 # passed verbatim; older ones are summarised.
@@ -614,11 +615,12 @@ class AgentRunner:
     async def _run_tool(
         self,
         tool: str,
-        args: dict[str, Any], 
+        args: dict[str, Any],
         user_id: str | None = None,
         memory_store: UserMemoryStore | None = None,
         metadata: dict[str, Any] | None = None,
     ) -> Any:
+        try:
             return await self._dispatch_tool(tool, args, user_id=user_id, memory_store=memory_store, metadata=metadata)
         except CommercialFallbackRequiredError:
             raise
@@ -769,6 +771,7 @@ class AgentRunner:
             },
         ]
         _VALID_VERDICTS = {"APPROVED", "APPROVED_WITH_CONDITIONS", "BLOCKED"}
+        try:
             raw = await self._chat_json(judge_model, messages)
             verdict = raw.get("verdict", "")
             if verdict not in _VALID_VERDICTS:
@@ -868,13 +871,17 @@ class AgentRunner:
     # ------------------------------------------------------------------
     # Auto-parallelization
     # ------------------------------------------------------------------
-
+    def _steps_are_independent(self, steps: list[Any]) -> bool:
         """Return True when no file appears in more than one step (safe to parallelize)."""
         seen: set[str] = set()
         for step in steps:
             files = list(step.files) if hasattr(step, "files") else step.get("files") or []
+            for f in files:
                 if f in seen:
                     return False
+                seen.add(f)
+        return True
+
     async def _maybe_run_parallel(
         self,
         *,
@@ -952,12 +959,14 @@ class AgentRunner:
     # ------------------------------------------------------------------
     # Event log helpers  (stateless harness / durable session log)
     # ------------------------------------------------------------------
-
+    def _log_event(self, session_id: str | None, event_type: str, payload: dict[str, Any]) -> None:
         """Append an event to the durable session log if a store is wired in."""
-            try:
-                self._session_store.append_event(session_id, event_type, payload)
-            except Exception as exc:
-                log.debug("event log write failed (non-fatal): %s", exc)
+        if not session_id or not self._session_store:
+            return
+        try:
+            self._session_store.append_event(session_id, event_type, payload)
+        except Exception as exc:
+            log.debug("event log write failed (non-fatal): %s", exc)
     # ------------------------------------------------------------------
     # Context compaction
     # ------------------------------------------------------------------
@@ -973,6 +982,7 @@ class AgentRunner:
         Asks the planner model to write a concise summary, then replaces the
         old messages with that summary + the most recent context.
         """
+        try:
             summary_text = await self._chat_text(
                 requested_model or DEFAULT_PLANNER_MODEL,
                 build_compaction_prompt(history),
@@ -1079,6 +1089,7 @@ class AgentRunner:
 
     def _extract_json(self, raw: str) -> Any:
         raw = raw.strip()
+        try:
             return json.loads(raw)
         except json.JSONDecodeError:
             match = re.search(r"\{.*\}", raw, re.S)
@@ -1170,6 +1181,7 @@ class AgentRunner:
         # Strip control characters (newlines, CR, tabs) so multi-line step
         # descriptions don't create malformed git commit messages.
         safe_description = " ".join(description.splitlines()).strip()[:200] or "agent change"
+        try:
             subprocess.run(["git", "add", *changed_files], cwd=self.tools.root, check=True, capture_output=True, text=True)
             subprocess.run(
                 ["git", "commit", "-m", f"agent: {safe_description}"],

--- a/agent/loop.py
+++ b/agent/loop.py
@@ -486,6 +486,8 @@ class AgentRunner:
                 "models": {"executor": executor_model, "verifier": verifier_model},
             }
 
+        for target_file in target_files:
+            original_content = self._safe_read(target_file)
             retries = 0
             feedback_issues: list[str] = []
             file_applied = False
@@ -566,6 +568,8 @@ class AgentRunner:
                 if verdict.status == "pass" and not syntax_issues:
                     diff_result = self.tools.apply_diff(out_path, new_content)
                     context_items.append({"tool": "apply_diff", "result": diff_result})
+                    if out_path not in changed_files:
+                        changed_files.append(out_path)
                     file_applied = True
                     break
 
@@ -1308,36 +1312,3 @@ class AgentRunner:
         applied_count = sum(1 for s in step_results if s.get("status") == "applied")
         lines.append(f"**Result:** {applied_count}/{len(step_results)} steps completed, {len(unique_files)} file(s) changed.")
         return "\n".join(lines)
-        return self._extract_json(text)
-
-    def _extract_json(self, text: str) -> dict:
-        return json.loads(re.search(r"\{.*\}", text, re.S).group(0))
-
-    def _safe_read(self, p: str) -> str: 
-        try: return Path(p).read_text()
-        except Exception: return ""
-
-    def _parse_execution_response(self, raw, fallback):
-        m = re.search(r"FILE:\s*(?P<path>.*)\s*ACTION:\s*(?P<action>create|replace|append)\s*```.*?\n(?P<content>.*?)\n```", raw, re.S)
-        if not m: return None
-        return m.group("path").strip() or fallback, m.group("content")
-
-    def _clean_generated_file_content(self, c): return c.strip() + "\n"
-
-    def _commit_step(self, desc, files):
-        try:
-            subprocess.run(["git", "add", *files], check=True)
-            subprocess.run(["git", "commit", "-m", f"agent: {desc[:50]}"], check=True)
-            return subprocess.check_output(["git", "rev-parse", "HEAD"], text=True).strip()
-        except Exception: return None
-
-    async def _spawn_subagent(self, instruction, requested_model, max_steps, user_id, memory_store, metadata) -> dict:
-        child = AgentRunner(ollama_base=self.ollama_base, workspace_root=self.tools.root)
-        return await child.run(instruction=instruction, history=[], requested_model=requested_model, auto_commit=False, max_steps=max_steps, user_id=user_id, memory_store=memory_store, metadata=metadata)
-
-    async def _synthesize_answer(self, g, s, o, m):
-        msg = [{"role": "system", "content": "Synthesize answer."}, {"role": "user", "content": f"Goal: {g}\nResults: {json.dumps(o)}"}]
-        return await self._chat_text(mol, msg)
-
-    def _build_summary(self, g, sr, c): return f"Goal: {g} completed."
-    def _build_rich_report(self, g, sr, c): return f"Report: {g} completed."

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -22,6 +22,7 @@
 
 ### Fixed
 
+- `agent/loop.py` — fixed an `IndentationError` in the step tool-selection loop by restoring the missing `try:` block around `_chat_json()` / `ToolCall` validation, unblocking test collection and backend startup/import paths.
 - `tests/test_failover_order.py::test_from_env_provider_order_local_first` — test was asserting `ollama-local` is always present without setting `INCLUDE_LOCAL_FALLBACK=true`. Updated to explicitly opt in, matching the current explicit-opt-in behaviour introduced in the previous fix.
 - `direct_chat.py` — agent-mode direct chat now appends the user message before queueing the background job (preventing missing-session `KeyError` on async completion) and returns HTTP `202 Accepted` with `job_id` for proper async semantics.
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -23,6 +23,7 @@
 ### Fixed
 
 - `agent/loop.py` — fixed an `IndentationError` in the step tool-selection loop by restoring the missing `try:` block around `_chat_json()` / `ToolCall` validation, unblocking test collection and backend startup/import paths.
+- `agent/loop.py` — removed a trailing duplicated method block that overrode the main implementations, and restored normal edit-step file application bookkeeping (`target_file` loop + `changed_files` tracking), fixing AgentRunner regressions in `spawn_subagent` and mocked edit-flow tests.
 - `tests/test_failover_order.py::test_from_env_provider_order_local_first` — test was asserting `ollama-local` is always present without setting `INCLUDE_LOCAL_FALLBACK=true`. Updated to explicitly opt in, matching the current explicit-opt-in behaviour introduced in the previous fix.
 - `direct_chat.py` — agent-mode direct chat now appends the user message before queueing the background job (preventing missing-session `KeyError` on async completion) and returns HTTP `202 Accepted` with `job_id` for proper async semantics.
 


### PR DESCRIPTION
### Motivation

- Tests and backend startup were failing during import due to multiple indentation regressions and missing `try:` blocks in the agent harness, so the `AgentRunner` module could not be imported or used.  

### Description

- Restored the missing `try:` block around the tool-selection call in `agent/loop.py` so `_chat_json()` / `ToolCall` validation is correctly guarded.  
- Added error-handling wrappers and fixed indentation in helpers including `async def _run_tool`, the judge call wrapper around `_chat_json`, `_extract_json`, and `_commit_step` to ensure exceptions are caught and call paths are consistent.  
- Reinstated and implemented the `_steps_are_independent` helper used for auto-parallelization and added the `_log_event` helper to centralise durable session event writes.  
- Updated `docs/changelog.md` under `Unreleased` to document the import/startup fix.  

### Testing

- Ran `python -m py_compile agent/loop.py` which succeeded.  
- Ran `pytest -x`, which now progresses past module import and test collection; the run reached test execution (13 tests passed before stopping) and produced a single failing test: `tests/test_agent_chat_integration.py::test_risky_module_detection_emits_warning`, which is a logic/assertion failure unrelated to the earlier syntax/import errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff9dcc2fe08327a8996f4b3354f650)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an indentation error causing orchestration failures and removed a duplicated implementation that broke edit-step bookkeeping.

* **Improvements**
  * More robust error handling across tool selection, execution and review with safer fallbacks.
  * Stronger gating to avoid overlapping concurrent edits.
  * Event logging, context compaction, JSON parsing and commit operations now fail gracefully instead of blocking progress.

* **Documentation**
  * Changelog updated with these fixes and restorations.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/strikersam/local-llm-server/pull/100)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->