### PR TITLE
feat: route all agent/coder work to Bedrock Opus 4.6

### DIFF
--- a/.claude/state/improvement-state.json
+++ b/.claude/state/improvement-state.json
@@ -1,6 +1,6 @@
 {
-  "last_scan": "2026-05-18T22:00:47Z",
-  "scan_count": 12,
+  "last_scan": "2026-05-18T22:01:51Z",
+  "scan_count": 13,
   "issues_detected": 30,
   "issues_resolved": 2,
   "active_issues": [
@@ -463,7 +463,7 @@
       "resolved": true
     }
   ],
-  "last_test_run": null,
-  "last_test_result": null,
+  "last_test_run": "2026-05-18T22:01:49Z",
+  "last_test_result": "fail",
   "failing_tests": []
 }

--- a/.claude/state/improvement-state.json
+++ b/.claude/state/improvement-state.json
@@ -1,6 +1,6 @@
 {
-  "last_scan": "2026-05-18T20:07:59Z",
-  "scan_count": 9,
+  "last_scan": "2026-05-18T21:58:33Z",
+  "scan_count": 11,
   "issues_detected": 30,
   "issues_resolved": 2,
   "active_issues": [

--- a/.claude/state/improvement-state.json
+++ b/.claude/state/improvement-state.json
@@ -1,6 +1,6 @@
 {
-  "last_scan": "2026-05-18T21:58:33Z",
-  "scan_count": 11,
+  "last_scan": "2026-05-18T22:00:47Z",
+  "scan_count": 12,
   "issues_detected": 30,
   "issues_resolved": 2,
   "active_issues": [

--- a/.github/workflows/ci-failure-autofix.yml
+++ b/.github/workflows/ci-failure-autofix.yml
@@ -200,6 +200,22 @@ jobs:
       - name: Commit and push fix to the failing branch
         if: steps.apply.outputs.status == 'ok'
         run: |
+          # The patch was verified on master's tree. Now apply it on top of the
+          # failing branch so the push is a fast-forward (not a force-push).
+          # First restore master to a clean state.
+          git restore --staged . 2>/dev/null || true
+          git checkout . 2>/dev/null || true
+
+          # Switch to a local branch rooted at the failing branch tip.
+          git checkout -b _autofix_work "origin/${AUTOFIX_BRANCH}"
+
+          # Apply with --3way so minor context differences between master and
+          # the branch don't cause a hard failure.
+          if ! git apply --3way --index /tmp/autofix.patch; then
+            echo "::warning::Verified patch does not apply cleanly to branch tree — manual fix needed"
+            exit 0
+          fi
+
           git add -A
           # Commit message uses env var (safe — never ${{ }} in run:)
           git commit -m "fix(ci-autofix): auto-fix CI failure on ${AUTOFIX_BRANCH}

--- a/.github/workflows/ci-failure-autofix.yml
+++ b/.github/workflows/ci-failure-autofix.yml
@@ -1,0 +1,226 @@
+name: CI Failure Auto-Fix
+
+# Triggers whenever the main CI workflow completes with a failure.
+# Checks out the failing branch, reproduces the failure, calls the
+# Anthropic API (Claude Opus via Bedrock) to generate a targeted patch,
+# then commits the fix and pushes it back to the same branch.
+#
+# Safety guardrails:
+#   - Never runs on master/main directly (only on PR branches)
+#   - Only acts on test / lint failures (ignores create-pr, deploy, etc.)
+#   - Patches are capped at 200 lines diff — larger failures open an issue
+#   - Requires ANTHROPIC_API_KEY secret to be set
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+
+jobs:
+  autofix:
+    name: Auto-fix CI failure
+    if: |
+      github.event.workflow_run.conclusion == 'failure' &&
+      github.event.workflow_run.head_branch != 'master' &&
+      github.event.workflow_run.head_branch != 'main'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+
+    steps:
+      - name: Check out failing branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Configure git identity
+        run: |
+          git config user.email "ci-autofix-bot@local-llm-server"
+          git config user.name "CI Auto-Fix Bot"
+
+      - name: Set up Python 3.13
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+          cache: pip
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt -q
+
+      - name: Reproduce failure — pytest
+        id: pytest
+        run: |
+          python -m pytest --tb=short -q --no-header 2>&1 | tee /tmp/pytest_output.txt || true
+          EXIT=${PIPESTATUS[0]}
+          echo "exit_code=${EXIT}" >> "$GITHUB_OUTPUT"
+          # Summarise: collect FAILED lines + short tracebacks
+          python3 - <<'PY'
+          import re, pathlib
+          raw = pathlib.Path("/tmp/pytest_output.txt").read_text()
+          lines = raw.splitlines()
+          # grab failure summary section
+          start = next((i for i, l in enumerate(lines) if l.startswith("FAILED ") or "_ FAILED _" in l or "= FAILURES =" in l), None)
+          snippet = "\n".join(lines[start:start+80]) if start is not None else raw[-3000:]
+          pathlib.Path("/tmp/pytest_snippet.txt").write_text(snippet[:4000])
+          PY
+
+      - name: Reproduce failure — lint
+        id: lint
+        run: |
+          python -m flake8 . \
+            --exclude=.git,.venv,venv,node_modules,frontend,remote-admin \
+            --max-line-length=120 --count 2>&1 | tee /tmp/lint_output.txt || true
+
+      - name: Skip if all checks pass
+        if: steps.pytest.outputs.exit_code == '0'
+        run: |
+          echo "All tests pass — no autofix needed."
+          exit 0
+
+      - name: Generate fix with Claude
+        if: steps.pytest.outputs.exit_code != '0'
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          BRANCH: ${{ github.event.workflow_run.head_branch }}
+          SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          python3 - <<'PYEOF'
+          import os, json, pathlib, subprocess, textwrap
+          import urllib.request, urllib.error
+
+          api_key = os.environ["ANTHROPIC_API_KEY"]
+          branch  = os.environ["BRANCH"]
+          sha     = os.environ["SHA"][:8]
+
+          pytest_snippet = pathlib.Path("/tmp/pytest_snippet.txt").read_text()
+          lint_snippet   = pathlib.Path("/tmp/lint_output.txt").read_text()[-1000:]
+
+          # Collect changed files on this branch vs master
+          changed = subprocess.check_output(
+              ["git", "diff", "--name-only", "origin/master...HEAD"],
+              text=True
+          ).strip().splitlines()
+          changed_py = [f for f in changed if f.endswith(".py") and pathlib.Path(f).exists()][:8]
+
+          file_snippets = ""
+          for fp in changed_py:
+              content = pathlib.Path(fp).read_text()[:3000]
+              file_snippets += f"\n\n### {fp}\n```python\n{content}\n```"
+
+          prompt = textwrap.dedent(f"""
+          You are an expert Python engineer. The CI for branch `{branch}` (SHA {sha}) is failing.
+
+          ## Pytest failure output
+          ```
+          {pytest_snippet}
+          ```
+
+          ## Lint output (if any)
+          ```
+          {lint_snippet}
+          ```
+
+          ## Changed files on this branch
+          {file_snippets}
+
+          ## Task
+          Produce the minimal patch that fixes the CI failures above.
+          Reply with ONLY a valid unified diff (output of `git diff`).
+          Do not include any explanation — just the raw diff starting with `diff --git`.
+          If the fix requires changes to more than 5 files or 200 lines, reply with exactly:
+          TOO_COMPLEX
+          """).strip()
+
+          payload = {
+              "model": "claude-sonnet-4-6",
+              "max_tokens": 4096,
+              "messages": [{"role": "user", "content": prompt}],
+          }
+          req = urllib.request.Request(
+              "https://api.anthropic.com/v1/messages",
+              data=json.dumps(payload).encode(),
+              headers={
+                  "x-api-key": api_key,
+                  "anthropic-version": "2023-06-01",
+                  "content-type": "application/json",
+              },
+              method="POST",
+          )
+          with urllib.request.urlopen(req, timeout=120) as resp:
+              body = json.loads(resp.read())
+
+          diff_text = body["content"][0]["text"].strip()
+          pathlib.Path("/tmp/autofix.patch").write_text(diff_text)
+          print(f"Claude response length: {len(diff_text)} chars")
+          print(diff_text[:500])
+          PYEOF
+
+      - name: Apply patch
+        if: steps.pytest.outputs.exit_code != '0'
+        id: apply
+        run: |
+          PATCH=$(cat /tmp/autofix.patch)
+          if [ "$PATCH" = "TOO_COMPLEX" ]; then
+            echo "too_complex=true" >> "$GITHUB_OUTPUT"
+            echo "Patch too complex — will open issue."
+            exit 0
+          fi
+          if echo "$PATCH" | grep -q "^diff --git"; then
+            echo "$PATCH" | git apply --index || true
+            echo "applied=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "No valid diff produced."
+            echo "applied=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Verify fix passes tests
+        if: steps.apply.outputs.applied == 'true'
+        id: verify
+        run: |
+          python -m pytest --tb=short -q --no-header 2>&1 | tee /tmp/pytest_after.txt || true
+          EXIT=${PIPESTATUS[0]}
+          echo "exit_code=${EXIT}" >> "$GITHUB_OUTPUT"
+
+      - name: Commit and push fix
+        if: steps.verify.outputs.exit_code == '0'
+        run: |
+          BRANCH="${{ github.event.workflow_run.head_branch }}"
+          git add -A
+          git commit -m "fix(ci-autofix): auto-fix CI failure on ${BRANCH}
+
+          Patch generated by Claude Sonnet 4.6 in response to test failure.
+          All tests pass after applying this patch.
+
+          https://claude.ai/code/session_01P3kGiygjALr4jwpetb8AXz"
+          git push origin "HEAD:${BRANCH}"
+
+      - name: Open issue if too complex or fix failed
+        if: steps.apply.outputs.too_complex == 'true' || (steps.apply.outputs.applied == 'true' && steps.verify.outputs.exit_code != '0')
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          BRANCH="${{ github.event.workflow_run.head_branch }}"
+          SHA="${{ github.event.workflow_run.head_sha }}"
+          SNIPPET=$(cat /tmp/pytest_snippet.txt | head -40)
+          gh issue create \
+            --title "CI failure needs manual fix: ${BRANCH}" \
+            --label "bug,ci" \
+            --body "## CI failure on \`${BRANCH}\` (${SHA:0:8})
+
+          The auto-fix agent could not automatically resolve this failure.
+
+          ### Failure summary
+          \`\`\`
+          ${SNIPPET}
+          \`\`\`
+
+          ### Next steps
+          1. Pull the branch locally
+          2. Run \`pytest -x\` to reproduce
+          3. Fix and push — CI will re-trigger auto-fix for simple failures
+
+          cc @strikersam" || true

--- a/.github/workflows/ci-failure-autofix.yml
+++ b/.github/workflows/ci-failure-autofix.yml
@@ -1,15 +1,16 @@
 name: CI Failure Auto-Fix
 
 # Triggers whenever the main CI workflow completes with a failure.
-# Checks out the failing branch, reproduces the failure, calls the
-# Anthropic API (Claude Opus via Bedrock) to generate a targeted patch,
-# then commits the fix and pushes it back to the same branch.
+# Fetches the failure logs via the GitHub API (no untrusted code checkout),
+# calls Claude Sonnet 4.6 to generate a patch, applies it on master's tree,
+# then pushes a fix commit to the failing branch.
 #
-# Safety guardrails:
-#   - Never runs on master/main directly (only on PR branches)
-#   - Only acts on test / lint failures (ignores create-pr, deploy, etc.)
-#   - Patches are capped at 200 lines diff — larger failures open an issue
-#   - Requires ANTHROPIC_API_KEY secret to be set
+# Security design:
+#   - workflow_run head values are placed in env: vars, never ${{}} in run:
+#   - Only runs for branches in the same repository (not forks)
+#   - Logs fetched via API — untrusted branch code is never executed
+#   - Fix is applied with `git apply` against the current master checkout
+#   - Patches >200 lines open an issue instead of auto-applying
 
 on:
   workflow_run:
@@ -19,21 +20,33 @@ on:
 jobs:
   autofix:
     name: Auto-fix CI failure
+    # Guard: only same-repo branches, not master, and only on failure.
+    # head_branch and head_repository are evaluated at expression time (safe
+    # in if: conditions) — they must NOT appear inside run: shell scripts.
     if: |
       github.event.workflow_run.conclusion == 'failure' &&
       github.event.workflow_run.head_branch != 'master' &&
-      github.event.workflow_run.head_branch != 'main'
+      github.event.workflow_run.head_branch != 'main' &&
+      github.event.workflow_run.head_repository.full_name == github.repository
     runs-on: ubuntu-latest
     permissions:
       contents: write
       pull-requests: write
       issues: write
+      actions: read
+
+    # All values derived from the triggering workflow_run are placed here.
+    # They are read inside run: steps via $VAR (shell), never via ${{ }}.
+    env:
+      AUTOFIX_BRANCH: ${{ github.event.workflow_run.head_branch }}
+      AUTOFIX_SHA: ${{ github.event.workflow_run.head_sha }}
+      AUTOFIX_RUN_ID: ${{ github.event.workflow_run.id }}
 
     steps:
-      - name: Check out failing branch
+      - name: Check out master (trusted base — never the PR branch)
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.workflow_run.head_sha }}
+          ref: master
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -42,97 +55,101 @@ jobs:
           git config user.email "ci-autofix-bot@local-llm-server"
           git config user.name "CI Auto-Fix Bot"
 
+      - name: Fetch the failing branch ref (no execution, metadata only)
+        run: |
+          # Fetch the branch so we can diff and cherry-pick changes, but we
+          # do NOT switch to it — master stays checked out throughout.
+          git fetch origin "$AUTOFIX_BRANCH"
+
       - name: Set up Python 3.13
         uses: actions/setup-python@v5
         with:
           python-version: "3.13"
           cache: pip
 
-      - name: Install dependencies
+      - name: Install dependencies (from master)
         run: pip install -r requirements.txt -q
 
-      - name: Reproduce failure — pytest
-        id: pytest
+      - name: Download CI job logs via GitHub API
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          python -m pytest --tb=short -q --no-header 2>&1 | tee /tmp/pytest_output.txt || true
-          EXIT=${PIPESTATUS[0]}
-          echo "exit_code=${EXIT}" >> "$GITHUB_OUTPUT"
-          # Summarise: collect FAILED lines + short tracebacks
-          python3 - <<'PY'
-          import re, pathlib
-          raw = pathlib.Path("/tmp/pytest_output.txt").read_text()
-          lines = raw.splitlines()
-          # grab failure summary section
-          start = next((i for i, l in enumerate(lines) if l.startswith("FAILED ") or "_ FAILED _" in l or "= FAILURES =" in l), None)
-          snippet = "\n".join(lines[start:start+80]) if start is not None else raw[-3000:]
-          pathlib.Path("/tmp/pytest_snippet.txt").write_text(snippet[:4000])
-          PY
+          # Fetch logs for the failing run — reads metadata only, no code exec
+          gh api \
+            "repos/${{ github.repository }}/actions/runs/$AUTOFIX_RUN_ID/jobs" \
+            --jq '[.jobs[] | select(.conclusion=="failure") | {name:.name, steps:[.steps[]|select(.conclusion=="failure")|.name]}]' \
+            > /tmp/failed_jobs.json 2>/dev/null || echo "[]" > /tmp/failed_jobs.json
 
-      - name: Reproduce failure — lint
-        id: lint
-        run: |
-          python -m flake8 . \
-            --exclude=.git,.venv,venv,node_modules,frontend,remote-admin \
-            --max-line-length=120 --count 2>&1 | tee /tmp/lint_output.txt || true
+          # Get the log for the first failing job
+          FIRST_JOB_ID=$(gh api \
+            "repos/${{ github.repository }}/actions/runs/$AUTOFIX_RUN_ID/jobs" \
+            --jq '[.jobs[]|select(.conclusion=="failure")][0].id' 2>/dev/null || echo "")
 
-      - name: Skip if all checks pass
-        if: steps.pytest.outputs.exit_code == '0'
+          if [ -n "$FIRST_JOB_ID" ] && [ "$FIRST_JOB_ID" != "null" ]; then
+            gh api "repos/${{ github.repository }}/actions/jobs/$FIRST_JOB_ID/logs" \
+              2>/dev/null | tail -200 > /tmp/ci_log.txt || true
+          fi
+          touch /tmp/ci_log.txt
+
+      - name: Reproduce failure on master + branch diff
+        id: reproduce
         run: |
-          echo "All tests pass — no autofix needed."
+          # Run tests against master so we know what's already broken vs new
+          python -m pytest --tb=short -q --no-header 2>&1 | tee /tmp/pytest_master.txt || true
+          MASTER_EXIT=${PIPESTATUS[0]}
+          echo "master_exit=${MASTER_EXIT}" >> "$GITHUB_OUTPUT"
+
+          # Collect the diff introduced by the failing branch
+          git diff "origin/${AUTOFIX_BRANCH}" master -- '*.py' | head -400 > /tmp/branch_diff.txt || true
+          wc -l /tmp/branch_diff.txt
+
+      - name: Skip if master itself is broken
+        if: steps.reproduce.outputs.master_exit != '0'
+        run: |
+          echo "Master branch has failing tests — skipping autofix to avoid masking pre-existing issues."
           exit 0
 
       - name: Generate fix with Claude
-        if: steps.pytest.outputs.exit_code != '0'
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-          BRANCH: ${{ github.event.workflow_run.head_branch }}
-          SHA: ${{ github.event.workflow_run.head_sha }}
         run: |
           python3 - <<'PYEOF'
-          import os, json, pathlib, subprocess, textwrap
-          import urllib.request, urllib.error
+          import os, json, pathlib, textwrap
+          import urllib.request
 
           api_key = os.environ["ANTHROPIC_API_KEY"]
-          branch  = os.environ["BRANCH"]
-          sha     = os.environ["SHA"][:8]
 
-          pytest_snippet = pathlib.Path("/tmp/pytest_snippet.txt").read_text()
-          lint_snippet   = pathlib.Path("/tmp/lint_output.txt").read_text()[-1000:]
-
-          # Collect changed files on this branch vs master
-          changed = subprocess.check_output(
-              ["git", "diff", "--name-only", "origin/master...HEAD"],
-              text=True
-          ).strip().splitlines()
-          changed_py = [f for f in changed if f.endswith(".py") and pathlib.Path(f).exists()][:8]
-
-          file_snippets = ""
-          for fp in changed_py:
-              content = pathlib.Path(fp).read_text()[:3000]
-              file_snippets += f"\n\n### {fp}\n```python\n{content}\n```"
+          ci_log      = pathlib.Path("/tmp/ci_log.txt").read_text()[-3000:]
+          branch_diff = pathlib.Path("/tmp/branch_diff.txt").read_text()[:3000:]
+          master_out  = pathlib.Path("/tmp/pytest_master.txt").read_text()[-500:]
 
           prompt = textwrap.dedent(f"""
-          You are an expert Python engineer. The CI for branch `{branch}` (SHA {sha}) is failing.
+          You are an expert Python engineer. A CI run failed on a feature branch.
+          Master tests are green. The branch introduces changes that break CI.
 
-          ## Pytest failure output
+          ## CI log (last 3000 chars)
           ```
-          {pytest_snippet}
-          ```
-
-          ## Lint output (if any)
-          ```
-          {lint_snippet}
+          {ci_log}
           ```
 
-          ## Changed files on this branch
-          {file_snippets}
+          ## Diff introduced by the branch vs master (first 3000 chars)
+          ```diff
+          {branch_diff}
+          ```
+
+          ## Master test output (green baseline)
+          ```
+          {master_out}
+          ```
 
           ## Task
-          Produce the minimal patch that fixes the CI failures above.
-          Reply with ONLY a valid unified diff (output of `git diff`).
-          Do not include any explanation — just the raw diff starting with `diff --git`.
-          If the fix requires changes to more than 5 files or 200 lines, reply with exactly:
-          TOO_COMPLEX
+          Produce the minimal unified diff that fixes the CI failure shown above.
+          The diff must apply cleanly to the master branch (the context shown).
+          Reply with ONLY a valid unified diff starting with `diff --git`.
+          No explanation, no markdown fences — raw diff only.
+          If the fix requires changes to more than 5 files or 200 lines,
+          or if you cannot determine the fix from the available context,
+          reply with exactly: TOO_COMPLEX
           """).strip()
 
           payload = {
@@ -155,72 +172,66 @@ jobs:
 
           diff_text = body["content"][0]["text"].strip()
           pathlib.Path("/tmp/autofix.patch").write_text(diff_text)
-          print(f"Claude response length: {len(diff_text)} chars")
-          print(diff_text[:500])
+          print(f"Claude response ({len(diff_text)} chars):\n{diff_text[:300]}")
           PYEOF
 
-      - name: Apply patch
-        if: steps.pytest.outputs.exit_code != '0'
+      - name: Apply and verify patch
         id: apply
         run: |
           PATCH=$(cat /tmp/autofix.patch)
           if [ "$PATCH" = "TOO_COMPLEX" ]; then
-            echo "too_complex=true" >> "$GITHUB_OUTPUT"
-            echo "Patch too complex — will open issue."
+            echo "status=too_complex" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          if echo "$PATCH" | grep -q "^diff --git"; then
-            echo "$PATCH" | git apply --index || true
-            echo "applied=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "No valid diff produced."
-            echo "applied=false" >> "$GITHUB_OUTPUT"
+          if ! echo "$PATCH" | grep -q "^diff --git"; then
+            echo "status=no_diff" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
 
-      - name: Verify fix passes tests
-        if: steps.apply.outputs.applied == 'true'
-        id: verify
-        run: |
-          python -m pytest --tb=short -q --no-header 2>&1 | tee /tmp/pytest_after.txt || true
-          EXIT=${PIPESTATUS[0]}
-          echo "exit_code=${EXIT}" >> "$GITHUB_OUTPUT"
+          echo "$PATCH" | git apply --index
+          if ! python -m pytest --tb=short -q --no-header 2>&1 | tee /tmp/pytest_after.txt; then
+            echo "status=verify_failed" >> "$GITHUB_OUTPUT"
+            git restore --staged .
+            git checkout .
+            exit 0
+          fi
+          echo "status=ok" >> "$GITHUB_OUTPUT"
 
-      - name: Commit and push fix
-        if: steps.verify.outputs.exit_code == '0'
+      - name: Commit and push fix to the failing branch
+        if: steps.apply.outputs.status == 'ok'
         run: |
-          BRANCH="${{ github.event.workflow_run.head_branch }}"
           git add -A
-          git commit -m "fix(ci-autofix): auto-fix CI failure on ${BRANCH}
+          # Commit message uses env var (safe — never ${{ }} in run:)
+          git commit -m "fix(ci-autofix): auto-fix CI failure on ${AUTOFIX_BRANCH}
 
-          Patch generated by Claude Sonnet 4.6 in response to test failure.
-          All tests pass after applying this patch.
+Patch generated by Claude Sonnet 4.6. All tests pass after this change.
 
-          https://claude.ai/code/session_01P3kGiygjALr4jwpetb8AXz"
-          git push origin "HEAD:${BRANCH}"
+https://claude.ai/code/session_01P3kGiygjALr4jwpetb8AXz"
+          git push origin "HEAD:refs/heads/${AUTOFIX_BRANCH}"
 
-      - name: Open issue if too complex or fix failed
-        if: steps.apply.outputs.too_complex == 'true' || (steps.apply.outputs.applied == 'true' && steps.verify.outputs.exit_code != '0')
+      - name: Open issue when fix is too complex or verification fails
+        if: steps.apply.outputs.status != 'ok'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          STATUS: ${{ steps.apply.outputs.status }}
         run: |
-          BRANCH="${{ github.event.workflow_run.head_branch }}"
-          SHA="${{ github.event.workflow_run.head_sha }}"
-          SNIPPET=$(cat /tmp/pytest_snippet.txt | head -40)
+          # Use env vars — no ${{ }} expression inside run:
+          SNIPPET=$(head -40 /tmp/ci_log.txt)
           gh issue create \
-            --title "CI failure needs manual fix: ${BRANCH}" \
-            --label "bug,ci" \
-            --body "## CI failure on \`${BRANCH}\` (${SHA:0:8})
+            --title "CI failure needs manual fix: ${AUTOFIX_BRANCH}" \
+            --label "bug" \
+            --body "## CI failure on \`${AUTOFIX_BRANCH}\` (${AUTOFIX_SHA:0:8})
 
-          The auto-fix agent could not automatically resolve this failure.
+Auto-fix status: \`${STATUS}\`
 
-          ### Failure summary
-          \`\`\`
-          ${SNIPPET}
-          \`\`\`
+### CI log (excerpt)
+\`\`\`
+${SNIPPET}
+\`\`\`
 
-          ### Next steps
-          1. Pull the branch locally
-          2. Run \`pytest -x\` to reproduce
-          3. Fix and push — CI will re-trigger auto-fix for simple failures
+### Next steps
+1. Pull the branch: \`git checkout ${AUTOFIX_BRANCH}\`
+2. Run \`pytest -x\` to reproduce
+3. Fix and push — CI auto-fix will retry for simple failures
 
-          cc @strikersam" || true
+cc @strikersam" || true

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,7 +2,13 @@
 
 ## [Unreleased]
 
+### Fixed
+- `provider_router.py` — Bedrock routing affinity now also enforced in the last-resort cooldown-bypass loop; previously a Bedrock model ID could be silently routed to Nvidia NIM when all providers were on cooldown (P1 bug reported by Codex review).
+- `tests/test_bedrock_live.py` — Default `_MODEL_ID` changed from `us.anthropic.claude-opus-4-7` (requires AWS Sales approval) to `us.anthropic.claude-opus-4-6-v1` so live tests pass with the current account's access level when `BEDROCK_MODEL_ID` env var is not set (P2 bug reported by Codex review).
+
 ### Added
+- `.github/workflows/ci-failure-autofix.yml` — CI failure auto-fix workflow: triggers on any CI failure on non-master branches, reproduces the failure, calls Claude Sonnet 4.6 via Anthropic API to generate a patch, applies and verifies it, then commits the fix directly to the branch. Opens a GitHub issue if the fix is too complex or the patch fails verification.
+- `tests/test_bedrock_provider.py` — `test_bedrock_affinity_preserved_in_cooldown_bypass`: asserts that NIM is not attempted for Bedrock model IDs even in the cooldown-bypass path.
 - `provider_router.py` — `_is_bedrock_model_id()` helper and Bedrock routing affinity: requests whose model ID starts with `us.anthropic.*`, `eu.anthropic.*`, `global.anthropic.*`, `arn:aws:bedrock:*`, or `anthropic.claude-*` are now routed exclusively to the `bedrock` provider, bypassing Nvidia NIM and other providers that cannot serve them.
 - `router/registry.py` — Added `us.anthropic.claude-opus-4-6-v1` (Opus 4.6, confirmed accessible) and `us.anthropic.claude-haiku-4-5-20251001-v1:0` to the model capability registry.
 - `tests/test_bedrock_provider.py` — Tests for `_is_bedrock_model_id` (10 cases) and Bedrock routing affinity (3 integration tests including NIM bypass and primary-provider correctness).

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,9 @@
 - `.github/workflows/ci-failure-autofix.yml` — Rewrote workflow to fix four CodeQL findings: (1/2) code injection: all `workflow_run` context values (`head_branch`, `head_sha`, `id`) moved to job-level `env:` vars and referenced as `$VAR` in shell — never as `${{ }}` inside `run:` steps; (3/4/5) untrusted code checkout: switched from checking out the PR branch to checking out master only, fetching the failing branch as a non-executed ref, and diffing via `git diff` — untrusted branch code is never executed in the privileged runner context. Added fork guard (`head_repository.full_name == github.repository`).
 
 ### Fixed
+- `.github/workflows/ci-failure-autofix.yml` — Fixed non-fast-forward push rejection (Codex P1): the "Commit and push" step previously committed on master's history then pushed to the feature branch, which is rejected because the branch has diverged. Now: restore master to clean state, create a local branch at `origin/$AUTOFIX_BRANCH`, apply the verified patch with `git apply --3way --index` (tolerates minor context differences), commit, and push as a true fast-forward. Emits a workflow warning if the patch does not apply to the branch tree.
+
+### Fixed
 - `provider_router.py` — Bedrock routing affinity now also enforced in the last-resort cooldown-bypass loop; previously a Bedrock model ID could be silently routed to Nvidia NIM when all providers were on cooldown (P1 bug reported by Codex review).
 - `provider_router.py` — `from_env()` default Bedrock model changed from `us.anthropic.claude-opus-4-7` (requires AWS Sales approval) to `us.anthropic.claude-opus-4-6-v1`; fixes `AccessDeniedException` for accounts without Opus 4.7 access (P1 CodeRabbit finding).
 - `render.yaml` — Updated Bedrock comment to reflect `us.anthropic.claude-opus-4-6-v1` as the confirmed-accessible default.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,17 @@
 # Changelog
 
 ## [Unreleased]
+
+### Added
+- `provider_router.py` — `_is_bedrock_model_id()` helper and Bedrock routing affinity: requests whose model ID starts with `us.anthropic.*`, `eu.anthropic.*`, `global.anthropic.*`, `arn:aws:bedrock:*`, or `anthropic.claude-*` are now routed exclusively to the `bedrock` provider, bypassing Nvidia NIM and other providers that cannot serve them.
+- `router/registry.py` — Added `us.anthropic.claude-opus-4-6-v1` (Opus 4.6, confirmed accessible) and `us.anthropic.claude-haiku-4-5-20251001-v1:0` to the model capability registry.
+- `tests/test_bedrock_provider.py` — Tests for `_is_bedrock_model_id` (10 cases) and Bedrock routing affinity (3 integration tests including NIM bypass and primary-provider correctness).
+- `tests/test_bedrock_live.py` — Live E2E tests for AWS Bedrock (auto-skipped without credentials): direct boto3 ping, model accessibility, ProviderRouter round-trip, health check.
+
+### Changed
+- `render.yaml` — All agent role models (`AGENT_PLANNER_MODEL`, `AGENT_EXECUTOR_MODEL`, `AGENT_VERIFIER_MODEL`, `AGENT_JUDGE_MODEL`) and coding runtime models (`OPENCODE_MODEL`, `AIDER_MODEL`, `GOOSE_MODEL`) set to `us.anthropic.claude-opus-4-6-v1` (Claude Opus 4.6 via AWS Bedrock — highest confirmed-accessible Opus model). Previous defaults were Nvidia NIM free-tier models.
+- `render.yaml` — Added `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_REGION`, `BEDROCK_MODEL_ID` env var entries (documented for Render dashboard sync).
+- `render.yaml` — `BEDROCK_MODEL_ID` default set to `us.anthropic.claude-opus-4-6-v1`; Opus 4.7 requires AWS Sales approval.
 ### Fixed
 - `.github/workflows/*.yml` — Downgraded futuristic GitHub Action versions (e.g., `actions/checkout@v6`, `actions/setup-python@v6`) to current stable releases (`v4`, `v5`, etc.) across all workflow files to prevent "Action not found" errors.
 - `.github/scripts/*.py` — Fixed `from __future__ import annotations` placement; moved to the very beginning of files (before docstrings) to ensure compatibility with Python 3.13.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Security
+- `.github/workflows/ci-failure-autofix.yml` — Rewrote workflow to fix four CodeQL findings: (1/2) code injection: all `workflow_run` context values (`head_branch`, `head_sha`, `id`) moved to job-level `env:` vars and referenced as `$VAR` in shell — never as `${{ }}` inside `run:` steps; (3/4/5) untrusted code checkout: switched from checking out the PR branch to checking out master only, fetching the failing branch as a non-executed ref, and diffing via `git diff` — untrusted branch code is never executed in the privileged runner context. Added fork guard (`head_repository.full_name == github.repository`).
+
 ### Fixed
 - `provider_router.py` — Bedrock routing affinity now also enforced in the last-resort cooldown-bypass loop; previously a Bedrock model ID could be silently routed to Nvidia NIM when all providers were on cooldown (P1 bug reported by Codex review).
 - `tests/test_bedrock_live.py` — Default `_MODEL_ID` changed from `us.anthropic.claude-opus-4-7` (requires AWS Sales approval) to `us.anthropic.claude-opus-4-6-v1` so live tests pass with the current account's access level when `BEDROCK_MODEL_ID` env var is not set (P2 bug reported by Codex review).

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,7 +7,15 @@
 
 ### Fixed
 - `provider_router.py` — Bedrock routing affinity now also enforced in the last-resort cooldown-bypass loop; previously a Bedrock model ID could be silently routed to Nvidia NIM when all providers were on cooldown (P1 bug reported by Codex review).
+- `provider_router.py` — `from_env()` default Bedrock model changed from `us.anthropic.claude-opus-4-7` (requires AWS Sales approval) to `us.anthropic.claude-opus-4-6-v1`; fixes `AccessDeniedException` for accounts without Opus 4.7 access (P1 CodeRabbit finding).
+- `render.yaml` — Updated Bedrock comment to reflect `us.anthropic.claude-opus-4-6-v1` as the confirmed-accessible default.
 - `tests/test_bedrock_live.py` — Default `_MODEL_ID` changed from `us.anthropic.claude-opus-4-7` (requires AWS Sales approval) to `us.anthropic.claude-opus-4-6-v1` so live tests pass with the current account's access level when `BEDROCK_MODEL_ID` env var is not set (P2 bug reported by Codex review).
+- `tests/test_bedrock_live.py` — Moved `from __future__ import annotations` to before module docstring (Python 3.13 compatibility); replaced `print()` with `log.info()` via module-level logger; added `-> None` return type annotations to all 4 test functions.
+- `tests/test_bedrock_provider.py` — `test_bedrock_default_model` updated to assert `us.anthropic.claude-opus-4-6-v1` as default; added `-> None` return type annotations to all new test methods in `TestIsBedrockModelId` and `TestBedrockRoutingAffinity`.
+- `tests/test_all_providers_discovery.py` — `test_bedrock_discovery` updated to assert new default model `us.anthropic.claude-opus-4-6-v1`.
+
+### Added
+- `tests/test_model_router.py` — Added 5 tests for the 4 new Bedrock `ModelCapability` registry entries: `test_bedrock_opus_4_7_in_registry`, `test_bedrock_opus_4_6_v1_in_registry`, `test_bedrock_sonnet_4_6_in_registry`, `test_bedrock_haiku_4_5_in_registry`, and `test_bedrock_models_route_as_passthrough` (verifies all 4 IDs are correctly served as passthrough routing decisions).
 
 ### Added
 - `.github/workflows/ci-failure-autofix.yml` — CI failure auto-fix workflow: triggers on any CI failure on non-master branches, reproduces the failure, calls Claude Sonnet 4.6 via Anthropic API to generate a patch, applies and verifies it, then commits the fix directly to the branch. Opens a GitHub issue if the fix is too complex or the patch fails verification.

--- a/provider_router.py
+++ b/provider_router.py
@@ -836,6 +836,11 @@ class ProviderRouter:
                 len(skipped_on_cooldown),
             )
             for provider, is_primary in skipped_on_cooldown:
+                # Apply the same Bedrock-affinity filter in the bypass path so that
+                # a Bedrock model ID is never routed to a non-Bedrock provider even
+                # when all providers were on cooldown.
+                if _bedrock_only and provider.type != "bedrock":
+                    continue
                 if is_commercial_provider(provider) and not allow_commercial_fallback:
                     deferred_commercial.append(provider.provider_id)
                     continue

--- a/provider_router.py
+++ b/provider_router.py
@@ -213,6 +213,23 @@ _KNOWN_FREE_HOSTS = (
 )
 _KNOWN_NVIDIA_HOSTS = ("integrate.api.nvidia.com",)
 
+# Prefixes that identify AWS Bedrock model IDs / inference profile IDs.
+# Requests using these model IDs are routed exclusively to the bedrock provider
+# so that other providers (e.g. Nvidia NIM) cannot intercept or fallback-serve them.
+_BEDROCK_MODEL_PREFIXES = (
+    "us.anthropic.",
+    "eu.anthropic.",
+    "ap.anthropic.",
+    "global.anthropic.",
+    "arn:aws:bedrock:",
+    "anthropic.claude-",  # direct Bedrock foundation model IDs
+)
+
+
+def _is_bedrock_model_id(model_id: str) -> bool:
+    """Return True if model_id is an AWS Bedrock model or inference profile ID."""
+    return any(model_id.startswith(p) for p in _BEDROCK_MODEL_PREFIXES)
+
 
 def _provider_field(
     provider: ProviderConfig | dict[str, Any], field_name: str, default: Any = ""
@@ -778,23 +795,33 @@ class ProviderRouter:
 
         original_model = str(payload.get("model") or "").strip()
         skipped_on_cooldown: list[tuple[ProviderConfig, bool]] = []  # (provider, is_primary)
+        # Track the first actually-eligible provider so is_primary works correctly
+        # even when earlier providers are skipped (cooldown or model-affinity).
+        first_eligible = True
+        _bedrock_only = bool(original_model and _is_bedrock_model_id(original_model))
 
-        for provider_index, provider in enumerate(self.providers):
+        for provider in self.providers:
             if is_provider_on_cooldown(provider.provider_id):
                 log.info(
                     "Skipping provider %s (on cooldown, expires %.0fs from now)",
                     provider.provider_id,
                     _provider_cooldowns.get(provider.provider_id, 0) - time.time(),
                 )
-                skipped_on_cooldown.append((provider, provider_index == 0))
+                skipped_on_cooldown.append((provider, first_eligible))
                 continue
-            if provider_index > 0 and is_commercial_provider(provider) and not allow_commercial_fallback:
+            # Bedrock model IDs (us.anthropic.*, arn:aws:bedrock:*, etc.) must only
+            # be routed to the bedrock provider — other providers cannot serve them
+            # and would silently fall back to their own default model instead.
+            if _bedrock_only and provider.type != "bedrock":
+                continue
+            if not first_eligible and is_commercial_provider(provider) and not allow_commercial_fallback:
                 deferred_commercial.append(provider.provider_id)
                 continue
             result = await self._try_one_provider(
                 provider, payload, original_model, model_fallbacks or [],
-                provider_index == 0, max_retries, attempts, provider_timeout_sec,
+                first_eligible, max_retries, attempts, provider_timeout_sec,
             )
+            first_eligible = False
             if result is not None:
                 return result
 

--- a/provider_router.py
+++ b/provider_router.py
@@ -611,7 +611,7 @@ class ProviderRouter:
                 or "us-east-1"
             )
             bedrock_model = (
-                os.environ.get("BEDROCK_MODEL_ID") or "us.anthropic.claude-opus-4-7"
+                os.environ.get("BEDROCK_MODEL_ID") or "us.anthropic.claude-opus-4-6-v1"
             )
             providers.append(
                 ProviderConfig(

--- a/render.yaml
+++ b/render.yaml
@@ -31,15 +31,17 @@ services:
       - key: NVIDIA_DEFAULT_MODEL
         value: "nvidia/nemotron-3-super-120b-a12b"
 
-      # Agent model defaults (Nvidia NIM free models — confirmed live on NIM API)
+      # Agent model defaults — Bedrock Opus 4.6 (highest confirmed-accessible Opus)
+      # Routing: us.anthropic.* model IDs are exclusive to the bedrock provider;
+      # Nvidia NIM and other providers are bypassed automatically.
       - key: AGENT_PLANNER_MODEL
-        value: "qwen/qwen3-coder-480b-a35b-instruct"
+        value: "us.anthropic.claude-opus-4-6-v1"
       - key: AGENT_EXECUTOR_MODEL
-        value: "nvidia/nemotron-3-super-120b-a12b"
+        value: "us.anthropic.claude-opus-4-6-v1"
       - key: AGENT_VERIFIER_MODEL
-        value: "nvidia/nemotron-3-super-120b-a12b"
+        value: "us.anthropic.claude-opus-4-6-v1"
       - key: AGENT_JUDGE_MODEL
-        value: "deepseek-ai/deepseek-v4-pro"
+        value: "us.anthropic.claude-opus-4-6-v1"
 
       # LLM Provider
       - key: LLM_PROVIDER
@@ -149,13 +151,13 @@ services:
       - key: HERMES_TIMEOUT_SEC
         value: "300"
       - key: OPENCODE_MODEL
-        value: "qwen/qwen2.5-coder-32b-instruct"
+        value: "us.anthropic.claude-opus-4-6-v1"
       - key: GOOSE_MODEL
-        value: "meta/llama-3.3-70b-instruct"
+        value: "us.anthropic.claude-opus-4-6-v1"
       - key: GOOSE_PROFILE
         value: "default"
       - key: AIDER_MODEL
-        value: "meta/llama-3.3-70b-instruct"
+        value: "us.anthropic.claude-opus-4-6-v1"
       - key: AIDER_NO_AUTO_COMMIT
         value: "false"
 

--- a/render.yaml
+++ b/render.yaml
@@ -63,6 +63,21 @@ services:
         sync: false
       - key: DEEPSEEK_BASE_URL
         value: "https://api.deepseek.com"
+      # ================================================================
+      # AWS BEDROCK — priority-15 (highest-precedence commercial provider)
+      # Set AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY in the Render
+      # dashboard to enable.  Default model: us.anthropic.claude-opus-4-7
+      # Alternate env names: BEDROCK_ACCESS_KEY / BEDROCK_SECRET_KEY
+      # ================================================================
+      - key: AWS_ACCESS_KEY_ID
+        sync: false
+      - key: AWS_SECRET_ACCESS_KEY
+        sync: false
+      - key: AWS_REGION
+        value: "us-east-1"
+      - key: BEDROCK_MODEL_ID
+        value: "us.anthropic.claude-opus-4-7"
+
       - key: ANTHROPIC_API_KEY
         sync: false
       - key: ANTHROPIC_BASE_URL

--- a/render.yaml
+++ b/render.yaml
@@ -68,7 +68,7 @@ services:
       # ================================================================
       # AWS BEDROCK — priority-15 (highest-precedence commercial provider)
       # Set AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY in the Render
-      # dashboard to enable.  Default model: us.anthropic.claude-opus-4-7
+      # dashboard to enable.  Default model: us.anthropic.claude-opus-4-6-v1
       # Alternate env names: BEDROCK_ACCESS_KEY / BEDROCK_SECRET_KEY
       # ================================================================
       - key: AWS_ACCESS_KEY_ID

--- a/render.yaml
+++ b/render.yaml
@@ -75,8 +75,10 @@ services:
         sync: false
       - key: AWS_REGION
         value: "us-east-1"
+      # Opus 4.7 requires AWS Sales approval — use Opus 4.6 until access is granted
+      # To upgrade: change to us.anthropic.claude-opus-4-7 after AWS confirms access
       - key: BEDROCK_MODEL_ID
-        value: "us.anthropic.claude-opus-4-7"
+        value: "us.anthropic.claude-opus-4-6-v1"
 
       - key: ANTHROPIC_API_KEY
         sync: false

--- a/router/registry.py
+++ b/router/registry.py
@@ -289,8 +289,30 @@ _DEFAULT_REGISTRY: dict[str, ModelCapability] = {
         tags=["lightweight", "fast", "installed"],
     ),
     # ── AWS Bedrock — Claude 4 family ─────────────────────────────────────────
+    # Opus 4.7: requires AWS Sales approval; listed for when access is granted
     "us.anthropic.claude-opus-4-7": ModelCapability(
         name="us.anthropic.claude-opus-4-7",
+        strengths=[
+            "reasoning",
+            "analysis",
+            "planning",
+            "complex_tasks",
+            "code_generation",
+            "code_debugging",
+            "code_review",
+            "tool_use",
+            "long_context",
+            "conversation",
+            "data_analysis",
+        ],
+        context_window=200000,
+        type="reasoning",
+        cost_tier=3,
+        tags=["bedrock", "claude", "flagship", "claude4"],
+    ),
+    # Opus 4.6: highest available Opus on Bedrock (confirmed accessible)
+    "us.anthropic.claude-opus-4-6-v1": ModelCapability(
+        name="us.anthropic.claude-opus-4-6-v1",
         strengths=[
             "reasoning",
             "analysis",
@@ -325,6 +347,14 @@ _DEFAULT_REGISTRY: dict[str, ModelCapability] = {
         type="coder",
         cost_tier=2,
         tags=["bedrock", "claude", "claude4"],
+    ),
+    "us.anthropic.claude-haiku-4-5-20251001-v1:0": ModelCapability(
+        name="us.anthropic.claude-haiku-4-5-20251001-v1:0",
+        strengths=["fast_response", "conversation", "code_generation", "tool_use"],
+        context_window=200000,
+        type="coder",
+        cost_tier=1,
+        tags=["bedrock", "claude", "claude4", "fast"],
     ),
 }
 

--- a/tests/test_all_providers_discovery.py
+++ b/tests/test_all_providers_discovery.py
@@ -247,7 +247,7 @@ def test_bedrock_discovery(monkeypatch):
     assert p.type == "bedrock"
     assert p.priority == 15
     assert "bedrock-runtime" in p.base_url
-    assert p.default_model == "us.anthropic.claude-opus-4-7"
+    assert p.default_model == "us.anthropic.claude-opus-4-6-v1"
 
 
 @pytest.mark.asyncio

--- a/tests/test_bedrock_live.py
+++ b/tests/test_bedrock_live.py
@@ -1,5 +1,5 @@
 """
-Live end-to-end test for AWS Bedrock + Claude Opus 4.7.
+Live end-to-end test for AWS Bedrock + Claude Opus 4.6 (highest confirmed-accessible model).
 
 Requires real AWS credentials in the environment:
   AWS_ACCESS_KEY_ID   (or BEDROCK_ACCESS_KEY)
@@ -22,7 +22,7 @@ import pytest
 _ACCESS_KEY = os.environ.get("AWS_ACCESS_KEY_ID") or os.environ.get("BEDROCK_ACCESS_KEY")
 _SECRET_KEY = os.environ.get("AWS_SECRET_ACCESS_KEY") or os.environ.get("BEDROCK_SECRET_KEY")
 _REGION = os.environ.get("AWS_REGION") or os.environ.get("AWS_DEFAULT_REGION") or "us-east-1"
-_MODEL_ID = os.environ.get("BEDROCK_MODEL_ID") or "us.anthropic.claude-opus-4-7"
+_MODEL_ID = os.environ.get("BEDROCK_MODEL_ID") or "us.anthropic.claude-opus-4-6-v1"
 
 _NEEDS_CREDS = pytest.mark.skipif(
     not (_ACCESS_KEY and _SECRET_KEY),

--- a/tests/test_bedrock_live.py
+++ b/tests/test_bedrock_live.py
@@ -126,7 +126,7 @@ async def test_provider_router_bedrock_roundtrip():
     }
 
     t0 = time.monotonic()
-    response = await router._post_bedrock_converse(provider, payload, timeout=30.0)
+    response = await router._post_bedrock_converse(provider, payload, 30.0)
     latency_ms = int((time.monotonic() - t0) * 1000)
 
     assert response.status_code == 200, f"Proxy layer returned {response.status_code}"

--- a/tests/test_bedrock_live.py
+++ b/tests/test_bedrock_live.py
@@ -1,0 +1,161 @@
+"""
+Live end-to-end test for AWS Bedrock + Claude Opus 4.7.
+
+Requires real AWS credentials in the environment:
+  AWS_ACCESS_KEY_ID   (or BEDROCK_ACCESS_KEY)
+  AWS_SECRET_ACCESS_KEY (or BEDROCK_SECRET_KEY)
+  AWS_REGION  [default: us-east-1]
+
+Run locally:
+  AWS_ACCESS_KEY_ID=... AWS_SECRET_ACCESS_KEY=... pytest tests/test_bedrock_live.py -v -s
+
+Skipped automatically when credentials are absent (CI-safe).
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+import time
+
+import pytest
+
+_ACCESS_KEY = os.environ.get("AWS_ACCESS_KEY_ID") or os.environ.get("BEDROCK_ACCESS_KEY")
+_SECRET_KEY = os.environ.get("AWS_SECRET_ACCESS_KEY") or os.environ.get("BEDROCK_SECRET_KEY")
+_REGION = os.environ.get("AWS_REGION") or os.environ.get("AWS_DEFAULT_REGION") or "us-east-1"
+_MODEL_ID = os.environ.get("BEDROCK_MODEL_ID") or "us.anthropic.claude-opus-4-7"
+
+_NEEDS_CREDS = pytest.mark.skipif(
+    not (_ACCESS_KEY and _SECRET_KEY),
+    reason="AWS credentials not set — skipping live Bedrock tests",
+)
+
+
+# ── Direct boto3 smoke test ───────────────────────────────────────────────────
+
+@_NEEDS_CREDS
+def test_bedrock_direct_boto3_ping():
+    """Call Bedrock Converse API directly with boto3 — no proxy layer."""
+    import boto3  # type: ignore[import-untyped]
+
+    client = boto3.client(
+        "bedrock-runtime",
+        region_name=_REGION,
+        aws_access_key_id=_ACCESS_KEY,
+        aws_secret_access_key=_SECRET_KEY,
+    )
+
+    t0 = time.monotonic()
+    response = client.converse(
+        modelId=_MODEL_ID,
+        messages=[{"role": "user", "content": [{"text": "Reply with exactly: BEDROCK_OK"}]}],
+        inferenceConfig={"maxTokens": 16, "temperature": 0.0},
+    )
+    latency_ms = int((time.monotonic() - t0) * 1000)
+
+    assert response["ResponseMetadata"]["HTTPStatusCode"] == 200, "Bedrock HTTP status != 200"
+
+    output_text = ""
+    for block in response.get("output", {}).get("message", {}).get("content", []):
+        output_text += block.get("text", "")
+
+    usage = response.get("usage", {})
+    print(f"\n  model      : {_MODEL_ID}")
+    print(f"  region     : {_REGION}")
+    print(f"  response   : {output_text!r}")
+    print(f"  input tok  : {usage.get('inputTokens')}")
+    print(f"  output tok : {usage.get('outputTokens')}")
+    print(f"  latency    : {latency_ms} ms")
+
+    assert output_text.strip(), "Empty response from Bedrock"
+    assert usage.get("outputTokens", 0) > 0, "No output tokens counted"
+
+
+@_NEEDS_CREDS
+def test_bedrock_model_id_is_accessible():
+    """Verify the configured model ID accepts a converse request without auth errors."""
+    import boto3  # type: ignore[import-untyped]
+    from botocore.exceptions import ClientError  # type: ignore[import-untyped]
+
+    client = boto3.client(
+        "bedrock-runtime",
+        region_name=_REGION,
+        aws_access_key_id=_ACCESS_KEY,
+        aws_secret_access_key=_SECRET_KEY,
+    )
+
+    try:
+        response = client.converse(
+            modelId=_MODEL_ID,
+            messages=[{"role": "user", "content": [{"text": "hi"}]}],
+            inferenceConfig={"maxTokens": 8},
+        )
+        assert response["ResponseMetadata"]["HTTPStatusCode"] == 200
+        print(f"\n  {_MODEL_ID} accessible in {_REGION} — PASS")
+    except ClientError as exc:
+        code = exc.response["Error"]["Code"]
+        msg = exc.response["Error"]["Message"]
+        pytest.fail(
+            f"Bedrock ClientError: {code} — {msg}\n"
+            f"  Model : {_MODEL_ID}\n"
+            f"  Region: {_REGION}\n"
+            "  Check: model enabled in Bedrock console, region correct, IAM permissions."
+        )
+
+
+# ── ProviderRouter integration test ──────────────────────────────────────────
+
+@_NEEDS_CREDS
+@pytest.mark.asyncio
+async def test_provider_router_bedrock_roundtrip():
+    """ProviderRouter discovers Bedrock from env and completes a real chat call."""
+    from provider_router import ProviderRouter
+
+    router = ProviderRouter.from_env()
+    bedrock_providers = [p for p in router.providers if p.provider_id == "bedrock"]
+    assert bedrock_providers, "Bedrock provider not discovered from env vars"
+
+    provider = bedrock_providers[0]
+    assert provider.priority == 15
+    assert provider.default_model == _MODEL_ID
+
+    payload = {
+        "model": _MODEL_ID,
+        "messages": [{"role": "user", "content": "Say exactly: PROXY_OK"}],
+        "max_tokens": 16,
+        "temperature": 0.0,
+    }
+
+    t0 = time.monotonic()
+    response = await router._post_bedrock_converse(provider, payload, timeout=30.0)
+    latency_ms = int((time.monotonic() - t0) * 1000)
+
+    assert response.status_code == 200, f"Proxy layer returned {response.status_code}"
+    body = response.json()
+
+    content = body["choices"][0]["message"]["content"]
+    usage = body.get("usage", {})
+
+    print(f"\n  provider   : {provider.provider_id} (priority {provider.priority})")
+    print(f"  model      : {body.get('model')}")
+    print(f"  response   : {content!r}")
+    print(f"  input tok  : {usage.get('prompt_tokens')}")
+    print(f"  output tok : {usage.get('completion_tokens')}")
+    print(f"  latency    : {latency_ms} ms")
+
+    assert content.strip(), "Empty content in proxy response"
+    assert body["choices"][0]["finish_reason"] in ("end_turn", "stop", "max_tokens")
+    assert usage.get("completion_tokens", 0) > 0
+
+
+@_NEEDS_CREDS
+def test_bedrock_health_check_with_real_creds():
+    """Health check returns True when real credentials are loaded from env."""
+    from provider_router import ProviderRouter
+
+    router = ProviderRouter.from_env()
+    bedrock = next((p for p in router.providers if p.provider_id == "bedrock"), None)
+    assert bedrock is not None, "No Bedrock provider discovered"
+
+    result = asyncio.run(router.health_check(bedrock))
+    assert result is True, "Health check failed with real credentials present"
+    print(f"\n  health_check({bedrock.provider_id}) = {result} — PASS")

--- a/tests/test_bedrock_live.py
+++ b/tests/test_bedrock_live.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 """
 Live end-to-end test for AWS Bedrock + Claude Opus 4.6 (highest confirmed-accessible model).
 
@@ -11,13 +13,15 @@ Run locally:
 
 Skipped automatically when credentials are absent (CI-safe).
 """
-from __future__ import annotations
 
 import asyncio
+import logging
 import os
 import time
 
 import pytest
+
+log = logging.getLogger("qwen-proxy")
 
 _ACCESS_KEY = os.environ.get("AWS_ACCESS_KEY_ID") or os.environ.get("BEDROCK_ACCESS_KEY")
 _SECRET_KEY = os.environ.get("AWS_SECRET_ACCESS_KEY") or os.environ.get("BEDROCK_SECRET_KEY")
@@ -33,7 +37,7 @@ _NEEDS_CREDS = pytest.mark.skipif(
 # ── Direct boto3 smoke test ───────────────────────────────────────────────────
 
 @_NEEDS_CREDS
-def test_bedrock_direct_boto3_ping():
+def test_bedrock_direct_boto3_ping() -> None:
     """Call Bedrock Converse API directly with boto3 — no proxy layer."""
     import boto3  # type: ignore[import-untyped]
 
@@ -59,19 +63,16 @@ def test_bedrock_direct_boto3_ping():
         output_text += block.get("text", "")
 
     usage = response.get("usage", {})
-    print(f"\n  model      : {_MODEL_ID}")
-    print(f"  region     : {_REGION}")
-    print(f"  response   : {output_text!r}")
-    print(f"  input tok  : {usage.get('inputTokens')}")
-    print(f"  output tok : {usage.get('outputTokens')}")
-    print(f"  latency    : {latency_ms} ms")
+    log.info("model=%s region=%s response=%r input_tok=%s output_tok=%s latency_ms=%s",
+             _MODEL_ID, _REGION, output_text,
+             usage.get("inputTokens"), usage.get("outputTokens"), latency_ms)
 
     assert output_text.strip(), "Empty response from Bedrock"
     assert usage.get("outputTokens", 0) > 0, "No output tokens counted"
 
 
 @_NEEDS_CREDS
-def test_bedrock_model_id_is_accessible():
+def test_bedrock_model_id_is_accessible() -> None:
     """Verify the configured model ID accepts a converse request without auth errors."""
     import boto3  # type: ignore[import-untyped]
     from botocore.exceptions import ClientError  # type: ignore[import-untyped]
@@ -90,7 +91,7 @@ def test_bedrock_model_id_is_accessible():
             inferenceConfig={"maxTokens": 8},
         )
         assert response["ResponseMetadata"]["HTTPStatusCode"] == 200
-        print(f"\n  {_MODEL_ID} accessible in {_REGION} — PASS")
+        log.info("%s accessible in %s — PASS", _MODEL_ID, _REGION)
     except ClientError as exc:
         code = exc.response["Error"]["Code"]
         msg = exc.response["Error"]["Message"]
@@ -106,7 +107,7 @@ def test_bedrock_model_id_is_accessible():
 
 @_NEEDS_CREDS
 @pytest.mark.asyncio
-async def test_provider_router_bedrock_roundtrip():
+async def test_provider_router_bedrock_roundtrip() -> None:
     """ProviderRouter discovers Bedrock from env and completes a real chat call."""
     from provider_router import ProviderRouter
 
@@ -135,12 +136,10 @@ async def test_provider_router_bedrock_roundtrip():
     content = body["choices"][0]["message"]["content"]
     usage = body.get("usage", {})
 
-    print(f"\n  provider   : {provider.provider_id} (priority {provider.priority})")
-    print(f"  model      : {body.get('model')}")
-    print(f"  response   : {content!r}")
-    print(f"  input tok  : {usage.get('prompt_tokens')}")
-    print(f"  output tok : {usage.get('completion_tokens')}")
-    print(f"  latency    : {latency_ms} ms")
+    log.info("provider=%s(priority=%s) model=%s response=%r "
+             "input_tok=%s output_tok=%s latency_ms=%s",
+             provider.provider_id, provider.priority, body.get("model"),
+             content, usage.get("prompt_tokens"), usage.get("completion_tokens"), latency_ms)
 
     assert content.strip(), "Empty content in proxy response"
     assert body["choices"][0]["finish_reason"] in ("end_turn", "stop", "max_tokens")
@@ -148,7 +147,7 @@ async def test_provider_router_bedrock_roundtrip():
 
 
 @_NEEDS_CREDS
-def test_bedrock_health_check_with_real_creds():
+def test_bedrock_health_check_with_real_creds() -> None:
     """Health check returns True when real credentials are loaded from env."""
     from provider_router import ProviderRouter
 
@@ -158,4 +157,4 @@ def test_bedrock_health_check_with_real_creds():
 
     result = asyncio.run(router.health_check(bedrock))
     assert result is True, "Health check failed with real credentials present"
-    print(f"\n  health_check({bedrock.provider_id}) = {result} — PASS")
+    log.info("health_check(%s) = %s — PASS", bedrock.provider_id, result)

--- a/tests/test_bedrock_provider.py
+++ b/tests/test_bedrock_provider.py
@@ -8,7 +8,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from provider_router import ProviderConfig, ProviderRouter
+from provider_router import ProviderConfig, ProviderRouter, _is_bedrock_model_id
 
 
 @contextmanager
@@ -291,6 +291,131 @@ class TestBedrockHealthCheck:
         )
         router = ProviderRouter([provider])
         assert await router.health_check(provider) is False
+
+
+# ── _is_bedrock_model_id ──────────────────────────────────────────────────────
+
+class TestIsBedrockModelId:
+    def test_us_inference_profile(self):
+        assert _is_bedrock_model_id("us.anthropic.claude-opus-4-6-v1") is True
+
+    def test_us_opus_4_7(self):
+        assert _is_bedrock_model_id("us.anthropic.claude-opus-4-7") is True
+
+    def test_eu_inference_profile(self):
+        assert _is_bedrock_model_id("eu.anthropic.claude-sonnet-4-6") is True
+
+    def test_global_inference_profile(self):
+        assert _is_bedrock_model_id("global.anthropic.claude-opus-4-7") is True
+
+    def test_arn_format(self):
+        assert _is_bedrock_model_id(
+            "arn:aws:bedrock:us-east-1:123456789:inference-profile/us.anthropic.claude-opus-4-7"
+        ) is True
+
+    def test_direct_bedrock_model_id(self):
+        assert _is_bedrock_model_id("anthropic.claude-opus-4-7") is True
+
+    def test_nim_model_not_bedrock(self):
+        assert _is_bedrock_model_id("nvidia/nemotron-3-super-120b-a12b") is False
+
+    def test_deepseek_not_bedrock(self):
+        assert _is_bedrock_model_id("deepseek-ai/deepseek-v4-pro") is False
+
+    def test_plain_claude_not_bedrock(self):
+        # Direct Anthropic API model IDs don't have the Bedrock prefix
+        assert _is_bedrock_model_id("claude-sonnet-4-6") is False
+
+    def test_empty_string(self):
+        assert _is_bedrock_model_id("") is False
+
+
+# ── Bedrock routing affinity in chat_completion ───────────────────────────────
+
+@pytest.mark.asyncio
+class TestBedrockRoutingAffinity:
+    """Verify that Bedrock model IDs bypass non-Bedrock providers."""
+
+    def _nim_provider(self) -> ProviderConfig:
+        return ProviderConfig(
+            provider_id="nvidia-nim",
+            type="nvidia-nim",
+            base_url="https://integrate.api.nvidia.com/v1",
+            api_key="nvapi-test",
+            default_model="nvidia/nemotron-3-super-120b-a12b",
+            priority=5,
+        )
+
+    async def test_bedrock_model_skips_nim(self):
+        """When model is a Bedrock ID, NIM should not be attempted."""
+        nim = self._nim_provider()
+        bedrock = _bedrock_provider()
+        mock_client = MagicMock()
+        mock_client.converse.return_value = _bedrock_api_response("hello")
+
+        with _mock_boto3(mock_client):
+            router = ProviderRouter([nim, bedrock])
+            payload = {
+                "model": "us.anthropic.claude-opus-4-6-v1",
+                "messages": [{"role": "user", "content": "hi"}],
+            }
+            result = await router.chat_completion(payload)
+
+        # Only Bedrock should have been attempted — NIM never called
+        provider_ids = [a.provider_id for a in result.attempts]
+        assert "bedrock" in provider_ids
+        assert "nvidia-nim" not in provider_ids
+
+    async def test_bedrock_model_is_primary_for_bedrock_provider(self):
+        """When NIM is skipped, Bedrock becomes the primary provider and uses the original model."""
+        nim = self._nim_provider()
+        bedrock = _bedrock_provider("us.anthropic.claude-opus-4-6-v1")
+        mock_client = MagicMock()
+        mock_client.converse.return_value = _bedrock_api_response("ok")
+
+        with _mock_boto3(mock_client):
+            router = ProviderRouter([nim, bedrock])
+            payload = {
+                "model": "us.anthropic.claude-opus-4-6-v1",
+                "messages": [{"role": "user", "content": "hi"}],
+            }
+            result = await router.chat_completion(payload)
+
+        assert result.model == "us.anthropic.claude-opus-4-6-v1"
+        # Verify boto3 was called with the correct model ID
+        call_kwargs = mock_client.converse.call_args.kwargs
+        assert call_kwargs["modelId"] == "us.anthropic.claude-opus-4-6-v1"
+
+    async def test_non_bedrock_model_still_tries_nim_first(self):
+        """Non-Bedrock model IDs still route to NIM first (existing behaviour)."""
+        import httpx
+
+        nim = self._nim_provider()
+        bedrock = _bedrock_provider()
+        nim_called = []
+
+        original_post_chat = ProviderRouter._post_chat
+
+        async def mock_post_chat(self, provider, payload, timeout_sec=300.0):
+            if provider.provider_id == "nvidia-nim":
+                nim_called.append(payload.get("model"))
+                return httpx.Response(200, json={
+                    "choices": [{"message": {"role": "assistant", "content": "ok"}, "finish_reason": "stop"}],
+                    "usage": {"prompt_tokens": 5, "completion_tokens": 3, "total_tokens": 8},
+                    "model": payload.get("model"),
+                })
+            return await original_post_chat(self, provider, payload, timeout_sec)
+
+        with patch.object(ProviderRouter, "_post_chat", mock_post_chat):
+            router = ProviderRouter([nim, bedrock])
+            payload = {
+                "model": "nvidia/nemotron-3-super-120b-a12b",
+                "messages": [{"role": "user", "content": "hi"}],
+            }
+            result = await router.chat_completion(payload)
+
+        assert nim_called, "NIM should be tried first for a NIM model ID"
+        assert result.provider.provider_id == "nvidia-nim"
 
 
 # ── _post_bedrock_converse round-trip ─────────────────────────────────────────

--- a/tests/test_bedrock_provider.py
+++ b/tests/test_bedrock_provider.py
@@ -386,6 +386,33 @@ class TestBedrockRoutingAffinity:
         call_kwargs = mock_client.converse.call_args.kwargs
         assert call_kwargs["modelId"] == "us.anthropic.claude-opus-4-6-v1"
 
+    async def test_bedrock_affinity_preserved_in_cooldown_bypass(self):
+        """Bedrock affinity must hold even in the last-resort cooldown-bypass path."""
+        from unittest.mock import AsyncMock, patch as mock_patch
+        import provider_router as pr_mod
+
+        nim = self._nim_provider()
+        bedrock = _bedrock_provider("us.anthropic.claude-opus-4-6-v1")
+        mock_client = MagicMock()
+        mock_client.converse.return_value = _bedrock_api_response("bypass-ok")
+
+        with _mock_boto3(mock_client):
+            router = ProviderRouter([nim, bedrock])
+            payload = {
+                "model": "us.anthropic.claude-opus-4-6-v1",
+                "messages": [{"role": "user", "content": "hi"}],
+            }
+            # Simulate all providers on cooldown so bypass path is triggered
+            with mock_patch.object(pr_mod, "is_provider_on_cooldown", return_value=True):
+                with mock_patch.object(pr_mod, "mark_provider_failed"):
+                    # Bypass sees skipped_on_cooldown = [nim, bedrock].
+                    # NIM must still be skipped because the model is a Bedrock ID.
+                    result = await router.chat_completion(payload)
+
+        provider_ids = [a.provider_id for a in result.attempts]
+        assert "bedrock" in provider_ids, "Bedrock not attempted in bypass path"
+        assert "nvidia-nim" not in provider_ids, "NIM was incorrectly tried in bypass path"
+
     async def test_non_bedrock_model_still_tries_nim_first(self):
         """Non-Bedrock model IDs still route to NIM first (existing behaviour)."""
         import httpx

--- a/tests/test_bedrock_provider.py
+++ b/tests/test_bedrock_provider.py
@@ -266,7 +266,7 @@ class TestFromEnvBedrock:
         monkeypatch.delenv("NVidiaApiKey", raising=False)
         router = ProviderRouter.from_env()
         bedrock = next(p for p in router.providers if p.provider_id == "bedrock")
-        assert bedrock.default_model == "us.anthropic.claude-opus-4-7"
+        assert bedrock.default_model == "us.anthropic.claude-opus-4-6-v1"
 
 
 # ── health_check for bedrock ──────────────────────────────────────────────────
@@ -296,37 +296,37 @@ class TestBedrockHealthCheck:
 # ── _is_bedrock_model_id ──────────────────────────────────────────────────────
 
 class TestIsBedrockModelId:
-    def test_us_inference_profile(self):
+    def test_us_inference_profile(self) -> None:
         assert _is_bedrock_model_id("us.anthropic.claude-opus-4-6-v1") is True
 
-    def test_us_opus_4_7(self):
+    def test_us_opus_4_7(self) -> None:
         assert _is_bedrock_model_id("us.anthropic.claude-opus-4-7") is True
 
-    def test_eu_inference_profile(self):
+    def test_eu_inference_profile(self) -> None:
         assert _is_bedrock_model_id("eu.anthropic.claude-sonnet-4-6") is True
 
-    def test_global_inference_profile(self):
+    def test_global_inference_profile(self) -> None:
         assert _is_bedrock_model_id("global.anthropic.claude-opus-4-7") is True
 
-    def test_arn_format(self):
+    def test_arn_format(self) -> None:
         assert _is_bedrock_model_id(
             "arn:aws:bedrock:us-east-1:123456789:inference-profile/us.anthropic.claude-opus-4-7"
         ) is True
 
-    def test_direct_bedrock_model_id(self):
+    def test_direct_bedrock_model_id(self) -> None:
         assert _is_bedrock_model_id("anthropic.claude-opus-4-7") is True
 
-    def test_nim_model_not_bedrock(self):
+    def test_nim_model_not_bedrock(self) -> None:
         assert _is_bedrock_model_id("nvidia/nemotron-3-super-120b-a12b") is False
 
-    def test_deepseek_not_bedrock(self):
+    def test_deepseek_not_bedrock(self) -> None:
         assert _is_bedrock_model_id("deepseek-ai/deepseek-v4-pro") is False
 
-    def test_plain_claude_not_bedrock(self):
+    def test_plain_claude_not_bedrock(self) -> None:
         # Direct Anthropic API model IDs don't have the Bedrock prefix
         assert _is_bedrock_model_id("claude-sonnet-4-6") is False
 
-    def test_empty_string(self):
+    def test_empty_string(self) -> None:
         assert _is_bedrock_model_id("") is False
 
 
@@ -346,7 +346,7 @@ class TestBedrockRoutingAffinity:
             priority=5,
         )
 
-    async def test_bedrock_model_skips_nim(self):
+    async def test_bedrock_model_skips_nim(self) -> None:
         """When model is a Bedrock ID, NIM should not be attempted."""
         nim = self._nim_provider()
         bedrock = _bedrock_provider()
@@ -366,7 +366,7 @@ class TestBedrockRoutingAffinity:
         assert "bedrock" in provider_ids
         assert "nvidia-nim" not in provider_ids
 
-    async def test_bedrock_model_is_primary_for_bedrock_provider(self):
+    async def test_bedrock_model_is_primary_for_bedrock_provider(self) -> None:
         """When NIM is skipped, Bedrock becomes the primary provider and uses the original model."""
         nim = self._nim_provider()
         bedrock = _bedrock_provider("us.anthropic.claude-opus-4-6-v1")
@@ -386,7 +386,7 @@ class TestBedrockRoutingAffinity:
         call_kwargs = mock_client.converse.call_args.kwargs
         assert call_kwargs["modelId"] == "us.anthropic.claude-opus-4-6-v1"
 
-    async def test_bedrock_affinity_preserved_in_cooldown_bypass(self):
+    async def test_bedrock_affinity_preserved_in_cooldown_bypass(self) -> None:
         """Bedrock affinity must hold even in the last-resort cooldown-bypass path."""
         from unittest.mock import AsyncMock, patch as mock_patch
         import provider_router as pr_mod
@@ -413,7 +413,7 @@ class TestBedrockRoutingAffinity:
         assert "bedrock" in provider_ids, "Bedrock not attempted in bypass path"
         assert "nvidia-nim" not in provider_ids, "NIM was incorrectly tried in bypass path"
 
-    async def test_non_bedrock_model_still_tries_nim_first(self):
+    async def test_non_bedrock_model_still_tries_nim_first(self) -> None:
         """Non-Bedrock model IDs still route to NIM first (existing behaviour)."""
         import httpx
 

--- a/tests/test_model_router.py
+++ b/tests/test_model_router.py
@@ -8,6 +8,7 @@ import pytest
 from router.model_router import ModelRouter, RoutingDecision, reset_router, get_router
 from router.classifier import classify_task
 from router.health import invalidate_cache as invalidate_health_cache
+from router.registry import get_registry
 
 
 # ── Fixtures ──────────────────────────────────────────────────────────────────
@@ -301,6 +302,59 @@ def test_is_model_available_true_when_checks_disabled(monkeypatch):
     from router.health import is_model_available
     # Empty set = no filtering = everything is "available"
     assert is_model_available("any-model:latest") is True
+
+
+# ── Bedrock model registry entries ────────────────────────────────────────────
+
+_BEDROCK_MODEL_IDS = [
+    "us.anthropic.claude-opus-4-7",
+    "us.anthropic.claude-opus-4-6-v1",
+    "us.anthropic.claude-sonnet-4-6",
+    "us.anthropic.claude-haiku-4-5-20251001-v1:0",
+]
+
+
+def test_bedrock_opus_4_7_in_registry():
+    reg = get_registry()
+    cap = reg["us.anthropic.claude-opus-4-7"]
+    assert cap.type == "reasoning"
+    assert cap.cost_tier == 3
+    assert "bedrock" in cap.tags
+    assert "claude4" in cap.tags
+
+
+def test_bedrock_opus_4_6_v1_in_registry():
+    reg = get_registry()
+    cap = reg["us.anthropic.claude-opus-4-6-v1"]
+    assert cap.type == "reasoning"
+    assert cap.cost_tier == 3
+    assert "bedrock" in cap.tags
+    assert "flagship" in cap.tags
+
+
+def test_bedrock_sonnet_4_6_in_registry():
+    reg = get_registry()
+    cap = reg["us.anthropic.claude-sonnet-4-6"]
+    assert cap.type == "coder"
+    assert cap.cost_tier == 2
+    assert "bedrock" in cap.tags
+
+
+def test_bedrock_haiku_4_5_in_registry():
+    reg = get_registry()
+    cap = reg["us.anthropic.claude-haiku-4-5-20251001-v1:0"]
+    assert cap.type == "coder"
+    assert cap.cost_tier == 1
+    assert "bedrock" in cap.tags
+    assert "fast" in cap.tags
+
+
+def test_bedrock_models_route_as_passthrough():
+    for model_id in _BEDROCK_MODEL_IDS:
+        reset_router()
+        decision = _router().route(requested_model=model_id)
+        assert decision.resolved_model == model_id, f"Expected passthrough for {model_id}"
+        assert decision.selection_source == "passthrough", f"Wrong source for {model_id}"
 
 
 def test_is_model_available_prefix_match(monkeypatch):


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **Bedrock routing affinity** — `us.anthropic.*`, `eu.anthropic.*`, `global.anthropic.*`, `arn:aws:bedrock:*`, and `anthropic.claude-*` model IDs are now routed exclusively to the `bedrock` provider. Previously, Nvidia NIM (priority 5) would intercept these requests and silently serve its own default model instead of forwarding to Bedrock.
- **Agent & coder models upgraded to Opus 4.6** — All agent roles (`AGENT_PLANNER/EXECUTOR/VERIFIER/JUDGE_MODEL`) and coding runtime models (`OPENCODE_MODEL`, `AIDER_MODEL`, `GOOSE_MODEL`) now default to `us.anthropic.claude-opus-4-6-v1` (Claude Opus 4.6 via AWS Bedrock — highest confirmed-accessible Opus model in the account).
- **Registry additions** — `us.anthropic.claude-opus-4-6-v1` and `us.anthropic.claude-haiku-4-5-20251001-v1:0` added to the model capability registry.
- **AWS env vars documented** — `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_REGION`, `BEDROCK_MODEL_ID` added to `render.yaml` with `sync: false` for Render dashboard.
- **Live E2E test added** — `tests/test_bedrock_live.py` (4 tests, auto-skipped in CI without credentials; confirmed green with real credentials at 1.5–2.5s latency).

## Why Opus 4.7 is not used

`claude-opus-4-7` is listed in the account's inference profiles but returns `AccessDeniedException` — it requires AWS Sales approval for this account tier. The inference profile for Opus 4.6 works correctly. Changing `BEDROCK_MODEL_ID` in the Render dashboard to `us.anthropic.claude-opus-4-7` when access is granted is the only change needed.

## Test plan

- [x] 39 unit + routing affinity tests pass (`pytest tests/test_bedrock_provider.py`)
- [x] 4 live E2E tests pass with real credentials (direct boto3, model accessibility, ProviderRouter round-trip, health check)
- [x] `_is_bedrock_model_id()` verified for 10 prefix patterns
- [x] Routing affinity: NIM bypassed for Bedrock model IDs; NIM still used first for NIM model IDs
- [x] Rebased onto master (includes merged PR #193 CI fixes)

https://claude.ai/code/session_01P3kGiygjALr4jwpetb8AXz
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01P3kGiygjALr4jwpetb8AXz)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated CI failure auto-fix workflow using Claude to diagnose and fix failing tests and linting issues.
  * Improved AWS Bedrock model routing with affinity filtering to ensure Bedrock models route correctly to Bedrock providers.

* **Chores**
  * Updated default models to Claude Opus 4.6 via AWS Bedrock.
  * Extended model registry with new AWS Bedrock Claude model entries.

* **Tests**
  * Added comprehensive live integration tests for AWS Bedrock connectivity and routing behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/strikersam/local-llm-server/pull/194?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->