### PR TITLE
feat: address review comments from PRs 167 & 168; add agency-cycle CEO workflow

### DIFF
--- a/agent/github_tools.py
+++ b/agent/github_tools.py
@@ -256,6 +256,11 @@ class GitHubTools:
     ) -> dict[str, Any]:
         """Merge an open pull request via the GitHub API."""
         self._validate_repo_parts(owner, repo)
+        if not isinstance(pull_number, int) or pull_number < 1:
+            raise ValueError(f"pull_number must be a positive integer, got {pull_number!r}")
+        _valid_methods = {"merge", "squash", "rebase"}
+        if merge_method not in _valid_methods:
+            raise ValueError(f"merge_method must be one of {_valid_methods}, got {merge_method!r}")
         payload: dict[str, Any] = {"merge_method": merge_method}
         if commit_title:
             payload["commit_title"] = commit_title

--- a/scripts/agency_fix.py
+++ b/scripts/agency_fix.py
@@ -1,0 +1,364 @@
+#!/usr/bin/env python3
+"""Agency Fix Agent — uses NVIDIA NIM (or Anthropic) to analyse failing tests and apply fixes.
+
+Usage:
+    python scripts/agency_fix.py <pytest-output-file>
+
+Exit codes:
+    0  All tests green after fix (or were already green)
+    1  Could not fix tests
+    2  No LLM API key available
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+logging.basicConfig(
+    stream=sys.stdout,
+    level=logging.INFO,
+    format="%(levelname)s %(message)s",
+)
+log = logging.getLogger("qwen-proxy")
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+NVIDIA_KEY = os.environ.get("NVIDIA_API_KEY", "")
+ANTHROPIC_KEY = os.environ.get("ANTHROPIC_API_KEY", "")
+NVIDIA_MODEL = os.environ.get("AGENCY_MODEL", "qwen/qwen2.5-coder-32b-instruct")
+ANTHROPIC_MODEL = "claude-opus-4-7"
+
+MAX_ITERATIONS = 3
+MAX_CONTEXT_CHARS = 40_000
+
+
+def call_llm(messages: list[dict[str, str]]) -> str:
+    if NVIDIA_KEY:
+        try:
+            from openai import OpenAI  # type: ignore[import]
+            client = OpenAI(
+                base_url="https://integrate.api.nvidia.com/v1",
+                api_key=NVIDIA_KEY,
+            )
+            resp = client.chat.completions.create(
+                model=NVIDIA_MODEL,
+                messages=messages,  # type: ignore[arg-type]
+                temperature=0.1,
+                max_tokens=8192,
+            )
+            content = resp.choices[0].message.content if resp.choices else None
+            if content:
+                return content
+            log.warning("NVIDIA NIM returned empty content — falling back to Anthropic")
+        except Exception as exc:
+            log.warning("NVIDIA NIM call failed (%s) — falling back to Anthropic", exc)
+
+    if ANTHROPIC_KEY:
+        try:
+            import anthropic  # type: ignore[import]
+            client = anthropic.Anthropic(api_key=ANTHROPIC_KEY)
+            system = next((m["content"] for m in messages if m["role"] == "system"), "")
+            user_msgs = [{"role": m["role"], "content": m["content"]} for m in messages if m["role"] != "system"]
+            resp = client.messages.create(
+                model=ANTHROPIC_MODEL,
+                system=system,
+                messages=user_msgs,  # type: ignore[arg-type]
+                max_tokens=8192,
+            )
+            if not resp.content:
+                log.warning("Anthropic returned empty content list")
+                return ""
+            return resp.content[0].text  # type: ignore[union-attr]
+        except Exception as exc:
+            log.warning("Anthropic call failed (%s)", exc)
+
+    return ""
+
+
+def run_pytest(extra_args: list[str] | None = None) -> tuple[int, str]:
+    cmd = [sys.executable, "-m", "pytest", "--tb=short", "-q", "--no-header", "--timeout=120"]
+    if extra_args:
+        cmd.extend(extra_args)
+    env = {**os.environ}
+    env.setdefault("API_KEYS", "ci-test-key")
+    env.setdefault("OLLAMA_BASE", "http://localhost:11434")
+    env.setdefault("ROUTER_HEALTH_CHECK_ENABLED", "false")
+    env.setdefault("MONGO_URL", "mongodb://localhost:27017")
+    env.setdefault("DB_NAME", "llm_wiki_dashboard_ci")
+    result = subprocess.run(
+        cmd,
+        cwd=str(REPO_ROOT),
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    output = (result.stdout + result.stderr).strip()
+    return result.returncode, output
+
+
+def extract_failing_tests(output: str) -> list[str]:
+    return re.findall(r"^FAILED\s+(\S+)", output, re.MULTILINE)
+
+
+def read_file_safe(path: Path, max_chars: int = 8000) -> str:
+    try:
+        text = path.read_text(errors="replace")
+        return text[:max_chars] if len(text) > max_chars else text
+    except OSError:
+        return ""
+
+
+def collect_context(failing: list[str], pytest_output: str) -> str:
+    parts: list[str] = [f"## Pytest output\n```\n{pytest_output[:8000]}\n```\n"]
+    seen_files: set[str] = set()
+    for test_id in failing:
+        file_part = test_id.split("::")[0]
+        if file_part not in seen_files:
+            seen_files.add(file_part)
+            fpath = REPO_ROOT / file_part
+            content = read_file_safe(fpath)
+            if content:
+                parts.append(f"## {file_part}\n```python\n{content}\n```\n")
+    combined = "\n".join(parts)
+    return combined[:MAX_CONTEXT_CHARS]
+
+
+def collect_source_files(failing: list[str]) -> str:
+    src_files: dict[str, str] = {}
+    for py_file in REPO_ROOT.glob("**/*.py"):
+        if any(skip in py_file.parts for skip in (".venv", "node_modules", "__pycache__", ".git")):
+            continue
+        if py_file.parts[len(REPO_ROOT.parts):][0:1] == ("tests",):
+            continue
+        src_files[str(py_file.relative_to(REPO_ROOT))] = read_file_safe(py_file, max_chars=4000)
+    priority = {"backend/server.py", "proxy.py", "provider_router.py"}
+    result_parts: list[str] = []
+    total = 0
+    for rel, content in src_files.items():
+        if rel in priority or total < 15_000:
+            chunk = f"## {rel}\n```python\n{content}\n```\n"
+            result_parts.append(chunk)
+            total += len(chunk)
+        if total > 20_000:
+            break
+    return "\n".join(result_parts)
+
+
+def build_prompt(pytest_output: str, failing: list[str], iteration: int) -> list[dict[str, str]]:
+    context = collect_context(failing, pytest_output)
+    src = collect_source_files(failing)
+
+    system = (
+        "You are an expert Python engineer working on the local-llm-server project.\n"
+        "Your job is to fix failing pytest tests by editing source files (NOT the tests themselves).\n"
+        "Never skip, xfail, or comment out tests.\n"
+        "Respond ONLY with a JSON object in this exact schema:\n"
+        "{\n"
+        '  "explanation": "<brief diagnosis>",\n'
+        '  "edits": [\n'
+        "    {\n"
+        '      "file": "<relative path from repo root>",\n'
+        '      "old": "<exact substring to replace — must be unique in the file>",\n'
+        '      "new": "<replacement text>"\n'
+        "    }\n"
+        "  ]\n"
+        "}\n"
+        "If no source edit can fix the failure, return {\"explanation\": \"<reason>\", \"edits\": []}.\n"
+        "The JSON must be parseable. Do NOT wrap it in markdown code fences."
+    )
+
+    user = (
+        f"Iteration {iteration}/{MAX_ITERATIONS}. Fix these failing tests:\n"
+        + "\n".join(f"  - {t}" for t in failing)
+        + "\n\n"
+        + context
+        + "\n\n## Source context\n"
+        + src
+    )
+
+    return [
+        {"role": "system", "content": system},
+        {"role": "user", "content": user},
+    ]
+
+
+def parse_edits(response: str) -> dict[str, Any]:
+    response = re.sub(r"```(?:json)?\n?", "", response).strip().rstrip("`")
+    try:
+        return json.loads(response)
+    except json.JSONDecodeError:
+        m = re.search(r"\{.*\}", response, re.DOTALL)
+        if m:
+            try:
+                return json.loads(m.group())
+            except json.JSONDecodeError:
+                pass
+    return {"explanation": "Could not parse LLM response", "edits": []}
+
+
+_BLOCKED_TOP_DIRS = frozenset({"tests", ".github", "scripts"})
+_BLOCKED_FILES = frozenset({
+    "pytest.ini", "setup.cfg", "pyproject.toml", "conftest.py",
+    "requirements.txt", "requirements-dev.txt", "CLAUDE.md",
+})
+_BLOCKED_EXTENSIONS = frozenset({".yml", ".yaml", ".toml", ".cfg", ".ini"})
+
+
+def _is_blocked(rel_resolved: Path) -> str | None:
+    """Return a human-readable reason if the path should not be edited, else None."""
+    if rel_resolved.parts[0:1] and rel_resolved.parts[0] in _BLOCKED_TOP_DIRS:
+        return f"top-level directory '{rel_resolved.parts[0]}' is blocked"
+    if rel_resolved.name in _BLOCKED_FILES:
+        return f"file '{rel_resolved.name}' is a control file"
+    if rel_resolved.suffix in _BLOCKED_EXTENSIONS:
+        return f"extension '{rel_resolved.suffix}' is blocked (config/CI files)"
+    return None
+
+
+def apply_edits(edits: list[dict[str, str]]) -> list[str]:
+    applied: list[str] = []
+    repo_root_resolved = REPO_ROOT.resolve()
+    for edit in edits:
+        rel = edit.get("file", "")
+        old = edit.get("old", "")
+        new = edit.get("new", "")
+        if not (rel and old) or not isinstance(rel, str) or not isinstance(old, str) or not isinstance(new, str):
+            continue
+        fpath = (REPO_ROOT / rel).resolve()
+        try:
+            rel_resolved = fpath.relative_to(repo_root_resolved)
+        except ValueError:
+            log.warning("skip %s — path escapes repo root", rel)
+            continue
+        reason = _is_blocked(rel_resolved)
+        if reason:
+            log.warning("skip %s — %s", rel, reason)
+            continue
+        if not fpath.is_file():
+            log.warning("skip %s — not a regular file", rel)
+            continue
+        content = fpath.read_text(errors="replace")
+        if old not in content:
+            log.warning("skip %s — old string not found", rel)
+            continue
+        if content.count(old) != 1:
+            log.warning("skip %s — old string matches %d locations (must be unique)", rel, content.count(old))
+            continue
+        fpath.write_text(content.replace(old, new, 1))
+        applied.append(rel)
+        log.info("edit applied: %s", rel)
+    return applied
+
+
+def update_changelog(explanation: str, fixed_tests: list[str]) -> None:
+    cl_path = REPO_ROOT / "docs" / "changelog.md"
+    if not cl_path.exists():
+        return
+    content = cl_path.read_text()
+    bullet = f"- Agency auto-fix: {explanation}"
+    for t in fixed_tests[:5]:
+        bullet += f"\n  - `{t}`"
+    marker = "## [Unreleased]"
+    if marker not in content:
+        return
+    # Find the Unreleased section boundary
+    unreleased_start = content.index(marker)
+    next_section = content.find("\n## ", unreleased_start + len(marker))
+    unreleased_block = content[unreleased_start:next_section] if next_section != -1 else content[unreleased_start:]
+    fixed_heading = "### Fixed"
+    if fixed_heading in unreleased_block:
+        # Append bullet to existing ### Fixed section
+        insert_at = content.index(fixed_heading, unreleased_start) + len(fixed_heading)
+        content = content[:insert_at] + f"\n{bullet}" + content[insert_at:]
+    else:
+        # Create new ### Fixed block after the marker
+        content = content.replace(marker, f"{marker}\n\n{fixed_heading}\n{bullet}", 1)
+    cl_path.write_text(content)
+
+
+def main() -> int:
+    if not NVIDIA_KEY and not ANTHROPIC_KEY:
+        log.error("Neither NVIDIA_API_KEY nor ANTHROPIC_API_KEY is set.")
+        return 2
+
+    initial_output_file = Path(sys.argv[1]) if len(sys.argv) > 1 else None
+    if initial_output_file and initial_output_file.exists():
+        pytest_output = initial_output_file.read_text()
+        has_failures = bool(extract_failing_tests(pytest_output))
+        has_errors = bool(re.search(r"^(ERROR|FAILED)\s", pytest_output, re.MULTILINE))
+        exit_code = 0 if not (has_failures or has_errors) else 1
+    else:
+        log.info("Running pytest baseline...")
+        exit_code, pytest_output = run_pytest()
+
+    if exit_code == 0:
+        log.info("All tests already passing — nothing to fix.")
+        return 0
+
+    failing = extract_failing_tests(pytest_output)
+    if not failing:
+        log.error("Tests failed but no FAILED lines found — may be a collection error.")
+        log.error(pytest_output[-2000:])
+        return 1
+
+    log.info("Failing tests (%d): %s", len(failing), ", ".join(failing[:5]))
+    all_applied: list[str] = []
+
+    for iteration in range(1, MAX_ITERATIONS + 1):
+        log.info("=== Agency Fix Iteration %d/%d ===", iteration, MAX_ITERATIONS)
+        messages = build_prompt(pytest_output, failing, iteration)
+        log.info("Calling LLM...")
+        response = call_llm(messages)
+
+        if not response:
+            log.warning("LLM returned empty response.")
+            break
+
+        parsed = parse_edits(response)
+        if not isinstance(parsed, dict):
+            log.warning("LLM response parsed to non-dict type %s; skipping.", type(parsed).__name__)
+            break
+        explanation = parsed.get("explanation", "")
+        raw_edits = parsed.get("edits", [])
+        # Normalise: a single dict response is wrapped into a list; anything
+        # other than a list of dicts is discarded.
+        if isinstance(raw_edits, dict):
+            raw_edits = [raw_edits]
+        edits = [e for e in raw_edits if isinstance(e, dict)] if isinstance(raw_edits, list) else []
+        log.info("LLM explanation: %s", explanation)
+
+        if not edits:
+            log.warning("No edits suggested.")
+            break
+
+        applied = apply_edits(edits)
+        all_applied.extend(applied)
+
+        if not applied:
+            log.warning("No edits could be applied.")
+            break
+
+        fixed_tests = list(failing)  # snapshot before re-run overwrites failing
+        log.info("Re-running pytest...")
+        exit_code, pytest_output = run_pytest()
+        failing = extract_failing_tests(pytest_output)
+
+        if exit_code == 0:
+            log.info("All tests green after iteration %d.", iteration)
+            update_changelog(explanation, fixed_tests)
+            return 0
+
+        log.warning("Still failing: %s", ", ".join(failing[:5]))
+
+    log.error("Could not fix all tests after %d iterations.", MAX_ITERATIONS)
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_agency.py
+++ b/tests/test_agency.py
@@ -42,7 +42,7 @@ def test_agency_initial_status(agency: Agency):
 
 
 @pytest.mark.asyncio
-async def test_run_cycle_no_issues(tmp_path: Path, agency: Agency):
+async def test_run_cycle_no_issues(tmp_path: Path, agency: Agency) -> None:
     """With no improvement loop available, falls back to rule-based, nominal."""
     with patch("agent.improvement_loop.get_improvement_loop", return_value=None), \
          patch.object(agency, "_dispatch_directive"), \
@@ -55,7 +55,7 @@ async def test_run_cycle_no_issues(tmp_path: Path, agency: Agency):
 
 
 @pytest.mark.asyncio
-async def test_run_cycle_with_failing_tests(tmp_path: Path, agency: Agency):
+async def test_run_cycle_with_failing_tests(tmp_path: Path, agency: Agency) -> None:
     """Failing tests should trigger a Dev agent directive."""
     from agent.improvement_loop import ImprovementLoop, set_improvement_loop
 
@@ -75,7 +75,7 @@ async def test_run_cycle_with_failing_tests(tmp_path: Path, agency: Agency):
 
 
 @pytest.mark.asyncio
-async def test_run_cycle_with_security_issues(tmp_path: Path, agency: Agency):
+async def test_run_cycle_with_security_issues(tmp_path: Path, agency: Agency) -> None:
     """Security issues should trigger a Security agent directive."""
     from agent.improvement_loop import (
         DetectedIssue, ImprovementLoop, IssueCategory, IssueSeverity, set_improvement_loop,
@@ -102,7 +102,7 @@ async def test_run_cycle_with_security_issues(tmp_path: Path, agency: Agency):
 
 
 @pytest.mark.asyncio
-async def test_ceo_assessment_nominal(tmp_path: Path, agency: Agency):
+async def test_ceo_assessment_nominal(tmp_path: Path, agency: Agency) -> None:
     """With no issues, CEO should report nominal."""
     from agent.improvement_loop import ImprovementLoop, set_improvement_loop
 
@@ -119,7 +119,7 @@ async def test_ceo_assessment_nominal(tmp_path: Path, agency: Agency):
 
 
 @pytest.mark.asyncio
-async def test_ceo_llm_parses_valid_json(agency: Agency):
+async def test_ceo_llm_parses_valid_json(agency: Agency) -> None:
     """CEO should parse valid JSON directive list from LLM response."""
     valid_json = """Here are my directives:
 [
@@ -136,21 +136,21 @@ async def test_ceo_llm_parses_valid_json(agency: Agency):
 
 
 @pytest.mark.asyncio
-async def test_ceo_llm_handles_empty_json(agency: Agency):
+async def test_ceo_llm_handles_empty_json(agency: Agency) -> None:
     """CEO should return empty list on '[]' or no-work response."""
     directives = _parse_ceo_directives("[]", cycle=1)
     assert directives == []
 
 
 @pytest.mark.asyncio
-async def test_ceo_llm_handles_invalid_json(agency: Agency):
+async def test_ceo_llm_handles_invalid_json(agency: Agency) -> None:
     """CEO should gracefully handle non-JSON LLM response."""
     directives = _parse_ceo_directives("All systems look good, no action needed.", cycle=1)
     assert directives == []
 
 
 @pytest.mark.asyncio
-async def test_ceo_llm_unknown_role_defaults_to_dev(agency: Agency):
+async def test_ceo_llm_unknown_role_defaults_to_dev(agency: Agency) -> None:
     json_text = '[{"role": "unknown_role", "priority": 3, "title": "T", "instruction": "I"}]'
     directives = _parse_ceo_directives(json_text, cycle=1)
     assert len(directives) == 1
@@ -179,7 +179,7 @@ def test_build_ceo_prompt_includes_context():
 
 
 @pytest.mark.asyncio
-async def test_run_cycle_with_trend_issues(tmp_path: Path, agency: Agency):
+async def test_run_cycle_with_trend_issues(tmp_path: Path, agency: Agency) -> None:
     """Trend issues should trigger a Scout directive on eligible cycles."""
     from agent.improvement_loop import (
         DetectedIssue, ImprovementLoop, IssueCategory, IssueSeverity, set_improvement_loop,
@@ -210,7 +210,7 @@ async def test_run_cycle_with_trend_issues(tmp_path: Path, agency: Agency):
 
 
 @pytest.mark.asyncio
-async def test_directive_has_preferred_runtime(tmp_path: Path, agency: Agency):
+async def test_directive_has_preferred_runtime(tmp_path: Path, agency: Agency) -> None:
     """Dev directives should prefer claude_code runtime."""
     from agent.improvement_loop import ImprovementLoop, set_improvement_loop
 

--- a/tests/test_backend_server_features.py
+++ b/tests/test_backend_server_features.py
@@ -177,7 +177,7 @@ def test_mask_observations_preserves_message_count():
 # ── _run_agent_loop ───────────────────────────────────────────────────────────
 
 @pytest.mark.anyio
-async def test_run_agent_loop_success(monkeypatch):
+async def test_run_agent_loop_success(monkeypatch) -> None:
     """Verify _run_agent_loop calls AgentRunner.run and returns the summary."""
     mock_result = {"summary": "Agent reached a conclusion."}
     captured: dict[str, object] = {}
@@ -209,7 +209,7 @@ async def test_run_agent_loop_success(monkeypatch):
     assert "AUTO-SELECTED SKILLS" in captured["instruction"]
 
 @pytest.mark.anyio
-async def test_run_agent_loop_failure(monkeypatch):
+async def test_run_agent_loop_failure(monkeypatch) -> None:
     """Verify _run_agent_loop handles AgentRunner exceptions gracefully."""
     
     class MockRunner:

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -37,11 +37,11 @@ def test_stub_mode_fill():
     assert result.success is False
 
 
-def test_stub_mode_screenshot():
+def test_stub_mode_screenshot(tmp_path):
     session = BrowserSession()
     if session.available:
         pytest.skip("Playwright installed")
-    result = asyncio.run(session.screenshot("/tmp/snap.png"))
+    result = asyncio.run(session.screenshot(str(tmp_path / "snap.png")))
     assert result.success is False
 
 

--- a/tests/test_claude_code_adapter.py
+++ b/tests/test_claude_code_adapter.py
@@ -31,7 +31,7 @@ def test_adapter_metadata(adapter: ClaudeCodeAdapter):
 
 
 @pytest.mark.asyncio
-async def test_health_check_binary_not_found(adapter: ClaudeCodeAdapter, monkeypatch):
+async def test_health_check_binary_not_found(adapter: ClaudeCodeAdapter, monkeypatch) -> None:
     monkeypatch.setattr("shutil.which", lambda _: None)
     health = await adapter.health_check()
     assert health.available is False
@@ -39,7 +39,7 @@ async def test_health_check_binary_not_found(adapter: ClaudeCodeAdapter, monkeyp
 
 
 @pytest.mark.asyncio
-async def test_health_check_no_api_key(adapter: ClaudeCodeAdapter, monkeypatch):
+async def test_health_check_no_api_key(adapter: ClaudeCodeAdapter, monkeypatch) -> None:
     monkeypatch.setattr("shutil.which", lambda _: "/usr/bin/claude")
     monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
     health = await adapter.health_check()
@@ -48,7 +48,7 @@ async def test_health_check_no_api_key(adapter: ClaudeCodeAdapter, monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_health_check_success(adapter: ClaudeCodeAdapter, monkeypatch):
+async def test_health_check_success(adapter: ClaudeCodeAdapter, monkeypatch) -> None:
     monkeypatch.setattr("shutil.which", lambda _: "/usr/bin/claude")
     monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test-key")
 
@@ -63,7 +63,7 @@ async def test_health_check_success(adapter: ClaudeCodeAdapter, monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_execute_binary_not_found(adapter: ClaudeCodeAdapter, monkeypatch):
+async def test_execute_binary_not_found(adapter: ClaudeCodeAdapter, monkeypatch) -> None:
     from runtimes.base import RuntimeUnavailableError, TaskSpec
     monkeypatch.setattr("shutil.which", lambda _: None)
     spec = TaskSpec(task_id="t1", instruction="do something", task_type="code_generation")
@@ -72,7 +72,7 @@ async def test_execute_binary_not_found(adapter: ClaudeCodeAdapter, monkeypatch)
 
 
 @pytest.mark.asyncio
-async def test_execute_no_api_key(adapter: ClaudeCodeAdapter, monkeypatch):
+async def test_execute_no_api_key(adapter: ClaudeCodeAdapter, monkeypatch) -> None:
     from runtimes.base import RuntimeUnavailableError, TaskSpec
     monkeypatch.setattr("shutil.which", lambda _: "/usr/bin/claude")
     monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
@@ -82,7 +82,7 @@ async def test_execute_no_api_key(adapter: ClaudeCodeAdapter, monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_execute_success(adapter: ClaudeCodeAdapter, monkeypatch):
+async def test_execute_success(adapter: ClaudeCodeAdapter, monkeypatch) -> None:
     from runtimes.base import TaskSpec
     monkeypatch.setattr("shutil.which", lambda _: "/usr/bin/claude")
     monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test-key")
@@ -103,7 +103,7 @@ async def test_execute_success(adapter: ClaudeCodeAdapter, monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_execute_failure_returns_result(adapter: ClaudeCodeAdapter, monkeypatch):
+async def test_execute_failure_returns_result(adapter: ClaudeCodeAdapter, monkeypatch) -> None:
     from runtimes.base import TaskSpec
     monkeypatch.setattr("shutil.which", lambda _: "/usr/bin/claude")
     monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test-key")

--- a/tests/test_docker_binary_missing.py
+++ b/tests/test_docker_binary_missing.py
@@ -4,7 +4,7 @@ from runtimes.adapters.docker_agent import DockerAgentAdapter
 
 
 @pytest.mark.asyncio
-async def test_docker_binary_missing(monkeypatch):
+async def test_docker_binary_missing(monkeypatch) -> None:
     import shutil
     monkeypatch.setattr(shutil, 'which', lambda name: None)
     adapter = DockerAgentAdapter()

--- a/tests/test_e2e_agent_chat.py
+++ b/tests/test_e2e_agent_chat.py
@@ -264,7 +264,7 @@ class TestAgentChatE2E:
 
         # Detailed failure message so a regression is easy to diagnose
         workspace_files = [str(p.relative_to(tmp_path)) for p in tmp_path.rglob("*")]
-        assert job["status"] in {"succeeded", "failed"}, (
+        assert job["status"] == "succeeded", (
             f"Job stuck in '{job['status']}' — likely the background task was cancelled.\n"
             f"Progress: {[e['phase'] + ': ' + e['message'] for e in job.get('progress_events', [])]}"
         )
@@ -419,7 +419,7 @@ class TestAgentChatE2E:
 
         job = _poll_job(client, headers, job_id, timeout=30.0)
         # Job must reach a terminal state — never stuck or 500
-        assert job["status"] in {"succeeded", "failed"}, (
+        assert job["status"] == "succeeded", (
             f"Job stuck in '{job['status']}' — agent loop may have crashed.\n"
             f"Progress: {[e['phase'] + ': ' + e['message'] for e in job.get('progress_events', [])]}"
         )
@@ -564,7 +564,7 @@ class TestAgentGitHubAPITools:
         })
         assert resp.status_code == 202, resp.text
         job = _poll_job(client, headers, resp.json()["job_id"], timeout=30.0)
-        assert job["status"] in {"succeeded", "failed"}
+        assert job["status"] == "succeeded"
 
     def test_agent_merges_pull_request(
         self, client: TestClient, monkeypatch
@@ -594,7 +594,7 @@ class TestAgentGitHubAPITools:
         })
         assert resp.status_code == 202, resp.text
         job = _poll_job(client, headers, resp.json()["job_id"], timeout=30.0)
-        assert job["status"] in {"succeeded", "failed"}
+        assert job["status"] == "succeeded"
 
     def test_agent_reads_github_issue(
         self, client: TestClient, monkeypatch
@@ -621,7 +621,7 @@ class TestAgentGitHubAPITools:
         })
         assert resp.status_code == 202, resp.text
         job = _poll_job(client, headers, resp.json()["job_id"], timeout=30.0)
-        assert job["status"] in {"succeeded", "failed"}
+        assert job["status"] == "succeeded"
 
 
 # ---------------------------------------------------------------------------
@@ -650,7 +650,7 @@ class TestAgentMCPGitTools:
         })
         assert resp.status_code == 202, resp.text
         job = _poll_job(client, headers, resp.json()["job_id"], timeout=30.0)
-        assert job["status"] in {"succeeded", "failed"}
+        assert job["status"] == "succeeded"
 
     def test_agent_git_diff(self, client: TestClient, monkeypatch) -> None:
         plan = _one_step_plan("git_diff", "Get the diff")
@@ -670,7 +670,7 @@ class TestAgentMCPGitTools:
         })
         assert resp.status_code == 202, resp.text
         job = _poll_job(client, headers, resp.json()["job_id"], timeout=30.0)
-        assert job["status"] in {"succeeded", "failed"}
+        assert job["status"] == "succeeded"
 
     def test_agent_git_create_branch(self, client: TestClient, monkeypatch) -> None:
         plan = _one_step_plan("git_create_branch", "Create branch")
@@ -693,7 +693,7 @@ class TestAgentMCPGitTools:
         })
         assert resp.status_code == 202, resp.text
         job = _poll_job(client, headers, resp.json()["job_id"], timeout=30.0)
