### PR TITLE
fix: add missing list_runtimes() + bump backend version to v4.1

### DIFF
--- a/backend/server.py
+++ b/backend/server.py
@@ -1273,7 +1273,7 @@ async def lifespan(app_: "FastAPI"):
     log.info("RuntimeManager stopped")
 
 
-app = FastAPI(title="LLM Relay v4.0 — Unified Platform", version="4.0.0", lifespan=lifespan)
+app = FastAPI(title="LLM Relay v4.1 — Unified Platform", version="4.1.0", lifespan=lifespan)
 
 
 frontend_url = os.environ.get("FRONTEND_URL", "http://localhost:3000").rstrip("/")
@@ -5421,3 +5421,4 @@ if _FRONTEND_BUILD.exists():
         if index.exists():
             return HTMLResponse(index.read_text())
         return JSONResponse({"detail": "Frontend not built"}, status_code=404)
+

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -3,6 +3,12 @@
 ## [Unreleased]
 
 ### Fixed
+- `runtimes/manager.py` — Added missing `list_runtimes() -> list[dict]` method; `runtimes/api.py` `GET /runtimes/` was calling it and crashing with `AttributeError`, causing a 500 on `/api/agents/runtimes` for all users.
+
+### Changed
+- `backend/server.py` — Bumped FastAPI app title/version to `LLM Relay v4.1` / `4.1.0` to match the frontend.
+
+### Fixed
 - `.github/workflows/deploy-backend.yml` — Added `permissions: contents: read` to limit GITHUB_TOKEN scope (CodeQL P1). Expanded `push.paths` to cover all files copied by `Dockerfile.backend`: `agents/**`, `mcp_server/**`, `schedules/**`, `docker/**`, `sync/**`, `setup/**`, `hardware/**`, `rbac.py`, `secrets_store.py`, `commercial_equivalent.py`, `tokens.py` — previously missing paths caused silent workflow skips on backend-only changes (Codex P1).
 
 ### Fixed

--- a/runtimes/manager.py
+++ b/runtimes/manager.py
@@ -63,6 +63,23 @@ class RuntimeManager:
             return None
         return {"runtime_id": runtime_id, "health": health.as_dict()}
 
+    def list_runtimes(self) -> list[dict]:
+        """Return all registered runtimes with their cached health status.
+
+        Each entry: {"runtime_id": str, "available": bool, "health": dict | None}
+        This is a fast, non-blocking call — uses the last cached health snapshot.
+        """
+        result = []
+        for adapter in self._registry.all():
+            rid = adapter.RUNTIME_ID
+            health = self._health.get_health(rid)
+            result.append({
+                "runtime_id": rid,
+                "available": health.available if health is not None else False,
+                "health": health.as_dict() if health is not None else None,
+            })
+        return result
+
     def get_policy(self) -> dict[str, Any]:
         """Return the active routing policy as a plain dict."""
         return self._router.policy.as_dict()
@@ -114,3 +131,4 @@ def _build_default_manager() -> RuntimeManager:
     mgr.register(AiderAdapter())
     mgr.register(JCodeAdapter())
     return mgr
+


### PR DESCRIPTION
## Bug
`/api/agents/runtimes` returns HTTP 500 for all users.

**Root cause:** `runtimes/api.py` L93 calls `mgr.list_runtimes()` but `RuntimeManager` has no such method → `AttributeError` → unhandled 500.

## Fix
- Add `list_runtimes() -> list[dict]` to `RuntimeManager` using `self._registry.all()` + `self._health.get_health()` (fast, non-blocking cached snapshot)
- Bump `backend/server.py` title/version `v4.0` → `v4.1` to match the frontend build

## Test
After deploy: `curl https://local-llm-server.onrender.com/api/agents/runtimes` should return HTTP 200 with a `{"runtimes": [...]}` payload.