### PR TITLE
ci: restore 5 missing fixes from PR #167 squash merge

### DIFF
--- a/.github/workflows/agency-cycle.yml
+++ b/.github/workflows/agency-cycle.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Scan for security issues (bandit)
         id: security
         run: |
-          pip install bandit safety 2>&1 | tail -2
+          pip install bandit safety -q
           bandit -r . \
             --exclude ".git,.venv,venv,node_modules,tests,frontend,remote-admin" \
             --format json --output /tmp/bandit.json -ll 2>/dev/null || true

--- a/.github/workflows/changelog-check.yml
+++ b/.github/workflows/changelog-check.yml
@@ -17,10 +17,13 @@ jobs:
           fetch-depth: 0
 
       - name: Check for changelog update
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           # Skip if this is a chore/ci/docs/style/test-only PR
           # (detected by PR title prefix — requires PR title convention)
-          PR_TITLE="${{ github.event.pull_request.title }}"
           case "$PR_TITLE" in
             chore:*|docs:*|style:*|ci:*|test:*|revert:*|build:*)
               echo "ℹ Exempt PR prefix detected ('$PR_TITLE') — changelog check skipped."
@@ -29,8 +32,6 @@ jobs:
           esac
 
           # Check if docs/changelog.md was modified in this PR
-          BASE_SHA="${{ github.event.pull_request.base.sha }}"
-          HEAD_SHA="${{ github.event.pull_request.head.sha }}"
 
           CHANGED=$(git diff --name-only "$BASE_SHA" "$HEAD_SHA" | grep 'docs/changelog\.md' || true)
 

--- a/.github/workflows/process-quick-note.yml
+++ b/.github/workflows/process-quick-note.yml
@@ -44,9 +44,10 @@ jobs:
         id: pick
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_NUMBER_OVERRIDE: ${{ github.event.inputs.issue_number }}
         run: |
-          if [ -n "${{ github.event.inputs.issue_number }}" ]; then
-            NUM="${{ github.event.inputs.issue_number }}"
+          if [ -n "$ISSUE_NUMBER_OVERRIDE" ]; then
+            NUM="$ISSUE_NUMBER_OVERRIDE"
             echo "Manual override — using issue #$NUM"
           else
             # Oldest open quick-note that has not exhausted retries

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,15 @@
 # Changelog
 
 ## [Unreleased]
+### Security
+- `.github/workflows/changelog-check.yml` — Move `PR_TITLE`, `BASE_SHA`, `HEAD_SHA` to `env:` block to prevent shell injection (CWE-78).
+- `.github/workflows/process-quick-note.yml` — Move `issue_number` workflow input to `ISSUE_NUMBER_OVERRIDE` env var to prevent shell injection.
+
+### Fixed
+- `.github/workflows/agency-cycle.yml` — Change `pip install bandit safety 2>&1 | tail -2` to `-q` so pip errors are not silently swallowed.
+- `pytest.ini` — Add `filterwarnings = ignore::pytest.PytestUnraisableExceptionWarning` to suppress Python 3.13 GC timing noise.
+- `tests/conftest.py` — Add `_gc_before_loop_close` session fixture to force GC before the event loop closes on Python 3.13, preventing `PytestUnraisableExceptionWarning` from orphaned subprocess transports.
+
 ### Added
 - `agent/repowise.py`, `agent/tools.py` — Implemented Repowise-inspired codebase intelligence tools: `get_overview`, `get_context`, `get_risk`, and `get_why` for enhanced agent reasoning.
 ### Fixed

--- a/pytest.ini
+++ b/pytest.ini
@@ -3,4 +3,6 @@ testpaths = tests
 asyncio_mode = auto
 asyncio_default_fixture_loop_scope = session
 asyncio_default_test_loop_scope = session
+filterwarnings =
+    ignore::pytest.PytestUnraisableExceptionWarning
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+import gc
 import os
 import sys
 from pathlib import Path
@@ -198,3 +199,18 @@ def reset_provider_cooldowns():
     clear_cooldowns()
     yield
     clear_cooldowns()
+
+
+@pytest.fixture(autouse=True, scope="session")
+async def _gc_before_loop_close():
+    """Force GC while the session event loop is still alive.
+
+    On Python 3.13, stricter GC timing causes BaseSubprocessTransport.__del__
+    to fire after the event loop closes, raising RuntimeError inside a test.
+    Running gc.collect() here (in a session-scoped async fixture teardown)
+    ensures any orphaned subprocess transports are cleaned up before the loop
+    is closed, preventing PytestUnraisableExceptionWarning failures.
+    """
+    yield
+    gc.collect()
+    gc.collect()


### PR DESCRIPTION
## Summary

Five changes from the original PR #167 branch did not land on master after the squash merge. This PR restores them.

- **Shell injection fix** — `.github/workflows/changelog-check.yml`: `PR_TITLE`, `BASE_SHA`, `HEAD_SHA` moved from inline `${{ }}` expressions in shell to `env:` block (CWE-78)
- **Shell injection fix** — `.github/workflows/process-quick-note.yml`: `issue_number` workflow input moved to `ISSUE_NUMBER_OVERRIDE` env var
- **Bandit install fix** — `.github/workflows/agency-cycle.yml`: `pip install bandit safety 2>&1 | tail -2` → `pip install bandit safety -q` so pip errors are visible
- **pytest warning filter** — `pytest.ini`: added `filterwarnings = ignore::pytest.PytestUnraisableExceptionWarning` to suppress Python 3.13 GC noise
- **GC fixture** — `tests/conftest.py`: added `_gc_before_loop_close` async session fixture to force GC before the event loop closes on Python 3.13, preventing `PytestUnraisableExceptionWarning` from orphaned subprocess transports

## Test plan

- [ ] CI `test` job passes (pytest green)
- [ ] CI `lint` job passes (no hardcoded secrets)
- [ ] CI `frontend` job passes

---
_Generated by [Claude Code](https://claude.ai/code/session_01TbZ7DVEbQVsg9VLFuPFL96)_