### PR TITLE
fix: update NVIDIA NIM model names to stable versions

### DIFF
--- a/.github/scripts/implement_agent.py
+++ b/.github/scripts/implement_agent.py
@@ -18,8 +18,8 @@ RESULT_FILE = "/tmp/impl_result.json"
 MAX_TURNS = 100
 
 CANDIDATE_MODELS = [
-    ("nvidia/llama-3.1-nemotron-ultra-253b-v1", "reasoning (Nemotron Ultra 253B)"),
-    ("qwen/qwen3-coder-480b-a35b-instruct", "coding (Qwen3-Coder 480B)"),
+    ("nvidia/llama-3.1-nemotron-70b-instruct", "reasoning (Nemotron 70B)"),
+    ("nvidia/qwen2.5-coder-32b-instruct", "coding (Qwen2.5-Coder 32B)"),
     ("qwen/qwen2.5-coder-32b-instruct", "coding (Qwen2.5 Coder 32B)"),
 ]
 

--- a/.github/scripts/review_agent.py
+++ b/.github/scripts/review_agent.py
@@ -18,7 +18,7 @@ def main():
     client = OpenAI(base_url="https://integrate.api.nvidia.com/v1", api_key=os.environ["NVIDIA_API_KEY"])
     diff = subprocess.check_output(["gh", "pr", "diff", PR_NUMBER, "--patch"], text=True)[:10000]
     prompt = f"Review PR #{PR_NUMBER}:\n\n{diff}\n\nRoles: Security, Correctness. Give overall PASS/FAIL. Format: OVERALL: PASS|FAIL"
-    res = client.chat.completions.create(model="nvidia/llama-3.1-nemotron-ultra-253b-v1", messages=[{"role": "user", "content": prompt}])
+    res = client.chat.completions.create(model="nvidia/llama-3.1-nemotron-70b-instruct", messages=[{"role": "user", "content": prompt}])
     text = res.choices[0].message.content
     verdict = "PASS" if "OVERALL: PASS" in text.upper() else "FAIL"
     with open(RESULT_FILE, "w") as f: json.dump({"verdict": verdict, "summary": text[:200]}, f)

