### PR TITLE
feat: auto-deploy backend to Render on master push

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -1,0 +1,80 @@
+name: Deploy Backend to Render
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - 'backend/**'
+      - 'agent/**'
+      - 'router/**'
+      - 'runtimes/**'
+      - 'tasks/**'
+      - 'handlers/**'
+      - 'workflow/**'
+      - 'provider_router.py'
+      - 'proxy.py'
+      - 'key_store.py'
+      - 'admin_auth.py'
+      - 'langfuse_obs.py'
+      - 'requirements.txt'
+      - 'Dockerfile.backend'
+      - '.github/workflows/deploy-backend.yml'
+  workflow_dispatch:
+    inputs:
+      reason:
+        description: 'Reason for manual deploy'
+        required: false
+        default: 'manual trigger'
+
+concurrency:
+  group: render-deploy
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    name: Trigger Render Deploy
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate deploy hook secret is set
+        run: |
+          if [ -z "${{ secrets.RENDER_DEPLOY_HOOK_URL }}" ]; then
+            echo "::error::RENDER_DEPLOY_HOOK_URL secret is not set or is empty."
+            echo "Go to: Render dashboard -> local-llm-server -> Settings -> Deploy Hook"
+            echo "Copy the hook URL (starts with https://api.render.com/deploy/srv-...)"
+            echo "Then add it as a GitHub secret named RENDER_DEPLOY_HOOK_URL"
+            exit 1
+          fi
+
+      - name: Trigger Render deployment
+        run: |
+          echo "Triggering Render deploy for commit ${{ github.sha }}"
+          RESPONSE=$(curl -s -w "\n%{http_code}" -X POST \
+            "${{ secrets.RENDER_DEPLOY_HOOK_URL }}" \
+            -H "Accept: application/json")
+          HTTP_CODE=$(echo "$RESPONSE" | tail -1)
+          BODY=$(echo "$RESPONSE" | head -1)
+          echo "Response code: $HTTP_CODE"
+          echo "Response body: $BODY"
+          if [ "$HTTP_CODE" -lt 200 ] || [ "$HTTP_CODE" -gt 299 ]; then
+            echo "::error::Render deploy hook returned HTTP $HTTP_CODE"
+            exit 1
+          fi
+          echo "Deploy triggered successfully"
+
+      - name: Wait and verify deploy started
+        run: |
+          echo "Waiting 15s for Render to register the deploy..."
+          sleep 15
+          MAX_ATTEMPTS=20
+          ATTEMPT=0
+          until curl -sf --max-time 10 \
+            "https://local-llm-server.onrender.com/api/health" > /dev/null; do
+            ATTEMPT=$((ATTEMPT + 1))
+            if [ "$ATTEMPT" -ge "$MAX_ATTEMPTS" ]; then
+              echo "::warning::Health check timed out — Render free tier can take 60-90s on first request after deploy."
+              exit 0
+            fi
+            echo "Attempt $ATTEMPT/$MAX_ATTEMPTS — waiting 10s..."
+            sleep 10
+          done
+          echo "Backend healthy at https://local-llm-server.onrender.com/api/health"

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+- `.github/workflows/deploy-backend.yml` — Auto-deploy backend to Render on every master push that touches backend code (`backend/**`, `agent/**`, `router/**`, `runtimes/**`, `Dockerfile.backend`, etc.). Uses `RENDER_DEPLOY_HOOK_URL` secret; also supports `workflow_dispatch` for manual triggers. Verifies health endpoint post-deploy.
+
+
 ### Fixed
 - `runtimes/adapters/internal_agent.py` — Removed `provider_chain=None` kwarg from `AgentRunner()` construction; `AgentRunner.__init__` never accepted this parameter, causing `TypeError: __init__() got an unexpected keyword argument 'provider_chain'` on every `InternalAgentAdapter.execute()` call and silently keeping all runtime-backed tasks idle.
 - `agent/loop.py` — Added public `AgentRunner.plan()` coroutine wrapper; `direct_chat.py` called `runner.plan()` which raised `AttributeError: 'AgentRunner' object has no attribute 'plan'` on every in-context agent execution.


### PR DESCRIPTION
## Problem
The Render backend is stuck at **v4.0.0** while the frontend is **v4.1**. Render's GitHub auto-deploy integration was not firing, causing:
- `/api/agents/runtimes` → 500 (reliability fix from PR #210 not deployed)
- All the frontend's reliability/direct-chat fixes invisible to users

## Solution
Add `deploy-backend.yml` that fires `RENDER_DEPLOY_HOOK_URL` on every push to master that touches backend files.

## Setup required
1. Go to **Render dashboard → local-llm-server → Settings → Deploy Hook**
2. Copy the hook URL (`https://api.render.com/deploy/srv-...?key=...`)
3. Update the `RENDER_DEPLOY_HOOK_URL` GitHub secret with that URL (current value is wrong — it's the service URL, not the hook)

Once merged + secret fixed, every backend change on master auto-deploys immediately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Implemented automated backend deployment workflow that monitors master branch for code changes, triggers deployment to production, and includes health verification to confirm successful deployment completion.
  * Updated changelog to document the new deployment automation workflow.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/strikersam/local-llm-server/pull/213?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->