### PR TITLE
fix(ci): make openclaw git push non-fatal when branch protection blocks it

### DIFF
--- a/.github/workflows/openclaw-security-automation.yml
+++ b/.github/workflows/openclaw-security-automation.yml
@@ -90,7 +90,8 @@ jobs:
             echo "No changes to commit"
           else
             git commit -m "fix(security): automated OpenClaw security fixes"
-            git push origin master
+            # Push may fail when branch protection requires PRs — treat as non-fatal
+            git push origin master || echo "::warning::Push to master blocked (branch protection); fixes were not auto-committed."
           fi
 
       - name: Create summary issue if alerts found

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 ### Fixed
+- `.github/workflows/openclaw-security-automation.yml` — Made `git push origin master` non-fatal; the push fails when branch protection requires PRs, which was causing the whole workflow run to fail. Now emits a workflow warning instead of a hard failure.
+### Fixed
 - `.github/workflows/pull-request.yml` — Fixed three bugs: (1) `- '!master'` was indented as a sibling of `branches:` rather than a child, so master pushes incorrectly triggered the workflow; (2) missing `GH_TOKEN` env on the "Check if PR already exists" step caused `gh` CLI to fail auth silently; (3) `gh pr create --label auto-created` returned HTTP 422 when the `auto-created` label didn't exist — added a prior step that upserts the label.
 - `.github/workflows/openclaw-security-automation.yml` — `issues.create()` with `labels: ['security', 'automated']` returned HTTP 422 (Unprocessable Entity) when those labels didn't exist in the repo; added a label-upsert guard (getLabel → createLabel on 404) before issue creation.
 - `frontend/package.json` — Added `jest.moduleNameMapper` for `react-router-dom` and `react-router` so jest 27 (react-scripts v5) can resolve react-router-dom v7's exports-only package without falling back to the non-existent `dist/main.js` entry.


### PR DESCRIPTION
## Summary

- The `openclaw-security-automation.yml` workflow was failing because `git push origin master` exits non-zero when branch protection requires pull requests (the repo has 8 active Dependabot alerts, so the fix agent stages real changes and hits this path).
- Fix: append `|| echo "::warning::..."` so the push failure becomes a workflow warning rather than a job failure. The workflow run now completes successfully; the warning in the logs explains why auto-commit was skipped.

## Test plan
- [ ] Trigger the openclaw workflow via `workflow_dispatch` — run should complete green
- [ ] Warning annotation visible in the step log if branch protection is active

---
_Generated by [Claude Code](https://claude.ai/code/session_016cw6ANPMYhRM3coq9Vm4qx)_