--- a/agent/loop.py
+++ b/agent/loop.py
@@ -45,7 +45,7 @@ _RISKY_FILES: frozenset[str] = frozenset({
 # These are overridden by env vars when local Ollama models are preferred.
 DEFAULT_PLANNER_MODEL = os.environ.get(
     "AGENT_PLANNER_MODEL",
-    "nvidia/llama-3.1-nemotron-ultra-253b-v1"
+    "nvidia/llama-3.1-nemotron-70b-instruct"
     if (os.environ.get("NVIDIA_API_KEY") or os.environ.get("NVidiaApiKey"))
     else "deepseek-r1:32b",
 )
@@ -63,7 +63,7 @@ DEFAULT_VERIFIER_MODEL = os.environ.get(
 )
 DEFAULT_JUDGE_MODEL = os.environ.get(
     "AGENT_JUDGE_MODEL",
-    "nvidia/llama-3.1-nemotron-ultra-253b-v1"
+    "nvidia/llama-3.1-nemotron-70b-instruct"
     if (os.environ.get("NVIDIA_API_KEY") or os.environ.get("NVidiaApiKey"))
     else DEFAULT_VERIFIER_MODEL,
 )

--- a/backend/server.py
+++ b/backend/server.py
@@ -250,11 +250,11 @@ def _default_agent_role_models() -> dict[str, str]:
     )
     if nim_enabled:
         return {
-            "default": os.environ.get("NVIDIA_DEFAULT_MODEL") or "nvidia/nemotron-3-super-120b-a12b",
-            "planner": os.environ.get("AGENT_PLANNER_MODEL") or "nvidia/llama-3.1-nemotron-ultra-253b-v1",
-            "executor": os.environ.get("AGENT_EXECUTOR_MODEL") or "nvidia/nemotron-3-super-120b-a12b",
-            "verifier": os.environ.get("AGENT_VERIFIER_MODEL") or "nvidia/nemotron-3-super-120b-a12b",
-            "judge": os.environ.get("AGENT_JUDGE_MODEL") or "nvidia/llama-3.1-nemotron-ultra-253b-v1",
+            "default": os.environ.get("NVIDIA_DEFAULT_MODEL") or "nvidia/llama-3.1-70b-instruct",
+            "planner": os.environ.get("AGENT_PLANNER_MODEL") or "nvidia/llama-3.1-nemotron-70b-instruct",
+            "executor": os.environ.get("AGENT_EXECUTOR_MODEL") or "nvidia/llama-3.1-70b-instruct",
+            "verifier": os.environ.get("AGENT_VERIFIER_MODEL") or "nvidia/llama-3.1-70b-instruct",
+            "judge": os.environ.get("AGENT_JUDGE_MODEL") or "nvidia/llama-3.1-nemotron-70b-instruct",
         }
     return {
         "default": os.environ.get("OLLAMA_MODEL") or "qwen3-coder:30b",
@@ -1996,7 +1996,7 @@ async def seed_default_providers():
         os.environ.get("NVIDIA_BASE_URL") or "https://integrate.api.nvidia.com/v1"
     ).rstrip("/")
     _nvidia_model = (
-        os.environ.get("NVIDIA_DEFAULT_MODEL") or "nvidia/nemotron-3-super-120b-a12b"
+        os.environ.get("NVIDIA_DEFAULT_MODEL") or "nvidia/llama-3.1-70b-instruct"
     )
     defaults = [
         {
@@ -2958,7 +2958,7 @@ def _nvidia_nim_provider_record() -> Optional[Dict]:
         os.environ.get("NVIDIA_BASE_URL") or "https://integrate.api.nvidia.com/v1"
     ).rstrip("/")
     model = (
-        os.environ.get("NVIDIA_DEFAULT_MODEL") or "nvidia/nemotron-3-super-120b-a12b"
+        os.environ.get("NVIDIA_DEFAULT_MODEL") or "nvidia/llama-3.1-70b-instruct"
     )
     return {
         "provider_id": "nvidia-nim",

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 ### Fixed
+- Updated all NVIDIA NIM model references to stable, current versions (`nvidia/llama-3.1-nemotron-70b-instruct` and `nvidia/qwen2.5-coder-32b-instruct`) to resolve 404/429 errors in GitHub Actions and proxy routing.
 - `agent/github_tools.py` — Fixed syntax errors regarding misplaced future imports.
 - `agent/loop.py` — Enforced 'real work' requirement for edit/create tasks; increased max tool calls per step to 50.
 - `runtimes/health.py` — Increased health check timeouts to 60s and circuit-breaker threshold to 10 failures to improve system uptime and reduce transient 'offline' status.

--- a/frontend/src/pages/SetupWizardPage.js
+++ b/frontend/src/pages/SetupWizardPage.js
@@ -57,11 +57,11 @@ const STEPS = [
 
 // Nvidia NIM free models
 const NVIDIA_MODELS = {
-  executor: 'nvidia/nemotron-3-super-120b-a12b',
-  planner:  'nvidia/llama-3.1-nemotron-ultra-253b-v1',
-  verifier: 'nvidia/nemotron-3-super-120b-a12b',
-  judge: 'nvidia/llama-3.1-nemotron-ultra-253b-v1',
-  default:  'nvidia/nemotron-3-super-120b-a12b',
+  executor: 'nvidia/llama-3.1-70b-instruct',
+  planner:  'nvidia/llama-3.1-nemotron-70b-instruct',
+  verifier: 'nvidia/llama-3.1-70b-instruct',
+  judge: 'nvidia/llama-3.1-nemotron-70b-instruct',
+  default:  'nvidia/llama-3.1-70b-instruct',
 };
 const LOCAL_MODELS = {
   executor: 'qwen3-coder:30b',
@@ -1081,7 +1081,7 @@ export default function SetupWizardPage({ onComplete }) {
                     <label className="text-sm font-medium text-gray-700">Direct Chat default model</label>
                     <input className="w-full mt-1 border border-gray-300 rounded-lg px-3 py-2 text-base text-gray-900 focus:border-indigo-500 focus:ring-2 focus:ring-indigo-200 focus:outline-none"
                       value={defaultModel} onChange={e => setDefaultModel(e.target.value)}
-                      placeholder="nvidia/nemotron-3-super-120b-a12b" />
+                      placeholder="nvidia/llama-3.1-70b-instruct" />
                     <p className="text-xs text-gray-500 mt-1">Used for non-agent chat when you stay on the provider default path.</p>
                   </div>
                   <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
@@ -1089,25 +1089,25 @@ export default function SetupWizardPage({ onComplete }) {
                       <label className="text-sm font-medium text-gray-700">Planner model</label>
                       <input className="w-full mt-1 border border-gray-300 rounded-lg px-3 py-2 text-base text-gray-900 focus:border-indigo-500 focus:ring-2 focus:ring-indigo-200 focus:outline-none"
                         value={plannerModel} onChange={e => setPlannerModel(e.target.value)}
-                        placeholder="nvidia/llama-3.1-nemotron-ultra-253b-v1" />
+                        placeholder="nvidia/llama-3.1-nemotron-70b-instruct" />
                     </div>
                     <div>
                       <label className="text-sm font-medium text-gray-700">Coder / executor model</label>
                       <input className="w-full mt-1 border border-gray-300 rounded-lg px-3 py-2 text-base text-gray-900 focus:border-indigo-500 focus:ring-2 focus:ring-indigo-200 focus:outline-none"
                         value={executorModel} onChange={e => setExecutorModel(e.target.value)}
-                        placeholder="nvidia/nemotron-3-super-120b-a12b" />
+                        placeholder="nvidia/llama-3.1-70b-instruct" />
                     </div>
                     <div>
                       <label className="text-sm font-medium text-gray-700">Verifier model</label>
                       <input className="w-full mt-1 border border-gray-300 rounded-lg px-3 py-2 text-base text-gray-900 focus:border-indigo-500 focus:ring-2 focus:ring-indigo-200 focus:outline-none"
                         value={verifierModel} onChange={e => setVerifierModel(e.target.value)}
-                        placeholder="nvidia/nemotron-3-super-120b-a12b" />
+                        placeholder="nvidia/llama-3.1-70b-instruct" />
                     </div>
                     <div>
                       <label className="text-sm font-medium text-gray-700">Judge model</label>
                       <input className="w-full mt-1 border border-gray-300 rounded-lg px-3 py-2 text-base text-gray-900 focus:border-indigo-500 focus:ring-2 focus:ring-indigo-200 focus:outline-none"
                         value={judgeModel} onChange={e => setJudgeModel(e.target.value)}
-                        placeholder="nvidia/llama-3.1-nemotron-ultra-253b-v1" />
+                        placeholder="nvidia/llama-3.1-nemotron-70b-instruct" />
                     </div>
                   </div>
                 </div>

--- a/render.yaml
+++ b/render.yaml
@@ -33,7 +33,7 @@ services:
 
       # Agent model defaults (Nvidia NIM free models)
       - key: AGENT_PLANNER_MODEL
-        value: "nvidia/llama-3.1-nemotron-ultra-253b-v1"
+        value: "nvidia/llama-3.1-nemotron-70b-instruct"
       - key: AGENT_EXECUTOR_MODEL
         value: "qwen/qwen2.5-coder-32b-instruct"
       - key: AGENT_VERIFIER_MODEL
@@ -130,6 +130,6 @@ services:
       - key: GOOSE_PROFILE
         value: "default"
       - key: AIDER_MODEL
-        value: "nvidia/llama-3.1-nemotron-ultra-253b-v1"
+        value: "nvidia/llama-3.1-nemotron-70b-instruct"
       - key: AIDER_NO_AUTO_COMMIT
         value: "false"

--- a/router/model_router.py
+++ b/router/model_router.py
@@ -99,9 +99,9 @@ def _build_builtin_model_map() -> dict[str, str]:
     nvidia = _nvidia_key_present()
 
     # Reasoning/planning model: nemotron-ultra (Nvidia) or deepseek-r1 (local)
-    _heavy = "nvidia/llama-3.1-nemotron-ultra-253b-v1" if nvidia else "deepseek-r1:32b"
+    _heavy = "nvidia/llama-3.1-nemotron-70b-instruct" if nvidia else "deepseek-r1:32b"
     # Largest local-only model (only applies when Nvidia not configured)
-    _largest = "nvidia/llama-3.1-nemotron-ultra-253b-v1" if nvidia else "deepseek-r1:671b"
+    _largest = "nvidia/llama-3.1-nemotron-70b-instruct" if nvidia else "deepseek-r1:671b"
     # Coding/execution model: qwen2.5-coder (Nvidia) or qwen3-coder (local)
     _coder = "qwen/qwen2.5-coder-32b-instruct" if nvidia else "qwen3-coder:30b"
     # Fast/small model
@@ -133,7 +133,7 @@ def _build_builtin_model_map() -> dict[str, str]:
         # Nvidia NIM short-name aliases (passthrough when key is set)
         "llama-3.3-70b": "meta/llama-3.3-70b-instruct",
         "llama-3.1-405b": "meta/llama-3.1-405b-instruct",
-        "nemotron-ultra": "nvidia/llama-3.1-nemotron-ultra-253b-v1",
+        "nemotron-ultra": "nvidia/llama-3.1-nemotron-70b-instruct",
         "qwen2.5-coder-32b": "qwen/qwen2.5-coder-32b-instruct",
         "deepseek-r1-nim": "deepseek-ai/deepseek-r1",
         # Gemma 4 short-name aliases (local Ollama pull names)
@@ -214,7 +214,7 @@ def _default_reasoning_model() -> str:
     if explicit:
         return explicit
     return (
-        "nvidia/llama-3.1-nemotron-ultra-253b-v1"
+        "nvidia/llama-3.1-nemotron-70b-instruct"
         if _nvidia_key_present()
         else "deepseek-r1:32b"
     )

--- a/setup/api.py
+++ b/setup/api.py
@@ -100,11 +100,11 @@ class Step2Request(BaseModel):
     """Local model detection results and default model selection."""
     default_model:      str  = "qwen/qwen2.5-coder-32b-instruct"
     coder_model:        str  = "qwen/qwen2.5-coder-32b-instruct"
-    planner_model:      str  = "nvidia/llama-3.1-nemotron-ultra-253b-v1"
+    planner_model:      str  = "nvidia/llama-3.1-nemotron-70b-instruct"
     executor_model:     str  = "qwen/qwen2.5-coder-32b-instruct"
     reviewer_model:     str  = "deepseek-ai/deepseek-r1"
     verifier_model:     str  = "deepseek-ai/deepseek-r1"
-    judge_model:        str  = "nvidia/llama-3.1-nemotron-ultra-253b-v1"
+    judge_model:        str  = "nvidia/llama-3.1-nemotron-70b-instruct"
     embedding_model:    str  = "nomic-embed-text"
     accepted_degraded:  bool = False   # user acknowledges degraded compatibility
     repo_path:          str | None = None  # path to local-llm-server repo


### PR DESCRIPTION
This PR updates the NVIDIA NIM model identifiers used throughout the repository. The previous models were returning 404 (Not Found) or 429 (Too Many Requests) errors. 

Key changes:
- Replaced `nvidia/llama-3.1-nemotron-ultra-253b-v1` with `nvidia/llama-3.1-nemotron-70b-instruct`.
- Replaced `qwen/qwen3-coder-480b-a35b-instruct` with `nvidia/qwen2.5-coder-32b-instruct`.
- Updated fallback models in `backend/server.py` and `frontend/src/pages/SetupWizardPage.js`.
- Verified changes by running `pytest tests/test_model_router.py`.

---
*PR created automatically by Jules for task [10598755530041137305](https://jules.google.com/task/10598755530041137305) started by @strikersam*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Updated NVIDIA NIM model defaults to stable versions across agent planning, model routing, and setup components.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/strikersam/local-llm-server/pull/106)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->