### PR TITLE
ci: fix non-existent action versions across all workflows

### DIFF
--- a/.github/workflows/changelog-check.yml
+++ b/.github/workflows/changelog-check.yml
@@ -12,7 +12,7 @@ jobs:
     if: github.actor != 'dependabot[bot]'
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
@@ -86,7 +86,7 @@ jobs:
 
       - name: Upload test results
         if: failure()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: test-results-${{ matrix.python-version }}
           path: .pytest_cache/
@@ -97,7 +97,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
           python-version: "3.13"
@@ -121,9 +121,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v4
         with:
           node-version: "20"
           cache: npm

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,7 +24,7 @@ jobs:
         language: [python, javascript]
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v3

--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -22,9 +22,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v4
         with:
           node-version: '20'
           cache: npm
@@ -48,7 +48,7 @@ jobs:
         run: cp -r remote-admin frontend/build/remote-admin
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v5
+        uses: actions/upload-pages-artifact@v3
         with:
           path: frontend/build
 

--- a/.github/workflows/fix-security-alerts.yml
+++ b/.github/workflows/fix-security-alerts.yml
@@ -46,7 +46,7 @@ jobs:
 
     steps:
       # ── 1. Checkout ────────────────────────────────────────────────────────
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 0

--- a/.github/workflows/process-quick-note.yml
+++ b/.github/workflows/process-quick-note.yml
@@ -34,7 +34,7 @@ jobs:
 
     steps:
       # ── 1. Checkout ───────────────────────────────────────────────────────
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 0


### PR DESCRIPTION
Fixes all GitHub Actions workflows that were failing instantly (0s) due to non-existent action versions.

| Action | Was | Now |
|--------|-----|-----|
| `actions/checkout` | `@v6` | `@v4` |
| `actions/setup-node` | `@v6` | `@v4` |
| `actions/upload-artifact` | `@v7` | `@v4` |
| `actions/upload-pages-artifact` | `@v5` | `@v3` |

Affected workflows: `fix-security-alerts.yml`, `ci.yml`, `codeql.yml`, `changelog-check.yml`, `process-quick-note.yml`, `deploy-frontend.yml`

---
_Generated by [Claude Code](https://claude.ai/code/session_01QwGqse54UvMPPKhwKffdD1)_