-        assert job["status"] in {"succeeded", "failed"}
+        assert job["status"] == "succeeded"
 
     def test_agent_git_commit(self, client: TestClient, monkeypatch) -> None:
         plan = _one_step_plan("git_commit", "Commit changes")
@@ -716,7 +716,7 @@ class TestAgentMCPGitTools:
         })
         assert resp.status_code == 202, resp.text
         job = _poll_job(client, headers, resp.json()["job_id"], timeout=30.0)
-        assert job["status"] in {"succeeded", "failed"}
+        assert job["status"] == "succeeded"
 
     def test_agent_git_push(self, client: TestClient, monkeypatch) -> None:
         plan = _one_step_plan("git_push", "Push to remote")
@@ -739,7 +739,7 @@ class TestAgentMCPGitTools:
         })
         assert resp.status_code == 202, resp.text
         job = _poll_job(client, headers, resp.json()["job_id"], timeout=30.0)
-        assert job["status"] in {"succeeded", "failed"}
+        assert job["status"] == "succeeded"
 
 
 # ---------------------------------------------------------------------------
@@ -902,7 +902,7 @@ class TestAgentFullPRWorkflow:
         job = _poll_job(client, headers, resp.json()["job_id"], timeout=30.0)
 
         workspace_files = list(tmp_path.rglob("*.txt"))
