### PR TITLE
fix: CI unblock — sqlite3.Row.get(), judge BLOCKED, parallel short-circuit, Bandit B602

### DIFF
--- a/.github/scripts/apply_review.py
+++ b/.github/scripts/apply_review.py
@@ -173,7 +173,7 @@ class ApplyReviewAgent:
     def _bash(self, cmd: str) -> str:
         env = {k: v for k, v in os.environ.items() if k not in _STRIP_KEYS}
         r = subprocess.run(
-            cmd, shell=True, capture_output=True, text=True, timeout=120, env=env,
+            cmd, shell=True, capture_output=True, text=True, timeout=120, env=env,  # nosec B602
         )
         return (r.stdout + r.stderr)[-3000:] + f"\n[exit {r.returncode}]"
 

--- a/agent/loop.py
+++ b/agent/loop.py
@@ -125,13 +125,15 @@ class AgentRunner:
                         step.id, step.files,
                     )
 
-            # Check for parallel execution opportunity (falls through to sequential)
-            await self._maybe_run_parallel(
+            # Check for parallel execution opportunity; short-circuit if handled
+            _parallel_result = await self._maybe_run_parallel(
                 plan=plan,
                 requested_model=requested_model,
                 auto_commit=auto_commit,
                 session_id=session_id,
             )
+            if _parallel_result is not None:
+                return _parallel_result
 
             for step in plan.steps[:max_steps]:
                 step_data = step.model_dump()
@@ -180,6 +182,8 @@ class AgentRunner:
                         break
                     except Exception:
                         continue
+                if "verdict" not in judge:
+                    judge = {"verdict": "BLOCKED", "failure_phase": "judge"}
 
             summary = self._build_summary(plan.goal, step_results, commits)
             self._log_event(session_id, "assistant_message", {"summary": summary})

--- a/agent/state.py
+++ b/agent/state.py
@@ -107,14 +107,15 @@ class AgentSessionStore:
                     "SELECT role, content FROM session_messages WHERE session_id = ? ORDER BY id",
                     (row["session_id"],),
                 ).fetchall()
+                _keys = row.keys()
                 sessions[row["session_id"]] = AgentSession(
                     session_id=row["session_id"],
                     title=row["title"],
                     provider_id=row["provider_id"],
                     workspace_id=row["workspace_id"],
-                    repo_url=row.get("repo_url"),
-                    repo_ref=row.get("repo_ref"),
-                    active_objective=row.get("active_objective"),
+                    repo_url=row["repo_url"] if "repo_url" in _keys else None,
+                    repo_ref=row["repo_ref"] if "repo_ref" in _keys else None,
+                    active_objective=row["active_objective"] if "active_objective" in _keys else None,
                     created_at=row["created_at"],
                     updated_at=row["updated_at"],
                     history=[AgentSessionMessage(role=m["role"], content=m["content"]) for m in msgs],


### PR DESCRIPTION
## Summary

Fixes all open non-quick-note issues and unblocks CI:

- **`agent/state.py`** — `sqlite3.Row` has no `.get()` method; replaces with `row["key"] if "key" in row.keys() else None`. This was causing the `conftest.py` ImportError that blocked ALL CI tests. Closes the root cause of issue #189.
- **`agent/loop.py`** — Judge retry loop left `judge = {}` on failure; now sets `{"verdict": "BLOCKED", "failure_phase": "judge"}`. Fixes `test_agent_runner_blocks_when_judge_output_invalid`.
- **`agent/loop.py`** — `_maybe_run_parallel` result was never captured; sequential loop always ran after. Now short-circuits when parallel result is returned. Fixes `test_auto_parallelize_triggers_for_independent_steps`.
- **`.github/scripts/apply_review.py`** — Added `# nosec B602` to intentional `shell=True` subprocess call. Closes #169.

All 31 agent tests pass locally.

https://claude.ai/code/session_01X67ea9AhTPy7gGrT33QXWH

---
_Generated by [Claude Code](https://claude.ai/code/session_01X67ea9AhTPy7gGrT33QXWH)_