### PR TITLE
chore: bump changelog to v5.0.0

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [5.0.0] — 2026-05-24
 
 ### Added
 - `agent/contract.py`: `AgentJobRequest` now has `extra="forbid"` (Pydantic v2) — unknown kwargs


### PR DESCRIPTION
Moves `[Unreleased]` to `[5.0.0] — 2026-05-24` following the merge of PR #218.

Tag `v5.0.0` already pushed.