### PR TITLE
fix(onboarding): activation surface unreachable + broken role route

### DIFF
--- a/activation_api.py
+++ b/activation_api.py
@@ -28,6 +28,7 @@ from activation import (
     save_activation,
 )
 from rbac import require_admin, audit
+from db import get_store
 
 log = logging.getLogger("qwen-proxy")
 
@@ -259,6 +260,13 @@ class _RoleUpdateBody(BaseModel):
     role: str
 
 
+class _RoleUpdateResponse(BaseModel):
+    """Response for a successful role change."""
+    user_id: str
+    role: str
+    updated: bool
+
+
 @activation_router.post("/users/{user_id}/role")
 async def change_user_role(
     user_id: str,
@@ -280,7 +288,7 @@ async def change_user_role(
             detail=f"Invalid role {body.role!r}. Allowed: {sorted(allowed_roles)}",
         )
 
-    db = get_db()
+    db = get_store()
     try:
         from bson import ObjectId
         try:

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,20 @@
 ## [Unreleased]
 
+### Fixed
+- **Onboarding/activation showed "Instance ID: unknown" and could not activate.**
+  `ActivationGate` and `AdminOnboardingPanel` called the activation API with raw `axios`
+  keyed on `REACT_APP_API_BASE` — an env var used nowhere else in the app — instead of the
+  shared `src/api.js` client (which resolves the backend URL the same way as login and attaches
+  the auth header). When the dashboard and backend ran on different origins, the status fetch
+  hit the wrong origin and failed (→ "unknown"), and admin re-activation failed with no
+  `Authorization` header. Both screens now use the shared `api` client.
+- **`/openapi.json` returned 500 (broke `/docs` and the role endpoint).** `change_user_role`
+  in `activation_api.py` referenced undefined names `_RoleUpdateResponse` and `get_db`; the
+  missing response model crashed OpenAPI schema generation and the route itself. Added the
+  `_RoleUpdateResponse` model and switched to `get_store()` (matching all other call sites).
+  Added `tests/test_activation_api.py` covering status, OpenAPI generation, and the role route
+  (auth gate, role validation, update, and 404).
+
 ### Changed
 - **README**: complete rewrite — full feature reality, autonomous agency use cases, step-by-step
   onboarding guide, screen-by-screen control plane reference, provider chain, security model,

--- a/frontend/src/v5/screens/ActivationGate.jsx
+++ b/frontend/src/v5/screens/ActivationGate.jsx
@@ -13,9 +13,7 @@
  *        • On success → reload
  */
 import React from 'react';
-import axios from 'axios';
-
-const API = process.env.REACT_APP_API_BASE || '';
+import api from '../../api';
 
 function CopyButton({ text, label }) {
   const [copied, setCopied] = React.useState(false);
@@ -65,7 +63,7 @@ export default function ActivationGate({ children }) {
   const [success,  setSuccess]  = React.useState(false);
 
   React.useEffect(() => {
-    axios.get(`${API}/api/activation/status`)
+    api.get('/api/activation/status')
       .then(r => setStatus(r.data))
       .catch(() => setStatus({ activated: false, instance_id: 'unknown', register_email: 'strikersam@gmail.com' }));
   }, []);
@@ -84,7 +82,7 @@ export default function ActivationGate({ children }) {
     if (!token.trim()) return;
     setLoading(true); setError('');
     try {
-      const r = await axios.post(`${API}/api/activation/activate`, { token: token.trim() });
+      const r = await api.post('/api/activation/activate', { token: token.trim() });
       if (r.data.success) {
         setSuccess(true);
         setTimeout(() => window.location.reload(), 1500);

--- a/frontend/src/v5/screens/AdminOnboardingPanel.jsx
+++ b/frontend/src/v5/screens/AdminOnboardingPanel.jsx
@@ -8,9 +8,7 @@
  * Embedded inside AdminScreen.jsx as collapsible sections.
  */
 import React from 'react';
-import axios from 'axios';
-
-const API = process.env.REACT_APP_API_BASE || '';
+import api from '../../api';
 
 function Badge({ children, color }) {
   const bg = color === 'green' ? 'rgba(70,217,164,0.10)' : color === 'red' ? 'rgba(255,107,125,0.10)' : 'rgba(255,255,255,0.06)';
@@ -46,7 +44,7 @@ function ActivationStatus() {
   const [err,     setErr]     = React.useState('');
 
   const load = () => {
-    axios.get(`${API}/api/activation/status`).then(r => setStatus(r.data)).catch(() => {});
+    api.get('/api/activation/status').then(r => setStatus(r.data)).catch(() => {});
   };
   React.useEffect(load, []);
 
@@ -54,7 +52,7 @@ function ActivationStatus() {
     if (!token.trim()) return;
     setLoading(true); setMsg(''); setErr('');
     try {
-      const r = await axios.post(`${API}/api/activation/activate`, { token: token.trim() });
+      const r = await api.post('/api/activation/activate', { token: token.trim() });
       if (r.data.success) { setMsg(`Activated for ${r.data.email}`); setToken(''); load(); }
       else setErr(r.data.error || 'Activation failed');
     } catch (e) { setErr(e.response?.data?.detail || 'Error'); }
@@ -123,14 +121,14 @@ function UserOnboardingTable() {
   const [loading, setLoading] = React.useState({});
   const [status,  setStatus]  = React.useState(null);
 
-  const loadStatus = () => axios.get(`${API}/api/activation/status`).then(r => setStatus(r.data)).catch(() => {});
-  const loadUsers  = () => axios.get(`${API}/api/activation/users`).then(r => setUsers(r.data || [])).catch(() => {});
+  const loadStatus = () => api.get('/api/activation/status').then(r => setStatus(r.data)).catch(() => {});
+  const loadUsers  = () => api.get('/api/activation/users').then(r => setUsers(r.data || [])).catch(() => {});
   React.useEffect(() => { loadStatus(); loadUsers(); }, []);
 
   const toggle = async (userId, allowed) => {
     setLoading(p => ({ ...p, [userId]: true }));
     try {
-      await axios.put(`${API}/api/activation/users/${encodeURIComponent(userId)}/onboarding`, { allowed });
+      await api.put(`/api/activation/users/${encodeURIComponent(userId)}/onboarding`, { allowed });
       setUsers(u => u.map(x => x.user_id === userId ? { ...x, onboarding_allowed: allowed } : x));
     } catch(e) { alert(e.response?.data?.detail || 'Error'); }
     finally { setLoading(p => ({ ...p, [userId]: false })); }
@@ -210,7 +208,7 @@ function UserOnboardingTable() {
 function AuditLog() {
   const [log, setLog] = React.useState([]);
   React.useEffect(() => {
-    axios.get(`${API}/api/activation/audit-log?limit=50`).then(r => setLog(r.data || [])).catch(() => {});
+    api.get('/api/activation/audit-log?limit=50').then(r => setLog(r.data || [])).catch(() => {});
   }, []);
 
   if (!log.length) return <div style={{ fontSize:13, color:'rgba(255,255,255,0.30)', padding:'8px 0' }}>No events yet.</div>;

--- a/tests/test_activation_api.py
+++ b/tests/test_activation_api.py
@@ -1,0 +1,93 @@
+"""Tests for activation_api — instance status, OpenAPI schema, and role route.
+
+Regression coverage for two onboarding bugs:
+  1. ``/api/activation/status`` must return a non-empty instanceId so the
+     activation wizard can display it (frontend showed "unknown" when this
+     surface was unreachable).
+  2. ``change_user_role`` referenced undefined names (``_RoleUpdateResponse``,
+     ``get_db``), which crashed OpenAPI schema generation and the route itself.
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from fastapi import FastAPI, Request
+from fastapi.testclient import TestClient
+
+from activation_api import activation_router
+
+
+def _client(*, admin: bool) -> TestClient:
+    app = FastAPI()
+
+    @app.middleware("http")
+    async def inject_user(request: Request, call_next):
+        if admin:
+            request.state.user = {"email": "admin@example.com", "role": "admin"}
+        return await call_next(request)
+
+    app.include_router(activation_router)
+    return TestClient(app, raise_server_exceptions=False)
+
+
+def test_status_returns_non_empty_instance_id() -> None:
+    client = _client(admin=False)
+    r = client.get("/api/activation/status")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["instance_id"]  # must be truthy — frontend shows "unknown" otherwise
+    assert body["activated"] is False
+
+
+def test_openapi_schema_generates() -> None:
+    # Previously failed with 500 because change_user_role's return annotation
+    # (_RoleUpdateResponse) was undefined.
+    client = _client(admin=False)
+    r = client.get("/openapi.json")
+    assert r.status_code == 200
+    assert "/api/activation/users/{user_id}/role" in r.json()["paths"]
+
+
+def test_change_role_requires_authentication() -> None:
+    client = _client(admin=False)
+    r = client.post("/api/activation/users/someone@example.com/role", json={"role": "admin"})
+    assert r.status_code == 401
+
+
+def test_change_role_rejects_invalid_role() -> None:
+    client = _client(admin=True)
+    r = client.post("/api/activation/users/someone@example.com/role", json={"role": "wizard"})
+    assert r.status_code == 422
+
+
+def test_change_role_updates_existing_user() -> None:
+    class _FakeUsers:
+        async def update_one(self, query, update):
+            return SimpleNamespace(matched_count=1)
+
+    fake_store = SimpleNamespace(users=_FakeUsers())
+    client = _client(admin=True)
+    with patch("activation_api.get_store", return_value=fake_store):
+        r = client.post(
+            "/api/activation/users/someone@example.com/role",
+            json={"role": "power_user"},
+        )
+    assert r.status_code == 200
+    body = r.json()
+    assert body == {"user_id": "someone@example.com", "role": "power_user", "updated": True}
+
+
+def test_change_role_returns_404_for_missing_user() -> None:
+    class _FakeUsers:
+        async def update_one(self, query, update):
+            return SimpleNamespace(matched_count=0)
+
+    fake_store = SimpleNamespace(users=_FakeUsers())
+    client = _client(admin=True)
+    with patch("activation_api.get_store", return_value=fake_store):
+        r = client.post(
+            "/api/activation/users/ghost@example.com/role",
+            json={"role": "user"},
+        )
+    assert r.status_code == 404


### PR DESCRIPTION
## Summary

Fixes the onboarding/activation flow where the wizard showed **"Instance ID: unknown"** and admins could not activate the instance.

### Root cause 1 — frontend (the visible symptom)
`ActivationGate.jsx` (which gates the entire app via `V5App.jsx`) and `AdminOnboardingPanel.jsx` called the activation API with **raw `axios`** keyed on `process.env.REACT_APP_API_BASE` — an env var used **nowhere else** in the codebase. The rest of the app, including login, uses the shared `src/api.js` client (`REACT_APP_BACKEND_URL` → `window.location.origin` fallback, `localStorage.backend_url`, auth-header injection, 401 self-heal).

Consequence: when the dashboard and backend run on different origins, the activation calls hit the **wrong origin** and failed → the `.catch` set `instance_id: 'unknown'`; admin re-activation also failed because the raw calls never sent the `Authorization` header that `require_admin` needs. Both screens now use the shared `api` client, so activation works wherever login works.

### Root cause 2 — backend (latent, broke `/openapi.json`)
`change_user_role` in `activation_api.py` referenced undefined names `_RoleUpdateResponse` (return model) and `get_db`. The missing response model crashed **OpenAPI schema generation** (`GET /openapi.json` → 500, breaking `/docs`) and the route itself would `NameError` if called. Added the `_RoleUpdateResponse` model and switched to `get_store()` (the accessor every other call site uses).

## Changes
- `frontend/src/v5/screens/ActivationGate.jsx`, `AdminOnboardingPanel.jsx`: use the shared `api` client instead of raw `axios` + `REACT_APP_API_BASE`.
- `activation_api.py`: add `_RoleUpdateResponse`, import/use `get_store()`.
- `tests/test_activation_api.py`: new — status returns non-empty `instance_id`, `/openapi.json` generates (200), role route auth gate (401), role validation (422), update (200), missing user (404).
- `docs/changelog.md`: `### Fixed` entries.

## Verification (in-sandbox, via FastAPI TestClient on the real `backend.server` app)
- `GET /api/activation/status` → 200 with a non-empty `instance_id`.
- `GET /openapi.json` → **200** (was **500** before the fix).
- `pytest tests/test_activation_api.py tests/test_setup_api.py tests/test_rbac.py` → 50 passed.
- Frontend not browser-tested in this environment (no browser); CI runs eslint/build.

## Test plan
- [ ] CI green (ci.yml, changelog-check, e2e, pull-request).
- [ ] Manual: load the dashboard against a remote backend → Instance ID renders; paste an activation token → activation succeeds.

https://claude.ai/code/session_013JGucmFEsWR8iXPcfyK898

---
_Generated by [Claude Code](https://claude.ai/code/session_013JGucmFEsWR8iXPcfyK898)_