-        assert job["status"] in {"succeeded", "failed"}, (
+        assert job["status"] == "succeeded", (
             f"Job stuck in '{job['status']}'\n"
             f"Progress: {[e['phase'] + ': ' + e['message'] for e in job.get('progress_events', [])]}"
         )
@@ -959,4 +959,4 @@ class TestAgentFullPRWorkflow:
         })
         assert resp.status_code == 202, resp.text
         job = _poll_job(client, headers, resp.json()["job_id"], timeout=30.0)
-        assert job["status"] in {"succeeded", "failed"}
+        assert job["status"] == "succeeded"

--- a/tests/test_knowledge_sync.py
+++ b/tests/test_knowledge_sync.py
@@ -109,7 +109,7 @@ def test_build_digest_includes_low_relevance_section():
 # ── Async: fetch_and_store ────────────────────────────────────────────────────
 
 @pytest.mark.asyncio
-async def test_fetch_and_store_success():
+async def test_fetch_and_store_success() -> None:
     client = _FakeClient(_FakeResp(201, {"id": "src-1", "title": "My source"}))
     result = await fetch_and_store(
         url="https://example.com/article",
@@ -121,7 +121,7 @@ async def test_fetch_and_store_success():
 
 
 @pytest.mark.asyncio
-async def test_fetch_and_store_non_200_returns_error():
+async def test_fetch_and_store_non_200_returns_error() -> None:
     client = _FakeClient(_FakeResp(422, text="Unprocessable"))
     result = await fetch_and_store(
         url="https://example.com",
@@ -133,7 +133,7 @@ async def test_fetch_and_store_non_200_returns_error():
 
 
 @pytest.mark.asyncio
-async def test_fetch_and_store_network_error():
+async def test_fetch_and_store_network_error() -> None:
     async def _fail(*a, **kw):
         raise httpx.ConnectError("refused")
 
@@ -146,7 +146,7 @@ async def test_fetch_and_store_network_error():
 # ── Async: create_wiki_page ────────────────────────────────────────────────────
 
 @pytest.mark.asyncio
-async def test_create_wiki_page_success():
+async def test_create_wiki_page_success() -> None:
     client = _FakeClient(_FakeResp(201, {"id": "page-42", "title": "My page"}))
     result = await create_wiki_page(
         title="AI Trend Digest — Week of 2025-05-01",
@@ -158,7 +158,7 @@ async def test_create_wiki_page_success():
 
 
 @pytest.mark.asyncio
-async def test_create_wiki_page_409_returns_skipped():
+async def test_create_wiki_page_409_returns_skipped() -> None:
     client = _FakeClient(_FakeResp(409, text="Conflict"))
     result = await create_wiki_page(title="duplicate", content="x", client=client)
     assert result.get("skipped") is True
@@ -167,7 +167,7 @@ async def test_create_wiki_page_409_returns_skipped():
 # ── Async: sync_trends ────────────────────────────────────────────────────────
 
 @pytest.mark.asyncio
-async def test_sync_trends_no_watcher_returns_empty():
+async def test_sync_trends_no_watcher_returns_empty() -> None:
     with patch("agent.trend_watcher.get_trend_watcher", return_value=None):
         result = await sync_trends()
     assert isinstance(result, SyncResult)
@@ -175,14 +175,14 @@ async def test_sync_trends_no_watcher_returns_empty():
 
 
 @pytest.mark.asyncio
-async def test_sync_trends_empty_alerts():
+async def test_sync_trends_empty_alerts() -> None:
     result = await sync_trends(alerts=[])
     assert result.ingested == 0
     assert result.errors == 0
 
 
 @pytest.mark.asyncio
-async def test_sync_trends_ingests_high_relevance(monkeypatch):
+async def test_sync_trends_ingests_high_relevance(monkeypatch) -> None:
     alerts = [_make_alert(score=0.8, url="https://ollama.ai/blog/release")]
     post_calls: list[dict] = []
 
@@ -203,7 +203,7 @@ async def test_sync_trends_ingests_high_relevance(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_sync_trends_skips_low_relevance(monkeypatch):
+async def test_sync_trends_skips_low_relevance(monkeypatch) -> None:
     alerts = [_make_alert(score=0.1, url="https://example.com/irrelevant")]
     wiki_calls: list = []
 
@@ -244,7 +244,7 @@ def test_knowledge_sync_defaults_none_before_set():
 # ── KnowledgeSync class methods ───────────────────────────────────────────────
 
 @pytest.mark.asyncio
-async def test_knowledge_sync_ingest_url():
+async def test_knowledge_sync_ingest_url() -> None:
     ks = KnowledgeSync()
     with patch("agent.knowledge_sync.fetch_and_store", new_callable=AsyncMock, return_value={"id": "s1"}) as mock_fn:
         result = await ks.ingest_url("https://x.com", "Test", ["tag1"])
@@ -253,7 +253,7 @@ async def test_knowledge_sync_ingest_url():
 
 
 @pytest.mark.asyncio
-async def test_knowledge_sync_create_page():
+async def test_knowledge_sync_create_page() -> None:
     ks = KnowledgeSync()
     with patch("agent.knowledge_sync.create_wiki_page", new_callable=AsyncMock, return_value={"id": "p1"}) as mock_fn:
         result = await ks.create_page("Title", "Content")

--- a/tests/test_provider_failover_integration.py
+++ b/tests/test_provider_failover_integration.py
@@ -22,7 +22,7 @@ def reset_cooldowns():
 
 
 @pytest.mark.anyio
-async def test_failover_skips_local_uses_windows_server(monkeypatch):
+async def test_failover_skips_local_uses_windows_server(monkeypatch) -> None:
     """Local Ollama down → Windows server Ollama used."""
     attempts: list[str] = []
 
@@ -65,7 +65,7 @@ async def test_failover_skips_local_uses_windows_server(monkeypatch):
 
 
 @pytest.mark.anyio
-async def test_failover_chain_local_windows_hf_deepseek_anthropic(monkeypatch):
+async def test_failover_chain_local_windows_hf_deepseek_anthropic(monkeypatch) -> None:
     """Full chain: local → windows → hf → deepseek → anthropic."""
     attempts: list[str] = []
 
@@ -139,7 +139,7 @@ async def test_failover_chain_local_windows_hf_deepseek_anthropic(monkeypatch):
 
 
 @pytest.mark.anyio
-async def test_failover_raises_503_when_all_fail(monkeypatch):
+async def test_failover_raises_503_when_all_fail(monkeypatch) -> None:
     """All providers fail → ProviderFallbackError is raised."""
 
     async def fake_post_chat(self, provider, payload, timeout_sec):
@@ -174,7 +174,7 @@ async def test_failover_raises_503_when_all_fail(monkeypatch):
 
 
 @pytest.mark.anyio
-async def test_provider_on_cooldown_is_skipped(monkeypatch):
+async def test_provider_on_cooldown_is_skipped(monkeypatch) -> None:
     """A provider on cooldown is not attempted."""
     from provider_router import mark_provider_failed
 
@@ -218,7 +218,7 @@ async def test_provider_on_cooldown_is_skipped(monkeypatch):
 
 
 @pytest.mark.anyio
-async def test_from_env_includes_windows_server(monkeypatch):
+async def test_from_env_includes_windows_server(monkeypatch) -> None:
     """ProviderRouter.from_env() picks up OLLAMA_WINDOWS_SERVER."""
     monkeypatch.setenv("OLLAMA_WINDOWS_SERVER", "http://192.168.1.50:11434")
     monkeypatch.setenv("OLLAMA_WINDOWS_MODEL", "llama3.2")


### PR DESCRIPTION
Clean re-apply of PR #185 changes on top of current master.

Changes:
- Test robustness: agent jobs must succeed for tests to pass
- Fixed path collision in test_browser.py (tmp_path fixture)
- Type annotations on async test functions
- Added scripts/agency_fix.py (AI-powered test fixer)
- Updated agent/github_tools.py with merge_pull_request() method
- Added `anthropic` SDK to agency-cycle.yml workflow

Fixes conflicts from Dependabot merges (#170-#184). Closes #185.