### PR TITLE
fix: AWS Bedrock fallback for agent loop, CI scripts, and workflow

### DIFF
--- a/.github/scripts/implement_agent.py
+++ b/.github/scripts/implement_agent.py
@@ -342,13 +342,40 @@ def _openai_tools_to_anthropic(tools: list[dict]) -> list[dict]:
     return result
 
 
+def _make_anthropic_client():
+    """Return (client, bedrock_model_or_None) using Bedrock if AWS creds present, else Anthropic direct."""
+    import anthropic as _anthropic
+    aws_access = os.environ.get("AWS_ACCESS_KEY_ID") or os.environ.get("BEDROCK_ACCESS_KEY")
+    aws_secret = os.environ.get("AWS_SECRET_ACCESS_KEY") or os.environ.get("BEDROCK_SECRET_KEY")
+    aws_region = (
+        os.environ.get("AWS_REGION")
+        or os.environ.get("AWS_DEFAULT_REGION")
+        or os.environ.get("BEDROCK_REGION")
+        or "us-east-1"
+    )
+    if aws_access and aws_secret:
+        bedrock_model = os.environ.get("BEDROCK_MODEL_ID") or "us.anthropic.claude-opus-4-6-v1"
+        client = _anthropic.AnthropicBedrock(
+            aws_access_key=aws_access,
+            aws_secret_key=aws_secret,
+            aws_region=aws_region,
+        )
+        return client, bedrock_model
+    anthropic_key = os.environ.get("ANTHROPIC_API_KEY", "")
+    if anthropic_key:
+        client = _anthropic.Anthropic(api_key=anthropic_key)
+        return client, OPUS_MODEL
+    return None, None
+
+
 def _run_anthropic_agent_loop(anthropic_key: str, user_msg: str) -> tuple[bool, str, int]:
