### PR TITLE
fix: remove unsafe nested-quote echo in deploy-backend workflow

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -73,7 +73,7 @@ jobs:
             echo "::error::Render deploy hook returned HTTP $HTTP_CODE"
             exit 1
           fi
-          echo "Deploy triggered — ID: $(echo $BODY | python3 -c \"import json,sys; print(json.load(sys.stdin).get('deploy',{}).get('id','unknown'))\" 2>/dev/null)"
+          echo "Deploy triggered successfully (HTTP $HTTP_CODE)"
 
       - name: Wait and verify backend health
         run: |

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -3,6 +3,9 @@
 ## [Unreleased]
 
 ### Fixed
+- `.github/workflows/deploy-backend.yml` — Replaced unsafe nested-quote `echo` (Python one-liner inside `$()` inside escaped double-quotes) with a simple portable `echo "Deploy triggered successfully (HTTP $HTTP_CODE)"`. The previous syntax caused Bash on GitHub Actions Ubuntu runners to exit with `syntax error near unexpected token` and report workflow failure on every master push, even though the Render deploy hook already accepted the request (HTTP 202).
+
+### Fixed
 - `runtimes/manager.py` — Added missing `list_runtimes() -> list[dict]` method; `runtimes/api.py` `GET /runtimes/` was calling it and crashing with `AttributeError`, causing a 500 on `/api/agents/runtimes` for all users.
 
 ### Changed


### PR DESCRIPTION
## Problem

The `Deploy Backend to Render` workflow introduced in PR #213 contained an `echo` line that embedded a Python one-liner inside `$()` inside double-quoted strings with escaped backslash-quotes. This caused Bash on GitHub Actions Ubuntu runners to reject it with:
```
syntax error near unexpected token 'json.load'
```

This made every `Deploy Backend to Render` run report **failure**, even though the Render deploy hook POST returned HTTP 202 (deploy accepted).

## Fix

Replace the unsafe multi-level-escaped echo with a simple portable one:
```bash
echo "Deploy triggered successfully (HTTP $HTTP_CODE)"
```

## Impact

- No functional change to deploy logic
- Workflow will correctly report **success** when Render accepts the deploy
- This merge will also trigger a fresh Render deploy (picking up the `list_runtimes` fix from PR #215)

## Testing

CI (pytest + frontend lint) must pass. After merge, `Deploy Backend to Render` should complete with exit 0.