### PR TITLE
fix(ci): install full requirements in weekly-trend-digest workflow

### DIFF
--- a/.github/workflows/weekly-trend-digest.yml
+++ b/.github/workflows/weekly-trend-digest.yml
@@ -22,7 +22,9 @@ jobs:
           cache: pip
 
       - name: Install dependencies
-        run: pip install httpx 2>&1 | tail -3
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
 
       - name: Fetch AI trends
         id: fetch

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,7 @@
 ### Added
 - `agent/repowise.py`, `agent/tools.py` — Implemented Repowise-inspired codebase intelligence tools: `get_overview`, `get_context`, `get_risk`, and `get_why` for enhanced agent reasoning.
 ### Fixed
+- `.github/workflows/weekly-trend-digest.yml` — Fixed failing "Fetch & Digest AI Trends" job: the workflow was installing only `httpx`, but importing `agent.trend_watcher` triggers `agent/__init__.py` which pulls in the full agent stack (`agent.loop`, `provider_router`, `router`, etc.). Changed to install `requirements.txt` so all transitive dependencies are available.
 - `.github/workflows/auto-merge.yml`, `.github/workflows/pull-request.yml` — Removed reference to non-existent `actions/setup-cli@v1` action (marketplace returns 404). `gh` CLI is pre-installed on `ubuntu-latest` runners; no setup step is needed.
 - `.github/workflows/openclaw-security-automation.yml` — Replaced binary-corrupted YAML file with a clean, valid workflow. Also fixed OpenClaw installation to clone from `github.com/openclaw/openclaw` (git clone) instead of `npm install openclaw@latest` (package does not exist on npm).
 - `.github/workflows/agency-cycle.yml` (PR #185) — Fixed invalid `actions/checkout@v6` and `actions/setup-python@v6` references; bumped to `@v4` and `@v5` respectively (highest available versions).


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- The `weekly-trend-digest.yml` "Fetch & Digest AI Trends" job was failing on every run
- Root cause: workflow only installed `httpx`, but `from agent.trend_watcher import TrendWatcher` triggers `agent/__init__.py` which eagerly imports `agent.loop` → `provider_router` → `router` — none of which were installed
- Fix: replace `pip install httpx` with `pip install -r requirements.txt` so all transitive deps are present

## Test plan

- [ ] Verify the weekly-trend-digest workflow run succeeds after merge
- [ ] Confirm no other workflows are affected (only `weekly-trend-digest.yml` changed)

https://claude.ai/code/session_01UpJDpe9zpBeexFUHpxppYR
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UpJDpe9zpBeexFUHpxppYR)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dependency installation for the weekly digest workflow to ensure all required packages are properly loaded.

* **Documentation**
  * Updated changelog to reflect workflow improvements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/strikersam/local-llm-server/pull/187?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->