-    """Run the implementation agent loop using Claude Opus via Anthropic SDK.
+    """Run the implementation agent loop using Claude Opus via Anthropic SDK or Bedrock.
 
     Returns (success, summary, turns_used).
     """
-    import anthropic as _anthropic
-    client = _anthropic.Anthropic(api_key=anthropic_key)
+    client, use_model = _make_anthropic_client()
+    if client is None:
+        return False, "No Anthropic/Bedrock credentials available", 0
     anthropic_tools = _openai_tools_to_anthropic(TOOLS)
 
     messages: list[dict] = [{"role": "user", "content": user_msg}]
@@ -359,11 +386,11 @@ def _run_anthropic_agent_loop(anthropic_key: str, user_msg: str) -> tuple[bool, 
 
     while turns < MAX_TURNS:
         turns += 1
-        print(f"\n[agent] Turn {turns}/{MAX_TURNS} model={OPUS_MODEL} (Anthropic)", flush=True)
+        print(f"\n[agent] Turn {turns}/{MAX_TURNS} model={use_model}", flush=True)
 
         try:
             resp = client.messages.create(
-                model=OPUS_MODEL,
+                model=use_model,
                 max_tokens=8192,
                 system=SYSTEM,
                 tools=anthropic_tools,  # type: ignore[arg-type]
@@ -458,9 +485,12 @@ def _run_anthropic_agent_loop(anthropic_key: str, user_msg: str) -> tuple[bool, 
 def main() -> None:
     anthropic_key = os.environ.get("ANTHROPIC_API_KEY", "")
     nvidia_key = os.environ.get("NVIDIA_API_KEY", "")
+    # Bedrock is usable even without ANTHROPIC_API_KEY
+    aws_access = os.environ.get("AWS_ACCESS_KEY_ID") or os.environ.get("BEDROCK_ACCESS_KEY")
+    has_anthropic_or_bedrock = bool(anthropic_key or aws_access)
 
-    if not anthropic_key and not nvidia_key:
-        print("ERROR: neither ANTHROPIC_API_KEY nor NVIDIA_API_KEY set", file=sys.stderr)
+    if not has_anthropic_or_bedrock and not nvidia_key:
+        print("ERROR: no API keys set (need ANTHROPIC_API_KEY, AWS Bedrock creds, or NVIDIA_API_KEY)", file=sys.stderr)
         sys.exit(1)
 
     note_path = Path("/tmp/note_content.txt")  # nosec: B108
@@ -488,13 +518,13 @@ def main() -> None:
     turns = 0
     final_model = OPUS_MODEL
 
-    # Primary: Claude Opus via Anthropic
-    if anthropic_key:
-        print("[agent] Using Anthropic Claude Opus as primary model", flush=True)
+    # Primary: Claude Opus via Anthropic direct or AWS Bedrock
+    if has_anthropic_or_bedrock:
+        print("[agent] Using Claude Opus as primary model (Bedrock or Anthropic direct)", flush=True)
         try:
             success, summary, turns = _run_anthropic_agent_loop(anthropic_key, user_msg)
         except Exception as exc:
-            print(f"[agent] Anthropic agent loop failed: {exc} — falling back to NVIDIA", file=sys.stderr)
+            print(f"[agent] Anthropic/Bedrock agent loop failed: {exc} — falling back to NVIDIA", file=sys.stderr)
 
     # Fallback: NVIDIA NIM
     if not success and nvidia_key:

--- a/.github/scripts/review_agent.py
+++ b/.github/scripts/review_agent.py
@@ -82,7 +82,37 @@ def load_council_skill() -> str:
 
 def _call_review_llm(prompt: str, *, anthropic_key: str, nvidia_key: str) -> str:
     """Call the best available LLM for review. Opus is primary; NVIDIA NIM is fallback."""
-    # Primary: Anthropic Claude Opus
+    # Primary: AWS Bedrock (when AWS creds present, preferred over direct Anthropic)
+    aws_access = os.environ.get("AWS_ACCESS_KEY_ID") or os.environ.get("BEDROCK_ACCESS_KEY")
+    aws_secret = os.environ.get("AWS_SECRET_ACCESS_KEY") or os.environ.get("BEDROCK_SECRET_KEY")
+    aws_region = (
+        os.environ.get("AWS_REGION")
+        or os.environ.get("AWS_DEFAULT_REGION")
+        or os.environ.get("BEDROCK_REGION")
+        or "us-east-1"
+    )
+    bedrock_model = os.environ.get("BEDROCK_MODEL_ID") or "us.anthropic.claude-opus-4-6-v1"
+    if aws_access and aws_secret:
+        try:
+            import anthropic as _anthropic
+            client = _anthropic.AnthropicBedrock(
+                aws_access_key=aws_access,
+                aws_secret_key=aws_secret,
+                aws_region=aws_region,
+            )
+            resp = client.messages.create(
+                model=bedrock_model,
+                max_tokens=2048,
+                messages=[{"role": "user", "content": prompt}],
+            )
+            text = next((b.text for b in resp.content if b.type == "text"), "")
+            if text:
+                print(f"[review] Got response from {bedrock_model} (Bedrock)", flush=True)
+                return text
+        except Exception as exc:
+            print(f"[review] Bedrock Opus failed: {exc} — trying Anthropic direct", file=sys.stderr)
+
+    # Primary: Anthropic Claude Opus (direct)
     if anthropic_key:
         try:
             import anthropic as _anthropic
@@ -123,9 +153,10 @@ def _call_review_llm(prompt: str, *, anthropic_key: str, nvidia_key: str) -> str
 def main() -> None:
     anthropic_key = os.environ.get("ANTHROPIC_API_KEY", "")
     nvidia_key = os.environ.get("NVIDIA_API_KEY", "")
+    aws_access = os.environ.get("AWS_ACCESS_KEY_ID") or os.environ.get("BEDROCK_ACCESS_KEY")
 
-    if not anthropic_key and not nvidia_key:
-        print("ERROR: neither ANTHROPIC_API_KEY nor NVIDIA_API_KEY set — defaulting to WARN", file=sys.stderr)
+    if not anthropic_key and not nvidia_key and not aws_access:
+        print("ERROR: no API keys set — defaulting to WARN", file=sys.stderr)
         with open(RESULT_FILE, "w") as f:
             json.dump({"verdict": "WARN", "summary": "Review skipped (no API key)", "details": ""}, f)
         sys.exit(0)

--- a/.github/workflows/process-quick-note.yml
+++ b/.github/workflows/process-quick-note.yml
@@ -194,6 +194,9 @@ jobs:
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           NVIDIA_API_KEY: ${{ secrets.NVIDIA_API_KEY }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION: ${{ secrets.AWS_REGION }}
         run: |
           python3 .github/scripts/implement_agent.py \
             "${{ steps.issue.outputs.url }}" \
@@ -350,6 +353,9 @@ jobs:
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           NVIDIA_API_KEY: ${{ secrets.NVIDIA_API_KEY }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION: ${{ secrets.AWS_REGION }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}
         run: |
@@ -389,6 +395,9 @@ jobs:
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           NVIDIA_API_KEY: ${{ secrets.NVIDIA_API_KEY }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION: ${{ secrets.AWS_REGION }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           python3 .github/scripts/review_agent.py \

--- a/agent/loop.py
+++ b/agent/loop.py
@@ -720,6 +720,66 @@ class AgentRunner:
                     return out_text
                 except Exception as exc:
                     log.debug("Anthropic Opus call failed (falling back to Ollama): %s", exc)
+
+            # Bedrock fallback: used when only AWS credentials are set (no ANTHROPIC_API_KEY)
+            if not anthropic_key and target_is_opus:
+                aws_access = os.environ.get("AWS_ACCESS_KEY_ID") or os.environ.get("BEDROCK_ACCESS_KEY")
+                aws_secret = os.environ.get("AWS_SECRET_ACCESS_KEY") or os.environ.get("BEDROCK_SECRET_KEY")
+                aws_region = (
+                    os.environ.get("AWS_REGION")
+                    or os.environ.get("AWS_DEFAULT_REGION")
+                    or os.environ.get("BEDROCK_REGION")
+                    or "us-east-1"
+                )
+                bedrock_model = os.environ.get("BEDROCK_MODEL_ID") or "us.anthropic.claude-opus-4-6-v1"
+                if aws_access and aws_secret:
+                    try:
+                        import anthropic as _anthropic
+                        bedrock_client = _anthropic.AnthropicBedrock(
+                            aws_access_key=aws_access,
+                            aws_secret_key=aws_secret,
+                            aws_region=aws_region,
+                        )
+                        system_content = None
+                        anth_messages: list[dict[str, str]] = []
+                        for m in messages:
+                            if m.get("role") == "system":
+                                system_content = m.get("content")
+                            else:
+                                anth_messages.append({"role": m.get("role"), "content": m.get("content")})
+                        resp = bedrock_client.messages.create(
+                            model=bedrock_model,
+                            max_tokens=4096,
+                            system=system_content or "",
+                            messages=anth_messages,
+                        )
+                        out_parts: list[str] = []
+                        for block in resp.content:
+                            if getattr(block, "type", None) == "text":
+                                out_parts.append(block.text)
+                        out_text = "\n".join(out_parts)
+                        if self.email:
+                            try:
+                                import asyncio
+                                from langfuse_obs import emit_chat_observation
+                                await asyncio.to_thread(
+                                    emit_chat_observation,
+                                    email=self.email,
+                                    department=self.department or "agent",
+                                    key_id=self.key_id,
+                                    model=bedrock_model,
+                                    messages=messages,
+                                    output_text=out_text,
+                                    prompt_tokens=0,
+                                    completion_tokens=0,
+                                    latency_ms=0,
+                                    task_name="agent-task",
+                                )
+                            except Exception:
+                                pass
+                        return out_text
+                    except Exception as exc:
+                        log.debug("Bedrock Opus call failed (falling back to Ollama): %s", exc)
         except Exception:
             # Any unexpected error should not break the normal Ollama path
             pass

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -3,6 +3,12 @@
 ## [Unreleased]
 
 ### Fixed
+- `agent/loop.py` — `_chat_text` now supports AWS Bedrock (`AnthropicBedrock`) as a fallback when only AWS credentials are set and no `ANTHROPIC_API_KEY` is present, enabling Render deployments with Bedrock-only auth to route Opus calls correctly.
+- `.github/scripts/implement_agent.py` — Added `_make_anthropic_client()` helper that selects Bedrock over Anthropic direct when AWS credentials are available; Bedrock is now tried as the Claude Opus primary before falling back to NVIDIA NIM.
+- `.github/scripts/review_agent.py` — `_call_review_llm()` now tries Bedrock before Anthropic direct; `main()` accepts AWS credentials as a valid API source.
+- `.github/workflows/process-quick-note.yml` — Implement, apply-review, and council-review steps now receive `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and `AWS_REGION` from repository secrets so Bedrock routing activates in CI.
+
+### Fixed
 - PR #200: Improve direct chat intent detection and agent-mode auto-execution; add session repo/task context and related fixes.
 - PR #200: Add doctor/preflight tests, runtime policy tests, and direct-chat intent docs.
 


### PR DESCRIPTION
## Summary

- `agent/loop.py` — `_chat_text` now uses `AnthropicBedrock` when only AWS credentials are set (no `ANTHROPIC_API_KEY`). Render deployments authenticating via Bedrock will now correctly route Opus calls instead of falling back to Ollama.
- `.github/scripts/implement_agent.py` — New `_make_anthropic_client()` helper selects Bedrock over Anthropic direct when AWS credentials are present. `main()` now accepts Bedrock credentials as sufficient to run (no `ANTHROPIC_API_KEY` required).
- `.github/scripts/review_agent.py` — `_call_review_llm()` tries Bedrock before Anthropic direct. `main()` accepts AWS creds as a valid credential source.
- `.github/workflows/process-quick-note.yml` — Implement, apply-review, and council-review steps now receive `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and `AWS_REGION` from repository secrets so Bedrock routing activates in CI.

## Root Cause

After PR #195 merged, `agent/loop.py`'s `_chat_text` only checked `ANTHROPIC_API_KEY` (Anthropic direct). When Render is configured with AWS Bedrock credentials only (no `ANTHROPIC_API_KEY`), all agent calls fell through to the Ollama endpoint which fails — silently preventing all agency/CEO tasks from running.

## Test plan

- [ ] Verify `agent/loop.py` imports cleanly: `python -c "import agent.loop"`
- [ ] Verify `implement_agent.py` imports cleanly
- [ ] With `AWS_ACCESS_KEY_ID` + `AWS_SECRET_ACCESS_KEY` + `AWS_REGION` set (no `ANTHROPIC_API_KEY`), the agent loop uses Bedrock
- [ ] With no credentials, NVIDIA NIM fallback still works
- [ ] GitHub Actions: ensure the three workflow steps receive the new `AWS_*` env vars

https://claude.ai/code/session_01X67ea9AhTPy7gGrT33QXWH

---
_Generated by [Claude Code](https://claude.ai/code/session_01X67ea9AhTPy7gGrT33QXWH)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added AWS Bedrock integration as a fallback option for Claude model inference across agent loops, implementation automation, and review scripts

* **Chores**
  * Updated GitHub Actions workflows to inject AWS credentials from repository secrets, enabling Bedrock model routing during workflow execution
  * Updated documentation with entries describing new Bedrock support and credential routing behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/strikersam/local-llm-server/pull/203?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->