### PR TITLE
fix(ci): fix pull-request.yml auth/label bugs and openclaw security label 422

### DIFF
--- a/.github/workflows/openclaw-security-automation.yml
+++ b/.github/workflows/openclaw-security-automation.yml
@@ -104,6 +104,31 @@ jobs:
             const commitSha       = '${{ github.sha }}';
             const timestamp       = '${{ steps.timestamp.outputs.timestamp }}';
 
+            // Ensure required labels exist before using them
+            const requiredLabels = [
+              { name: 'security',   color: 'e11d48', description: 'Security-related issue' },
+              { name: 'automated',  color: '0075ca', description: 'Automatically generated' },
+            ];
+            for (const label of requiredLabels) {
+              try {
+                await github.rest.issues.getLabel({
+                  owner: context.repo.owner,
+                  repo:  context.repo.repo,
+                  name:  label.name,
+                });
+              } catch (e) {
+                if (e.status === 404) {
+                  await github.rest.issues.createLabel({
+                    owner:       context.repo.owner,
+                    repo:        context.repo.repo,
+                    name:        label.name,
+                    color:       label.color,
+                    description: label.description,
+                  });
+                }
+              }
+            }
+
             // Avoid duplicate open issues
             const { data: existingIssues } = await github.rest.issues.listForRepo({
               owner: context.repo.owner,

--- a/.github/workflows/openclaw-security-automation.yml
+++ b/.github/workflows/openclaw-security-automation.yml
@@ -118,13 +118,18 @@ jobs:
                 });
               } catch (e) {
                 if (e.status === 404) {
-                  await github.rest.issues.createLabel({
-                    owner:       context.repo.owner,
-                    repo:        context.repo.repo,
-                    name:        label.name,
-                    color:       label.color,
-                    description: label.description,
-                  });
+                  try {
+                    await github.rest.issues.createLabel({
+                      owner:       context.repo.owner,
+                      repo:        context.repo.repo,
+                      name:        label.name,
+                      color:       label.color,
+                      description: label.description,
+                    });
+                  } catch (createErr) {
+                    // 422 means another concurrent run already created it — treat as success
+                    if (createErr.status !== 422) throw createErr;
+                  }
                 }
               }
             }

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -4,8 +4,11 @@ on:
   push:
     branches:
       - '**'
-    # Exclude master branch to avoid creating PR from master to master
-    - '!master'
+      - '!master'
+
+permissions:
+  contents: read
+  pull-requests: write
 
 jobs:
   create-pr:
@@ -16,8 +19,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      # gh CLI is pre-installed on ubuntu-latest; no additional setup step needed.
-
       - name: Get current branch
         id: branch
         run: |
@@ -25,8 +26,10 @@ jobs:
 
       - name: Check if PR already exists
         id: pr_check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          BRANCH_NAME=${{ steps.branch.outputs.branch_name }}
+          BRANCH_NAME="${{ steps.branch.outputs.branch_name }}"
           EXISTING_PR=$(gh pr list --head "$BRANCH_NAME" --base master --state open --json number -q '.[0].number')
           if [ -n "$EXISTING_PR" ]; then
             echo "pr_number=$EXISTING_PR" >> $GITHUB_OUTPUT
@@ -35,12 +38,19 @@ jobs:
             echo "exists=false" >> $GITHUB_OUTPUT
           fi
 
+      - name: Ensure auto-created label exists
+        if: steps.pr_check.outputs.exists == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh label create auto-created --color "0075ca" --description "Automatically created PR" 2>/dev/null || true
+
       - name: Create PR if not exists
         if: steps.pr_check.outputs.exists == 'false'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          BRANCH_NAME=${{ steps.branch.outputs.branch_name }}
+          BRANCH_NAME="${{ steps.branch.outputs.branch_name }}"
           PR_TITLE="Automated PR: $BRANCH_NAME"
           PR_BODY="This PR was automatically created by the Pull Request Creation workflow."
           gh pr create --title "$PR_TITLE" --body "$PR_BODY" --base master --head "$BRANCH_NAME" --label auto-created

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,11 @@
 # Changelog
 
 ## [Unreleased]
+### Fixed
+- `.github/workflows/pull-request.yml` — Fixed three bugs: (1) `- '!master'` was indented as a sibling of `branches:` rather than a child, so master pushes incorrectly triggered the workflow; (2) missing `GH_TOKEN` env on the "Check if PR already exists" step caused `gh` CLI to fail auth silently; (3) `gh pr create --label auto-created` returned HTTP 422 when the `auto-created` label didn't exist — added a prior step that upserts the label.
+- `.github/workflows/openclaw-security-automation.yml` — `issues.create()` with `labels: ['security', 'automated']` returned HTTP 422 (Unprocessable Entity) when those labels didn't exist in the repo; added a label-upsert guard (getLabel → createLabel on 404) before issue creation.
+- `frontend/package.json` — Added `jest.moduleNameMapper` for `react-router-dom` and `react-router` so jest 27 (react-scripts v5) can resolve react-router-dom v7's exports-only package without falling back to the non-existent `dist/main.js` entry.
+
 ### Security
 - `.github/workflows/changelog-check.yml` — Move `PR_TITLE`, `BASE_SHA`, `HEAD_SHA` to `env:` block to prevent shell injection (CWE-78).
 - `.github/workflows/process-quick-note.yml` — Move `issue_number` workflow input to `ISSUE_NUMBER_OVERRIDE` env var to prevent shell injection.


### PR DESCRIPTION
## Summary

- **`pull-request.yml`**: Three bugs that caused the workflow to fail on every PR push:
  - `- '!master'` was indented as a sibling of `branches:` instead of a child — master pushes incorrectly triggered the workflow
  - Missing `GH_TOKEN` env on the "Check if PR already exists" step — `gh` CLI silently failed auth
  - `gh pr create --label auto-created` returned 422 when the `auto-created` label didn't exist; added a step that upserts the label first

- **`openclaw-security-automation.yml`**: `issues.create()` with `labels: ['security', 'automated']` returned 422 (Unprocessable Entity) when those labels didn't exist in the repo; added a label-upsert guard (getLabel → createLabel on 404) before issue creation

Also merges the work done earlier in this session:
- Merged PR #187 (fix weekly-trend-digest CI), #173 (@vitejs/plugin-react bump), #175 (react-router-dom v6→v7 with jest compat fix)

## Test plan
- [ ] `pull-request.yml` runs green on any non-master branch push
- [ ] `openclaw-security-automation.yml` runs green when security alerts exist
- [ ] All existing CI checks pass on this PR

---
_Generated by [Claude Code](https://claude.ai/code/session_016cw6ANPMYhRM3coq9Vm4qx)_