### PR TITLE
Fix onboarding activation, version SSOT, README screenshots, NVIDIA-primary quick-note engine

### DIFF
--- a/.github/scripts/apply_review.py
+++ b/.github/scripts/apply_review.py
@@ -2,13 +2,13 @@
 from __future__ import annotations
 
 """
-apply_review.py — Apply PR review comments using Claude Opus (primary) or NVIDIA NIM (fallback).
+apply_review.py — Apply PR review comments using NVIDIA NIM (primary) or Claude Opus (fallback).
 
 Usage: python3 apply_review.py <pr_number>
 
 Env vars:
-  ANTHROPIC_API_KEY     Anthropic API key (Opus primary — preferred)
-  NVIDIA_API_KEY        NVIDIA NIM API key (fallback)
+  NVIDIA_API_KEY        NVIDIA NIM API key (primary engine)
+  ANTHROPIC_API_KEY     Anthropic API key (optional Opus fallback)
   GH_TOKEN              GitHub token for reading/posting PR comments
   GITHUB_REPOSITORY     owner/repo string (set automatically by GitHub Actions)
 """
@@ -413,18 +413,10 @@ def main() -> None:
     agent = ApplyReviewAgent("", OPUS_MODEL, context)
     success = False
 
-    # Primary: Claude Opus via Anthropic
-    if anthropic_key:
-        log.info(f"Trying model {OPUS_MODEL} (Anthropic — primary)")
-        try:
-            success = agent.run_with_anthropic(anthropic_key)
-        except Exception as e:
-            log.warning(f"Anthropic Opus failed: {e} — trying NVIDIA fallback")
-
-    # Fallback: NVIDIA NIM
-    if not success and nvidia_key:
+    # Primary engine: NVIDIA NIM
+    if nvidia_key:
         for model, desc in NVIDIA_CANDIDATE_MODELS:
-            log.info(f"Trying model {model} ({desc}) (NVIDIA NIM — fallback)")
+            log.info(f"Trying model {model} ({desc}) (NVIDIA NIM — primary)")
             agent = ApplyReviewAgent(nvidia_key, model, context)
             try:
                 success = agent.run()
@@ -432,6 +424,15 @@ def main() -> None:
                     break
             except Exception as e:
                 log.warning(f"Model {model} failed: {e}")
+
+    # Optional fallback: Claude Opus via Anthropic
+    if not success and anthropic_key:
+        log.info(f"NVIDIA did not apply review — falling back to {OPUS_MODEL} (Anthropic)")
+        agent = ApplyReviewAgent("", OPUS_MODEL, context)
+        try:
+            success = agent.run_with_anthropic(anthropic_key)
+        except Exception as e:
+            log.warning(f"Anthropic Opus fallback failed: {e}")
 
     summary = agent.summary if agent else ""
     result_path.write_text(json.dumps({"success": success, "applied": True, "summary": summary}))

--- a/.github/scripts/implement_agent.py
+++ b/.github/scripts/implement_agent.py
@@ -33,8 +33,8 @@ TASK = sys.argv[3] if len(sys.argv) > 3 else ""
 RESULT_FILE = "/tmp/impl_result.json"  # nosec: B108 - Predictable temp file path used for backward compatibility; secure temp file used internally
 MAX_TURNS = 120
 
-# Primary: Claude Opus via Anthropic (CEO / agency grade).
-# Fallback: NVIDIA NIM free-tier models.
+# Primary engine: NVIDIA NIM free-tier models (the real workhorse).
+# Optional fallback: Claude Opus via Anthropic, used only if NVIDIA fails and a key is set.
 OPUS_MODEL = "claude-opus-4-6"
 NVIDIA_CANDIDATE_MODELS = [
     ("qwen/qwen3-coder-480b-a35b-instruct",      "coding (Qwen3-Coder 480B — primary)"),
@@ -486,19 +486,12 @@ def main() -> None:
     success = False
     summary = "No implementation performed"
     turns = 0
-    final_model = OPUS_MODEL
+    final_model = NVIDIA_CANDIDATE_MODELS[0][0]
 
-    # Primary: Claude Opus via Anthropic
-    if anthropic_key:
-        print("[agent] Using Anthropic Claude Opus as primary model", flush=True)
-        try:
-            success, summary, turns = _run_anthropic_agent_loop(anthropic_key, user_msg)
-        except Exception as exc:
-            print(f"[agent] Anthropic agent loop failed: {exc} — falling back to NVIDIA", file=sys.stderr)
-
-    # Fallback: NVIDIA NIM
-    if not success and nvidia_key:
-        print("[agent] Falling back to NVIDIA NIM models", flush=True)
+    # Primary engine: NVIDIA NIM. Opus-via-Anthropic is only an optional fallback
+    # (the Opus/Bedrock path is unreliable here), so NVIDIA does the real work.
+    if nvidia_key:
+        print("[agent] Using NVIDIA NIM as the primary engine", flush=True)
         client = OpenAI(base_url="https://integrate.api.nvidia.com/v1", api_key=nvidia_key)
 
         messages: list[dict] = [
@@ -615,6 +608,15 @@ def main() -> None:
 
         if not success and turns >= MAX_TURNS:
             summary = f"Agent hit turn limit ({MAX_TURNS}) without completing"
+
+    # Optional fallback: Claude Opus via Anthropic, only if NVIDIA did not finish.
+    if not success and anthropic_key:
+        print("[agent] NVIDIA did not complete — trying Anthropic Claude Opus fallback", flush=True)
+        final_model = OPUS_MODEL
+        try:
+            success, summary, turns = _run_anthropic_agent_loop(anthropic_key, user_msg)
+        except Exception as exc:
+            print(f"[agent] Anthropic fallback failed: {exc}", file=sys.stderr)
 
     result = {"success": success, "summary": summary, "turns": turns}
     with open(RESULT_FILE, "w") as f:

--- a/.github/scripts/implement_agent.py
+++ b/.github/scripts/implement_agent.py
@@ -15,6 +15,7 @@ Writes /tmp/impl_result.json with {"success": bool, "summary": str}
 
 
 import json
+import logging
 import os
 import subprocess
 import sys
@@ -23,6 +24,10 @@ import time
 from pathlib import Path
 
 from openai import OpenAI
+
+# CLI script: log to stdout so messages stay visible and ordered in CI logs.
+logging.basicConfig(level=logging.INFO, format="%(message)s", stream=sys.stdout)
+log = logging.getLogger("implement_agent")
 
 # ---------------------------------------------------------------------------
 # Args
@@ -491,7 +496,7 @@ def main() -> None:
     # Primary engine: NVIDIA NIM. Opus-via-Anthropic is only an optional fallback
     # (the Opus/Bedrock path is unreliable here), so NVIDIA does the real work.
     if nvidia_key:
-        print("[agent] Using NVIDIA NIM as the primary engine", flush=True)
+        log.info("[agent] Using NVIDIA NIM as the primary engine")
         client = OpenAI(base_url="https://integrate.api.nvidia.com/v1", api_key=nvidia_key)
 
         messages: list[dict] = [
@@ -611,12 +616,12 @@ def main() -> None:
 
     # Optional fallback: Claude Opus via Anthropic, only if NVIDIA did not finish.
     if not success and anthropic_key:
-        print("[agent] NVIDIA did not complete — trying Anthropic Claude Opus fallback", flush=True)
+        log.info("[agent] NVIDIA did not complete — trying Anthropic Claude Opus fallback")
         final_model = OPUS_MODEL
         try:
             success, summary, turns = _run_anthropic_agent_loop(anthropic_key, user_msg)
         except Exception as exc:
-            print(f"[agent] Anthropic fallback failed: {exc}", file=sys.stderr)
+            log.exception("[agent] Anthropic fallback failed: %s", exc)
 
     result = {"success": success, "summary": summary, "turns": turns}
     with open(RESULT_FILE, "w") as f:

--- a/.github/scripts/review_agent.py
+++ b/.github/scripts/review_agent.py
@@ -30,8 +30,8 @@ from openai import OpenAI
 PR_NUMBER = sys.argv[1] if len(sys.argv) > 1 else ""
 RESULT_FILE = "/tmp/review_result.json"  # nosec: B108 - Predictable temp file path used for backward compatibility
 
-# Opus is preferred for council review (CEO / agency quality).
-# NVIDIA NIM models are the fallback when Anthropic is not configured.
+# NVIDIA NIM is the primary engine for council review.
+# Opus-via-Anthropic is only an optional fallback when configured.
 OPUS_MODEL = "claude-opus-4-6"
 NVIDIA_CANDIDATE_MODELS = [
     "qwen/qwen3-coder-480b-a35b-instruct",
@@ -81,25 +81,9 @@ def load_council_skill() -> str:
 
 
 def _call_review_llm(prompt: str, *, anthropic_key: str, nvidia_key: str) -> str:
-    """Call the best available LLM for review. Opus is primary; NVIDIA NIM is fallback."""
-    # Primary: Anthropic Claude Opus
-    if anthropic_key:
-        try:
-            import anthropic as _anthropic
-            client = _anthropic.Anthropic(api_key=anthropic_key)
-            resp = client.messages.create(
-                model=OPUS_MODEL,
-                max_tokens=2048,
-                messages=[{"role": "user", "content": prompt}],
-            )
-            text = next((b.text for b in resp.content if b.type == "text"), "")
-            if text:
-                print(f"[review] Got response from {OPUS_MODEL} (Anthropic)", flush=True)
-                return text
-        except Exception as exc:
-            print(f"[review] Anthropic Opus failed: {exc} — trying NVIDIA fallback", file=sys.stderr)
-
-    # Fallback: NVIDIA NIM
+    """Call the best available LLM for review. NVIDIA NIM is the primary engine;
+    Opus-via-Anthropic is only an optional fallback."""
+    # Primary: NVIDIA NIM
     if nvidia_key:
         client = OpenAI(base_url="https://integrate.api.nvidia.com/v1", api_key=nvidia_key)
         for model in NVIDIA_CANDIDATE_MODELS:
@@ -116,6 +100,23 @@ def _call_review_llm(prompt: str, *, anthropic_key: str, nvidia_key: str) -> str
             except Exception as exc:
                 print(f"[review] Model {model} failed: {exc}", file=sys.stderr)
                 continue
+
+    # Optional fallback: Anthropic Claude Opus
+    if anthropic_key:
+        try:
+            import anthropic as _anthropic
+            client = _anthropic.Anthropic(api_key=anthropic_key)
+            resp = client.messages.create(
+                model=OPUS_MODEL,
+                max_tokens=2048,
+                messages=[{"role": "user", "content": prompt}],
+            )
+            text = next((b.text for b in resp.content if b.type == "text"), "")
+            if text:
+                print(f"[review] Got response from {OPUS_MODEL} (Anthropic fallback)", flush=True)
+                return text
+        except Exception as exc:
+            print(f"[review] Anthropic Opus fallback failed: {exc}", file=sys.stderr)
 
     return ""
 

--- a/.github/scripts/review_agent.py
+++ b/.github/scripts/review_agent.py
@@ -19,6 +19,7 @@ blocked by a reviewer crash.
 
 
 import json
+import logging
 import os
 import subprocess
 import sys
@@ -26,6 +27,10 @@ import textwrap
 from pathlib import Path
 
 from openai import OpenAI
+
+# CLI script: log to stdout so messages stay visible and ordered in CI logs.
+logging.basicConfig(level=logging.INFO, format="%(message)s", stream=sys.stdout)
+log = logging.getLogger("review_agent")
 
 PR_NUMBER = sys.argv[1] if len(sys.argv) > 1 else ""
 RESULT_FILE = "/tmp/review_result.json"  # nosec: B108 - Predictable temp file path used for backward compatibility
@@ -95,10 +100,10 @@ def _call_review_llm(prompt: str, *, anthropic_key: str, nvidia_key: str) -> str
                 )
                 text = response.choices[0].message.content or ""
                 if text:
-                    print(f"[review] Got response from {model} (NVIDIA NIM)", flush=True)
+                    log.info("[review] Got response from %s (NVIDIA NIM)", model)
                     return text
             except Exception as exc:
-                print(f"[review] Model {model} failed: {exc}", file=sys.stderr)
+                log.warning("[review] Model %s failed: %s", model, exc)
                 continue
 
     # Optional fallback: Anthropic Claude Opus
@@ -113,10 +118,10 @@ def _call_review_llm(prompt: str, *, anthropic_key: str, nvidia_key: str) -> str
             )
             text = next((b.text for b in resp.content if b.type == "text"), "")
             if text:
-                print(f"[review] Got response from {OPUS_MODEL} (Anthropic fallback)", flush=True)
+                log.info("[review] Got response from %s (Anthropic fallback)", OPUS_MODEL)
                 return text
         except Exception as exc:
-            print(f"[review] Anthropic Opus fallback failed: {exc}", file=sys.stderr)
+            log.exception("[review] Anthropic Opus fallback failed: %s", exc)
 
     return ""
 

--- a/.gitignore
+++ b/.gitignore
@@ -83,5 +83,6 @@ render-env-vars.txt
 # Instance activation (generated at runtime — never commit)
 .instance_id
 .activation_token
+.activation_keypair.json
 .onboarding_state.json
 .activation_audit.jsonl

--- a/README.md
+++ b/README.md
@@ -172,6 +172,113 @@ Agents run on schedule, push results to the Task Board, and only interrupt you w
 
 ---
 
+## Screens
+
+A visual tour of the dashboard. Screenshots reflect the most recent captured UI and are
+regenerated from `scripts/sync_readme_gallery.py`.
+
+<!-- README_UI_GALLERY:START -->
+### 🛰 Control Plane
+
+The command center: live agent health, recent activity, and system metrics at a glance.
+
+<p align="center"><img src="docs/screenshots/readme/v4-control-plane.png" width="92%" alt="Control Plane dashboard"/></p>
+
+### 🛬 Login
+
+People can sign in through a simple starting page instead of touching raw config files.
+
+<p align="center"><img src="docs/screenshots/readme/v4-login.png" width="92%" alt="Login"/></p>
+
+### 🧙 Setup Wizard
+
+The wizard helps you choose providers, models, runtimes, a default agent, and a cost policy.
+
+<p align="center"><img src="docs/screenshots/readme/v4-setup-wizard.png" width="92%" alt="Setup Wizard"/></p>
+
+### 💬 Chat
+
+This is where people talk to the CEO agent directly, using the providers and rules you set up.
+
+<p align="center"><img src="docs/screenshots/readme/v4-chat.png" width="92%" alt="Chat"/></p>
+
+### 🗂 Task Board
+
+This makes AI work visible. You can see what is waiting, running, blocked, in review, or done.
+
+<p align="center"><img src="docs/screenshots/readme/v4-tasks-kanban.png" width="92%" alt="Kanban Task Board"/></p>
+
+### 🤖 Agent Roster
+
+This is your cast of AI helpers. Each agent can have its own model, runtime, specialty, and rules.
+
+<p align="center"><img src="docs/screenshots/readme/v4-agents.png" width="92%" alt="Agent Roster"/></p>
+
+### ⚙️ Runtimes
+
+This shows the engines behind the scenes that actually run your AI work.
+
+<p align="center"><img src="docs/screenshots/readme/v4-runtimes.png" width="92%" alt="Agent Runtimes"/></p>
+
+### 🛣 Routing Policy
+
+This is where you decide how smart, cheap, fast, or private the system should be when picking a model.
+
+<p align="center"><img src="docs/screenshots/readme/v4-routing.png" width="92%" alt="Routing Policy"/></p>
+
+### 🔌 Providers and Models
+
+This is where you connect local and cloud AI sources and decide what models are available.
+
+<p align="center">
+  <img src="docs/screenshots/readme/v4-providers.png" width="48%" alt="Providers"/>
+  &nbsp;
+  <img src="docs/screenshots/readme/v4-models.png" width="48%" alt="Models"/>
+</p>
+
+### 📚 Knowledge
+
+This is your team's memory: wiki pages, source material, and reusable context.
+
+<p align="center"><img src="docs/screenshots/readme/v4-knowledge.png" width="92%" alt="Knowledge and Wiki"/></p>
+
+### 🔭 Logs and activity
+
+This helps you answer, ‘what just happened?’ — every LLM call, token count, latency, and cost.
+
+<p align="center"><img src="docs/screenshots/readme/v4-logs.png" width="92%" alt="Logs"/></p>
+
+### 🗓 Schedules
+
+This is how you make AI jobs run later or run again automatically.
+
+<p align="center"><img src="docs/screenshots/readme/v4-schedules.png" width="92%" alt="Schedules"/></p>
+
+### 🧭 Settings and guardrails
+
+Central settings keep defaults, policies, and integrations in one place instead of scattered config files.
+
+<p align="center"><img src="docs/screenshots/readme/v4-settings.png" width="92%" alt="Settings"/></p>
+
+### 🛡 Admin portal
+
+This gives admins a simpler place to manage access, instance activation, and system behavior.
+
+<p align="center"><img src="docs/screenshots/readme/v4-admin.png" width="92%" alt="Admin Portal"/></p>
+
+### 📱 Mobile
+
+The dashboard is responsive — sign in, run the setup wizard, and monitor agents from a phone.
+
+<p align="center">
+  <img src="docs/screenshots/readme/v4-login-mobile.png" width="32%" alt="Mobile login"/>
+  &nbsp;
+  <img src="docs/screenshots/readme/v4-setup-mobile.png" width="32%" alt="Mobile setup wizard"/>
+</p>
+<!-- README_UI_GALLERY:END -->
+
+---
+
 ## Architecture
 
 ```

--- a/activation.py
+++ b/activation.py
@@ -75,21 +75,27 @@ def _decode_jwt_unverified(token: str) -> tuple[dict, dict, bytes, bytes]:
 
 # ── Public key loading ────────────────────────────────────────────────────────
 
+# Ed25519 SubjectPublicKeyInfo DER prefix (RFC 8410)
+_ED25519_DER_PREFIX = bytes.fromhex("302a300506032b6570032100")
+
+
+def owner_public_key_b64() -> str:
+    """Return the trusted owner public key (base64, raw 32 bytes).
+
+    Operators self-hosting their own instance can override the embedded key by
+    setting ``ACTIVATION_PUBLIC_KEY_B64`` in the environment. This lets them mint
+    activation tokens with their own keypair (via ``scripts/activate.py``) without
+    editing source. Falls back to the embedded owner key when the env var is unset.
+    """
+    return os.environ.get("ACTIVATION_PUBLIC_KEY_B64", "").strip() or _OWNER_PUBLIC_KEY_B64
+
+
 def _load_public_key() -> Ed25519PublicKey:
-    raw = base64.b64decode(_OWNER_PUBLIC_KEY_B64)
-    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey as _K
+    raw = base64.b64decode(owner_public_key_b64())
+    if len(raw) != 32:
+        raise ValueError(f"Ed25519 public key must be 32 raw bytes, got {len(raw)}")
     from cryptography.hazmat.primitives.serialization import load_der_public_key
-    # Build from raw bytes using cryptography primitives
-    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
-    # The cryptography library requires DER-encoded key for from_encoded_point;
-    # easiest path is to reconstruct via the raw key interface.
-    import struct
-    # Ed25519 SubjectPublicKeyInfo DER prefix (RFC 8410)
-    DER_PREFIX = bytes.fromhex(
-        "302a300506032b6570032100"
-    )
-    from cryptography.hazmat.primitives.serialization import load_der_public_key
-    return load_der_public_key(DER_PREFIX + raw)
+    return load_der_public_key(_ED25519_DER_PREFIX + raw)  # type: ignore[return-value]
 
 
 # ── Instance ID ───────────────────────────────────────────────────────────────
@@ -209,11 +215,36 @@ def save_activation(token: str) -> ActivationResult:
 
 _activation_cache: ActivationResult | None = None
 _activation_loaded = False
+_bypass_warned = False
+
+
+def activation_required() -> bool:
+    """Whether the licensing gate is enforced.
+
+    Self-hosters who own the instance can disable the gate entirely by setting
+    ``ACTIVATION_REQUIRED=false``. Defaults to enforced (``true``) so the
+    signed-token path remains the standard for distributed installs.
+    """
+    val = os.environ.get("ACTIVATION_REQUIRED", "true").strip().lower()
+    return val not in ("0", "false", "no", "off")
 
 
 def is_activated() -> bool:
-    """Fast in-process check. Loads from disk on first call."""
-    global _activation_cache, _activation_loaded
+    """Fast in-process check. Loads from disk on first call.
+
+    When ``ACTIVATION_REQUIRED=false`` the gate is bypassed and the instance is
+    always treated as activated (self-hosted mode). This never weakens signature
+    verification — it only makes the gate opt-out for the operator running the box.
+    """
+    global _activation_cache, _activation_loaded, _bypass_warned
+    if not activation_required():
+        if not _bypass_warned:
+            log.warning(
+                "ACTIVATION_REQUIRED=false — instance activation gate is DISABLED "
+                "(self-hosted mode). Onboarding is unlocked without a signed token."
+            )
+            _bypass_warned = True
+        return True
     if not _activation_loaded:
         _activation_cache = load_activation()
         _activation_loaded = True

--- a/activation_api.py
+++ b/activation_api.py
@@ -104,9 +104,12 @@ class ActivationStatusResponse(BaseModel):
     # Registration hint for non-activated instances
     register_email: str = "strikersam@gmail.com"
     register_instructions: str = (
-        "Copy your Instance ID above and email it to strikersam@gmail.com with the subject "
-        "'LLM Relay Activation Request'. You'll receive a signed activation code by reply. "
-        "Paste it in the Activation panel to unlock onboarding."
+        "If you own this instance you can activate it yourself — no email needed. "
+        "Either set ACTIVATION_REQUIRED=false in the backend environment to disable the "
+        "licensing gate, or run `python scripts/activate.py` to mint a signed code with "
+        "your own key (set the printed ACTIVATION_PUBLIC_KEY_B64 in the backend env, then "
+        "paste the code below). See docs/runbooks/activation.md. "
+        "Otherwise, email your Instance ID to strikersam@gmail.com to request a code."
     )
 
 
@@ -145,14 +148,19 @@ async def activation_status() -> ActivationStatusResponse:
     Safe to call before login (needed to show the activation wizard).
     """
     iid = instance_id()
-    act = get_activation()
-    if act and act.valid:
+    if is_activated():
+        act = get_activation()
+        if act and act.valid:
+            return ActivationStatusResponse(
+                activated=True,
+                instance_id=iid,
+                email=act.email,
+                issued_at=act.issued_at,
+                expires_at=act.expires_at,
+            )
+        # Activated via ACTIVATION_REQUIRED=false — no signed token on disk.
         return ActivationStatusResponse(
-            activated=True,
-            instance_id=iid,
-            email=act.email,
-            issued_at=act.issued_at,
-            expires_at=act.expires_at,
+            activated=True, instance_id=iid, email="activation-not-required"
         )
     return ActivationStatusResponse(activated=False, instance_id=iid)
 

--- a/activation_api.py
+++ b/activation_api.py
@@ -28,6 +28,7 @@ from activation import (
     save_activation,
 )
 from rbac import require_admin, audit
+from db import get_store
 
 log = logging.getLogger("qwen-proxy")
 
@@ -259,6 +260,13 @@ class _RoleUpdateBody(BaseModel):
     role: str
 
 
+class _RoleUpdateResponse(BaseModel):
+    """Response for a successful role change."""
+    user_id: str
+    role: str
+    updated: bool
+
+
 @activation_router.post("/users/{user_id}/role")
 async def change_user_role(
     user_id: str,
@@ -280,7 +288,7 @@ async def change_user_role(
             detail=f"Invalid role {body.role!r}. Allowed: {sorted(allowed_roles)}",
         )
 
-    db = get_db()
+    db = get_store()
     try:
         from bson import ObjectId
         try:

--- a/backend/server.py
+++ b/backend/server.py
@@ -72,6 +72,7 @@ from setup import setup_router
 from activation_api import activation_router
 from setup.api import get_wizard_state
 from secrets_store import secrets_router, get_secrets_store
+from version import __version__, APP_NAME, APP_LABEL, APP_TAGLINE
 
 logging.basicConfig(
     level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s"
@@ -1276,7 +1277,7 @@ async def lifespan(app_: "FastAPI"):
     log.info("RuntimeManager stopped")
 
 
-app = FastAPI(title="LLM Relay v4.1 — Unified Platform", version="4.1.0", lifespan=lifespan)
+app = FastAPI(title=f"{APP_LABEL} — {APP_TAGLINE}", version=__version__, lifespan=lifespan)
 
 
 frontend_url = os.environ.get("FRONTEND_URL", "http://localhost:3000").rstrip("/")
@@ -4822,8 +4823,8 @@ async def observability_metrics(user: dict = Depends(get_current_user)):
 @app.get("/api/platform")
 async def platform_info(user: dict = Depends(get_current_user)):
     return {
-        "name": "LLM Relay Platform",
-        "version": "2.0.0",
+        "name": APP_NAME,
+        "version": __version__,
         "ngrok_domain": NGROK_DOMAIN,
         "ngrok_configured": bool(NGROK_TOKEN),
         "langfuse_configured": bool(LANGFUSE_PK and LANGFUSE_SK),

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,20 @@
 ## [Unreleased]
 
+### Fixed
+- **Onboarding/activation showed "Instance ID: unknown" and could not activate.**
+  `ActivationGate` and `AdminOnboardingPanel` called the activation API with raw `axios`
+  keyed on `REACT_APP_API_BASE` — an env var used nowhere else in the app — instead of the
+  shared `src/api.js` client (which resolves the backend URL the same way as login and attaches
+  the auth header). When the dashboard and backend ran on different origins, the status fetch
+  hit the wrong origin and failed (→ "unknown"), and admin re-activation failed with no
+  `Authorization` header. Both screens now use the shared `api` client.
+- **`/openapi.json` returned 500 (broke `/docs` and the role endpoint).** `change_user_role`
+  in `activation_api.py` referenced undefined names `_RoleUpdateResponse` and `get_db`; the
+  missing response model crashed OpenAPI schema generation and the route itself. Added the
+  `_RoleUpdateResponse` model and switched to `get_store()` (matching all other call sites).
+  Added `tests/test_activation_api.py` covering status, OpenAPI generation, and the role route
+  (auth gate, role validation, update, and 404).
+
 ### Changed
 - **README**: complete rewrite — full feature reality, autonomous agency use cases, step-by-step
   onboarding guide, screen-by-screen control plane reference, provider chain, security model,

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -16,8 +16,19 @@
 - `activation.owner_public_key_b64()` / `activation.activation_required()` helpers, with
   `tests/test_activation_selfservice.py` covering key round-trip, instance binding, untrusted-key
   rejection, the escape hatch, and the CLI.
+- **Version single source of truth.** `version.py` (canonical Python) + `frontend/src/version.js`
+  (canonical frontend — CRA can't import `package.json` from `src/`). `scripts/bump_version.py X.Y.Z`
+  propagates the version to `version.py`, `version.js`, `frontend/package.json`,
+  `frontend/public/index.html`, and the README badge in one command;
+  `tests/test_version_consistency.py` fails CI if any of them drift.
 
 ### Fixed
+- **Stale `v4.1` / wrong version strings.** The browser tab title and meta in
+  `frontend/public/index.html` said "LLM Relay v4.1", the FastAPI app title said
+  "LLM Relay v4.1 — Unified Platform" (`version="4.1.0"`), and `/api/platform` returned
+  `"2.0.0"`. All now read from `version.py`/`version.js` and show the current release.
+  Sidebar/topbar brand in `AppShell.jsx` also said "LLM Relay V5.0" (inconsistent with the
+  "Agency Core" branding elsewhere) — now sourced from `APP_LABEL`.
 - **Onboarding/activation showed "Instance ID: unknown" and could not activate.**
   `ActivationGate` and `AdminOnboardingPanel` called the activation API with raw `axios`
   keyed on `REACT_APP_API_BASE` — an env var used nowhere else in the app — instead of the

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -44,6 +44,11 @@
   (auth gate, role validation, update, and 404).
 
 ### Changed
+- **Quick-note engine now runs on NVIDIA NIM as the primary engine.** The Opus-via-Anthropic
+  path was unreliable (Opus/Bedrock integration never worked), so `implement_agent.py`,
+  `review_agent.py`, and `apply_review.py` now use NVIDIA NIM (Qwen3-Coder 480B first) as the
+  real workhorse, with Claude Opus demoted to an optional fallback that only runs if NVIDIA fails
+  and `ANTHROPIC_API_KEY` is set. `tests/test_quick_note_engine.py` guards the NVIDIA-primary wiring.
 - **README screenshots restored.** The README rewrite dropped the screen gallery (and its
   inject markers), so the page had no visuals. Re-added a `## Screens` section with the
   `README_UI_GALLERY` markers and pointed `scripts/sync_readme_gallery.py` at the current

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -44,6 +44,11 @@
   (auth gate, role validation, update, and 404).
 
 ### Changed
+- **README screenshots restored.** The README rewrite dropped the screen gallery (and its
+  inject markers), so the page had no visuals. Re-added a `## Screens` section with the
+  `README_UI_GALLERY` markers and pointed `scripts/sync_readme_gallery.py` at the current
+  `docs/screenshots/readme/v4-*` set (the old config referenced `v3-*` and non-existent
+  `webui-*` files, which crashed the sync). Regenerated `docs/screenshots/manifest.json`.
 - **README**: complete rewrite — full feature reality, autonomous agency use cases, step-by-step
   onboarding guide, screen-by-screen control plane reference, provider chain, security model,
   and updated roadmap showing phases 1–5 complete. Deploy and config sections expanded with

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,22 @@
 ## [Unreleased]
 
+### Security
+- **Self-service instance activation (unblocks the owner/self-hoster).** The activation gate
+  previously had only one path — email the owner for a signed code — with no tool to mint one,
+  so the operator was locked out of their own instance. Added `ACTIVATION_REQUIRED=false`
+  (opt-in, off by default) to disable the gate for self-hosters, and `ACTIVATION_PUBLIC_KEY_B64`
+  so an operator can trust their own keypair via env without editing source. Signature
+  verification is unchanged — the escape hatch only stops *enforcing* the gate. Verified via the
+  `risky-module-review` skill.
+
+### Added
+- `scripts/activate.py`: CLI that mints and installs an Ed25519-signed activation token for the
+  current instance (generates a keypair if none exists; writes git-ignored files at `0600`).
+- `docs/runbooks/activation.md`: owner/admin activation procedure (disable gate · self-mint · request).
+- `activation.owner_public_key_b64()` / `activation.activation_required()` helpers, with
+  `tests/test_activation_selfservice.py` covering key round-trip, instance binding, untrusted-key
+  rejection, the escape hatch, and the CLI.
+
 ### Fixed
 - **Onboarding/activation showed "Instance ID: unknown" and could not activate.**
   `ActivationGate` and `AdminOnboardingPanel` called the activation API with raw `axios`

--- a/docs/runbooks/activation.md
+++ b/docs/runbooks/activation.md
@@ -1,0 +1,98 @@
+# Runbook — Instance Activation
+
+The onboarding wizard is gated behind **instance activation**. This page explains
+how to unlock it, especially when **you are the owner / self-hosting** the box.
+
+## TL;DR — you are blocked at the activation screen
+
+You have three options, fastest first:
+
+| Option | When to use | What to do |
+|--------|-------------|------------|
+| **A. Disable the gate** | You self-host and don't need licensing | Set `ACTIVATION_REQUIRED=false` in the backend environment, restart. |
+| **B. Self-mint a code** | You want to keep the signed-token licensing, with your own key | Run `python scripts/activate.py`, set the printed `ACTIVATION_PUBLIC_KEY_B64` in the backend env, paste the code in the UI. |
+| **C. Request a code** | You are a downstream user of someone else's instance | Email your Instance ID to the owner and paste back the code they send. |
+
+---
+
+## Why activation exists
+
+`activation.py` implements an Ed25519-signed licensing gate. A valid activation
+token is a JWT signed by the **owner's private key**; the server verifies it
+against a trusted **public key**. The token embeds your `instanceId`, so a code
+issued for one install cannot be reused on another.
+
+The original flow assumed a separation between *owner* (holds the private key)
+and *admin* (runs the box and emails for a code). When you are **both**, that
+round trip is a dead end — there was no tool to mint a code. Options A and B
+below close that gap.
+
+---
+
+## Option A — disable the gate (self-hosted)
+
+Set the environment variable and restart the backend:
+
+```bash
+ACTIVATION_REQUIRED=false
+```
+
+- On Render: **Environment → Add** `ACTIVATION_REQUIRED=false` → **Save** → redeploy.
+- Locally / Docker: add it to your `.env` or `docker-compose` environment.
+
+`is_activated()` then returns `true` without a signed token and onboarding
+unlocks. The signature verification code is **not** weakened — the gate is simply
+not enforced while this flag is off. Defaults to `true` (enforced) when unset.
+
+---
+
+## Option B — self-mint a signed code with your own key
+
+Keeps the cryptographic licensing intact, using a keypair you control.
+
+```bash
+# Run from the repo root. Reads/creates .instance_id automatically.
+python scripts/activate.py --email you@example.com
+```
+
+The script:
+
+1. Loads a private key from `ACTIVATION_PRIVATE_KEY_B64`, or `.activation_keypair.json`,
+   or **generates a fresh keypair** (saved to `.activation_keypair.json`, git-ignored, `chmod 600`).
+2. Mints a token bound to this instance and writes it to `.activation_token`.
+3. Prints the **public key** to trust.
+
+Because a freshly generated key is not the one embedded in `activation.py`, make
+the server trust it by exporting the printed value in the backend environment:
+
+```bash
+ACTIVATION_PUBLIC_KEY_B64="<printed-public-key>"
+```
+
+Restart the backend. If you ran the script on the same host as the backend,
+`.activation_token` is already installed and onboarding is unlocked. If the
+backend runs elsewhere (e.g. Render), use `--print-only`, then paste the printed
+token into the **Activation** panel in the UI — the server verifies and persists it.
+
+> Keep `.activation_keypair.json` (and `ACTIVATION_PRIVATE_KEY_B64`) private. The
+> private key is what lets you mint codes — for yourself and for any downstream
+> users of your instances.
+
+---
+
+## Option C — request a code (downstream user)
+
+1. Copy your **Instance ID** from the activation screen.
+2. Email it to the instance owner.
+3. Paste the signed code they reply with into the **Activation** panel.
+
+---
+
+## Security notes
+
+- `ACTIVATION_REQUIRED=false` is an **opt-in, off-by-default** escape hatch. It does
+  not bypass or weaken signature verification — it only stops enforcing the gate.
+- `ACTIVATION_PUBLIC_KEY_B64` lets an operator trust their own key without editing
+  source. Set it only to keys you control.
+- Generated keypairs and tokens are written with `0600` permissions and are
+  git-ignored (`.activation_keypair.json`, `.activation_token`, `.instance_id`).

--- a/docs/screenshots/manifest.json
+++ b/docs/screenshots/manifest.json
@@ -1,11 +1,22 @@
 [
   {
+    "heading": "### \ud83d\udef0 Control Plane",
+    "summary": "The command center: live agent health, recent activity, and system metrics at a glance.",
+    "screenshots": [
+      {
+        "path": "docs/screenshots/readme/v4-control-plane.png",
+        "alt": "Control Plane dashboard",
+        "width": "92%"
+      }
+    ]
+  },
+  {
     "heading": "### \ud83d\udeec Login",
     "summary": "People can sign in through a simple starting page instead of touching raw config files.",
     "screenshots": [
       {
-        "path": "docs/screenshots/readme/v3-login.png",
-        "alt": "LLM Relay login",
+        "path": "docs/screenshots/readme/v4-login.png",
+        "alt": "Login",
         "width": "92%"
       }
     ]
@@ -15,7 +26,7 @@
     "summary": "The wizard helps you choose providers, models, runtimes, a default agent, and a cost policy.",
     "screenshots": [
       {
-        "path": "docs/screenshots/readme/v3-setup-wizard.png",
+        "path": "docs/screenshots/readme/v4-setup-wizard.png",
         "alt": "Setup Wizard",
         "width": "92%"
       }
@@ -23,11 +34,11 @@
   },
   {
     "heading": "### \ud83d\udcac Chat",
-    "summary": "This is where people talk to AI directly, using the providers and rules you set up.",
+    "summary": "This is where people talk to the CEO agent directly, using the providers and rules you set up.",
     "screenshots": [
       {
-        "path": "docs/screenshots/readme/v3-chat.png",
-        "alt": "Direct Chat",
+        "path": "docs/screenshots/readme/v4-chat.png",
+        "alt": "Chat",
         "width": "92%"
       }
     ]
@@ -37,7 +48,7 @@
     "summary": "This makes AI work visible. You can see what is waiting, running, blocked, in review, or done.",
     "screenshots": [
       {
-        "path": "docs/screenshots/readme/v3-tasks-kanban.png",
+        "path": "docs/screenshots/readme/v4-tasks-kanban.png",
         "alt": "Kanban Task Board",
         "width": "92%"
       }
@@ -48,7 +59,7 @@
     "summary": "This is your cast of AI helpers. Each agent can have its own model, runtime, specialty, and rules.",
     "screenshots": [
       {
-        "path": "docs/screenshots/readme/v3-agents.png",
+        "path": "docs/screenshots/readme/v4-agents.png",
         "alt": "Agent Roster",
         "width": "92%"
       }
@@ -59,7 +70,7 @@
     "summary": "This shows the engines behind the scenes that actually run your AI work.",
     "screenshots": [
       {
-        "path": "docs/screenshots/readme/v3-runtimes.png",
+        "path": "docs/screenshots/readme/v4-runtimes.png",
         "alt": "Agent Runtimes",
         "width": "92%"
       }
@@ -70,7 +81,7 @@
     "summary": "This is where you decide how smart, cheap, fast, or private the system should be when picking a model.",
     "screenshots": [
       {
-        "path": "docs/screenshots/readme/v3-routing.png",
+        "path": "docs/screenshots/readme/v4-routing.png",
         "alt": "Routing Policy",
         "width": "92%"
       }
@@ -81,12 +92,12 @@
     "summary": "This is where you connect local and cloud AI sources and decide what models are available.",
     "screenshots": [
       {
-        "path": "docs/screenshots/readme/v3-providers.png",
+        "path": "docs/screenshots/readme/v4-providers.png",
         "alt": "Providers",
         "width": "48%"
       },
       {
-        "path": "docs/screenshots/readme/v3-models.png",
+        "path": "docs/screenshots/readme/v4-models.png",
         "alt": "Models",
         "width": "48%"
       }
@@ -97,7 +108,7 @@
     "summary": "This is your team's memory: wiki pages, source material, and reusable context.",
     "screenshots": [
       {
-        "path": "docs/screenshots/readme/v3-knowledge.png",
+        "path": "docs/screenshots/readme/v4-knowledge.png",
         "alt": "Knowledge and Wiki",
         "width": "92%"
       }
@@ -105,10 +116,10 @@
   },
   {
     "heading": "### \ud83d\udd2d Logs and activity",
-    "summary": "This helps you answer, \u2018what just happened?\u2019",
+    "summary": "This helps you answer, \u2018what just happened?\u2019 \u2014 every LLM call, token count, latency, and cost.",
     "screenshots": [
       {
-        "path": "docs/screenshots/readme/v3-logs.png",
+        "path": "docs/screenshots/readme/v4-logs.png",
         "alt": "Logs",
         "width": "92%"
       }
@@ -119,7 +130,7 @@
     "summary": "This is how you make AI jobs run later or run again automatically.",
     "screenshots": [
       {
-        "path": "docs/screenshots/readme/v3-schedules.png",
+        "path": "docs/screenshots/readme/v4-schedules.png",
         "alt": "Schedules",
         "width": "92%"
       }
@@ -130,7 +141,7 @@
     "summary": "Central settings keep defaults, policies, and integrations in one place instead of scattered config files.",
     "screenshots": [
       {
-        "path": "docs/screenshots/readme/v3-settings.png",
+        "path": "docs/screenshots/readme/v4-settings.png",
         "alt": "Settings",
         "width": "92%"
       }
@@ -138,45 +149,28 @@
   },
   {
     "heading": "### \ud83d\udee1 Admin portal",
-    "summary": "This gives admins a simpler place to manage access, controls, and system behavior.",
+    "summary": "This gives admins a simpler place to manage access, instance activation, and system behavior.",
     "screenshots": [
       {
-        "path": "docs/screenshots/readme/v3-admin.png",
+        "path": "docs/screenshots/readme/v4-admin.png",
         "alt": "Admin Portal",
         "width": "92%"
       }
     ]
   },
   {
-    "heading": "### \ud83d\udda5 Built-in web UI",
-    "summary": "The proxy also ships a lightweight built-in app at `/app`, so you can ship a useful UI without the separate hosted dashboard.",
+    "heading": "### \ud83d\udcf1 Mobile",
+    "summary": "The dashboard is responsive \u2014 sign in, run the setup wizard, and monitor agents from a phone.",
     "screenshots": [
       {
-        "path": "docs/screenshots/webui/webui-app.png",
-        "alt": "Built-in Web UI",
-        "width": "92%"
-      }
-    ]
-  },
-  {
-    "heading": "### \ud83d\udd10 Built-in admin login",
-    "summary": "The built-in admin surface has a dedicated login gate before exposing sensitive controls.",
-    "screenshots": [
+        "path": "docs/screenshots/readme/v4-login-mobile.png",
+        "alt": "Mobile login",
+        "width": "32%"
+      },
       {
-        "path": "docs/screenshots/webui/webui-admin-login.png",
-        "alt": "Built-in admin login",
-        "width": "92%"
-      }
-    ]
-  },
-  {
-    "heading": "### \ud83e\uddf0 Built-in admin workspace",
-    "summary": "Once authenticated, admins can manage providers, workspaces, and runtime metadata from the in-proxy UI.",
-    "screenshots": [
-      {
-        "path": "docs/screenshots/webui/webui-admin.png",
-        "alt": "Built-in admin workspace",
-        "width": "92%"
+        "path": "docs/screenshots/readme/v4-setup-mobile.png",
+        "alt": "Mobile setup wizard",
+        "width": "32%"
       }
     ]
   }

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -4,8 +4,8 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <meta name="theme-color" content="#0F0F13" />
-  <meta name="description" content="LLM Relay v4.1 — Autonomous AI Agency. Self-healing, CEO-coordinated agents, internet-connected trend intelligence, and 8 runtimes on your own hardware." />
-  <title>LLM Relay v4.1 — Autonomous AI Agency</title>
+  <meta name="description" content="Agency Core v5.0 — Autonomous AI Platform. Self-hosted, CEO-coordinated agents, internet-connected trend intelligence, and 8 runtimes on your own hardware." />
+  <title>Agency Core v5.0 — Autonomous AI Platform</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;500;600;700;800&family=IBM+Plex+Mono:wght@400;500;600&family=Inter:wght@400;500;600;700&family=Geist:wght@400;500;600;700&display=swap" rel="stylesheet">

--- a/frontend/src/v5/AppShell.jsx
+++ b/frontend/src/v5/AppShell.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
+import { APP_NAME, APP_LABEL } from '../version';
 
 
-// nav.jsx — LLM Relay V5.0 navigation (clean, all screens)
+// nav.jsx — Agency Core navigation (clean, all screens)
 
 const NAV_ITEMS = [
   { id:'chat',       label:'Chat',       icon:'MessageSquare',  desc:'Unified assistant',      section:'WORKSPACE' },
@@ -74,8 +75,8 @@ function SidebarNav({ activeScreen, onNavigate, onClose, agentRunning, isAdmin }
             <Icon name="Cpu" size={16} style={{ color:'#fff' }}/>
           </div>
           <div>
-            <div style={{ fontSize:14, fontWeight:900, color:'#fff', letterSpacing:'-0.04em', lineHeight:1.1 }}>LLM Relay</div>
-            <div style={{ fontSize:10, fontFamily:'var(--font-mono)', color:'var(--accent)', letterSpacing:'0.14em', textTransform:'uppercase', marginTop:2 }}>V5.0 · Agency Core</div>
+            <div style={{ fontSize:14, fontWeight:900, color:'#fff', letterSpacing:'-0.04em', lineHeight:1.1 }}>{APP_NAME}</div>
+            <div style={{ fontSize:10, fontFamily:'var(--font-mono)', color:'var(--accent)', letterSpacing:'0.14em', textTransform:'uppercase', marginTop:2 }}>{APP_LABEL}</div>
           </div>
         </div>
         <AgentStatus running={agentRunning}/>
@@ -217,7 +218,7 @@ function MobileTopBar({ title, subtitle, onMenuOpen }) {
         <Icon name="Cpu" size={13} style={{ color:'#fff' }}/>
       </div>
       <div style={{ flex:1, minWidth:0 }}>
-        <div style={{ fontSize:15, fontWeight:900, color:'#fff', letterSpacing:'-0.04em', lineHeight:1.1 }}>LLM Relay V5.0</div>
+        <div style={{ fontSize:15, fontWeight:900, color:'#fff', letterSpacing:'-0.04em', lineHeight:1.1 }}>{APP_LABEL}</div>
         {subtitle && <div style={{ fontSize:9, fontFamily:'var(--font-mono)', color:'var(--accent)', letterSpacing:'0.14em', textTransform:'uppercase', marginTop:1 }}>{subtitle}</div>}
       </div>
     </div>
@@ -241,7 +242,7 @@ function AppShell({ children, activeScreen, onNavigate, agentRunning, isAdmin })
       )}
       <div style={{ flex:1, display:'flex', flexDirection:'column', minWidth:0, height:'100%', overflow:'hidden' }}>
         <div className="mobile-topbar">
-          <MobileTopBar title="LLM Relay V5.0" subtitle={navItem.label} onMenuOpen={()=>setSidebarOpen(true)}/>
+          <MobileTopBar title={APP_LABEL} subtitle={navItem.label} onMenuOpen={()=>setSidebarOpen(true)}/>
         </div>
         <div style={{ flex:1, overflowY:'auto', overflowX:'hidden' }}>
           {children}

--- a/frontend/src/v5/screens/ActivationGate.jsx
+++ b/frontend/src/v5/screens/ActivationGate.jsx
@@ -170,6 +170,16 @@ export default function ActivationGate({ children }) {
           </Step>
         </div>
 
+        {/* Owner / self-host note */}
+        <div style={{ marginTop:16, padding:'12px 16px', borderRadius:12, background:'rgba(70,217,164,0.05)', border:'1px solid rgba(70,217,164,0.18)' }}>
+          <div style={{ fontSize:12, fontWeight:700, color:'#46d9a4', marginBottom:4 }}>Own this instance? Activate it yourself.</div>
+          <div style={{ fontSize:12, color:'rgba(255,255,255,0.5)', lineHeight:1.6 }}>
+            Set <code style={{ fontFamily:'var(--font-mono, monospace)', color:'#a0b4d0' }}>ACTIVATION_REQUIRED=false</code> in the backend
+            environment to unlock onboarding, or run <code style={{ fontFamily:'var(--font-mono, monospace)', color:'#a0b4d0' }}>python scripts/activate.py</code> to
+            mint your own signed code. See <code style={{ fontFamily:'var(--font-mono, monospace)', color:'#a0b4d0' }}>docs/runbooks/activation.md</code>.
+          </div>
+        </div>
+
         {/* Footer note */}
         <p style={{ textAlign:'center', fontSize:11, color:'rgba(255,255,255,0.2)', marginTop:20, lineHeight:1.6, fontFamily:'var(--font-mono, monospace)' }}>
           Activation is tied to this Instance ID. If you reinstall, you'll need a new code.<br/>

--- a/frontend/src/v5/screens/ActivationGate.jsx
+++ b/frontend/src/v5/screens/ActivationGate.jsx
@@ -57,6 +57,7 @@ function Step({ num, title, children, done }) {
 
 export default function ActivationGate({ children }) {
   const [status,   setStatus]   = React.useState(null);   // null = loading
+  const [statusError, setStatusError] = React.useState('');
   const [token,    setToken]    = React.useState('');
   const [error,    setError]    = React.useState('');
   const [loading,  setLoading]  = React.useState(false);
@@ -64,8 +65,12 @@ export default function ActivationGate({ children }) {
 
   React.useEffect(() => {
     api.get('/api/activation/status')
-      .then(r => setStatus(r.data))
-      .catch(() => setStatus({ activated: false, instance_id: 'unknown', register_email: 'strikersam@gmail.com' }));
+      .then(r => { setStatusError(''); setStatus(r.data); })
+      .catch(e => {
+        // Don't disguise an unreachable backend as "not activated" — surface it.
+        setStatusError(e.response?.data?.detail || 'Unable to reach the activation service. Is the backend running?');
+        setStatus({ activated: false, instance_id: 'unknown', register_email: '' });
+      });
   }, []);
 
   if (status === null) {
@@ -117,6 +122,12 @@ export default function ActivationGate({ children }) {
             This LLM Relay is not yet activated. Follow the three steps below to unlock onboarding and start using the platform.
           </p>
         </div>
+
+        {statusError && (
+          <div style={{ marginBottom:16, padding:'10px 14px', borderRadius:12, background:'rgba(255,189,102,0.07)', border:'1px solid rgba(255,189,102,0.25)', color:'#ffbd66', fontSize:12, lineHeight:1.5, textAlign:'center' }}>
+            ⚠ {statusError}
+          </div>
+        )}
 
         {/* Card */}
         <div style={{ background:'rgba(255,255,255,0.03)', border:'1px solid rgba(255,255,255,0.08)', borderRadius:20, padding:'28px 24px' }}>

--- a/frontend/src/v5/screens/ActivationGate.jsx
+++ b/frontend/src/v5/screens/ActivationGate.jsx
@@ -13,9 +13,7 @@
  *        • On success → reload
  */
 import React from 'react';
-import axios from 'axios';
-
-const API = process.env.REACT_APP_API_BASE || '';
+import api from '../../api';
 
 function CopyButton({ text, label }) {
   const [copied, setCopied] = React.useState(false);
@@ -65,7 +63,7 @@ export default function ActivationGate({ children }) {
   const [success,  setSuccess]  = React.useState(false);
 
   React.useEffect(() => {
-    axios.get(`${API}/api/activation/status`)
+    api.get('/api/activation/status')
       .then(r => setStatus(r.data))
       .catch(() => setStatus({ activated: false, instance_id: 'unknown', register_email: 'strikersam@gmail.com' }));
   }, []);
@@ -84,7 +82,7 @@ export default function ActivationGate({ children }) {
     if (!token.trim()) return;
     setLoading(true); setError('');
     try {
-      const r = await axios.post(`${API}/api/activation/activate`, { token: token.trim() });
+      const r = await api.post('/api/activation/activate', { token: token.trim() });
       if (r.data.success) {
         setSuccess(true);
         setTimeout(() => window.location.reload(), 1500);

--- a/frontend/src/v5/screens/AdminOnboardingPanel.jsx
+++ b/frontend/src/v5/screens/AdminOnboardingPanel.jsx
@@ -8,9 +8,7 @@
  * Embedded inside AdminScreen.jsx as collapsible sections.
  */
 import React from 'react';
-import axios from 'axios';
-
-const API = process.env.REACT_APP_API_BASE || '';
+import api from '../../api';
 
 function Badge({ children, color }) {
   const bg = color === 'green' ? 'rgba(70,217,164,0.10)' : color === 'red' ? 'rgba(255,107,125,0.10)' : 'rgba(255,255,255,0.06)';
@@ -46,7 +44,7 @@ function ActivationStatus() {
   const [err,     setErr]     = React.useState('');
 
   const load = () => {
-    axios.get(`${API}/api/activation/status`).then(r => setStatus(r.data)).catch(() => {});
+    api.get('/api/activation/status').then(r => setStatus(r.data)).catch(() => {});
   };
   React.useEffect(load, []);
 
@@ -54,7 +52,7 @@ function ActivationStatus() {
     if (!token.trim()) return;
     setLoading(true); setMsg(''); setErr('');
     try {
-      const r = await axios.post(`${API}/api/activation/activate`, { token: token.trim() });
+      const r = await api.post('/api/activation/activate', { token: token.trim() });
       if (r.data.success) { setMsg(`Activated for ${r.data.email}`); setToken(''); load(); }
       else setErr(r.data.error || 'Activation failed');
     } catch (e) { setErr(e.response?.data?.detail || 'Error'); }
@@ -123,14 +121,14 @@ function UserOnboardingTable() {
   const [loading, setLoading] = React.useState({});
   const [status,  setStatus]  = React.useState(null);
 
-  const loadStatus = () => axios.get(`${API}/api/activation/status`).then(r => setStatus(r.data)).catch(() => {});
-  const loadUsers  = () => axios.get(`${API}/api/activation/users`).then(r => setUsers(r.data || [])).catch(() => {});
+  const loadStatus = () => api.get('/api/activation/status').then(r => setStatus(r.data)).catch(() => {});
+  const loadUsers  = () => api.get('/api/activation/users').then(r => setUsers(r.data || [])).catch(() => {});
   React.useEffect(() => { loadStatus(); loadUsers(); }, []);
 
   const toggle = async (userId, allowed) => {
     setLoading(p => ({ ...p, [userId]: true }));
     try {
-      await axios.put(`${API}/api/activation/users/${encodeURIComponent(userId)}/onboarding`, { allowed });
+      await api.put(`/api/activation/users/${encodeURIComponent(userId)}/onboarding`, { allowed });
       setUsers(u => u.map(x => x.user_id === userId ? { ...x, onboarding_allowed: allowed } : x));
     } catch(e) { alert(e.response?.data?.detail || 'Error'); }
     finally { setLoading(p => ({ ...p, [userId]: false })); }
@@ -210,7 +208,7 @@ function UserOnboardingTable() {
 function AuditLog() {
   const [log, setLog] = React.useState([]);
   React.useEffect(() => {
-    axios.get(`${API}/api/activation/audit-log?limit=50`).then(r => setLog(r.data || [])).catch(() => {});
+    api.get('/api/activation/audit-log?limit=50').then(r => setLog(r.data || [])).catch(() => {});
   }, []);
 
   if (!log.length) return <div style={{ fontSize:13, color:'rgba(255,255,255,0.30)', padding:'8px 0' }}>No events yet.</div>;

--- a/frontend/src/v5/screens/AdminOnboardingPanel.jsx
+++ b/frontend/src/v5/screens/AdminOnboardingPanel.jsx
@@ -138,8 +138,9 @@ function UserOnboardingTable() {
     .catch(e => setLoadErr(e.response?.data?.detail || 'Unable to load activation status.'));
   const loadUsers  = () => api.get('/api/activation/users').then(r => setUsers(r.data || []))
     .catch(e => setLoadErr(e.response?.data?.detail || 'Unable to load users.'));
-  const reload = () => { setLoadErr(''); loadStatus(); loadUsers(); };
-  React.useEffect(() => { reload(); }, []);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const reload = React.useCallback(() => { setLoadErr(''); loadStatus(); loadUsers(); }, []);
+  React.useEffect(() => { reload(); }, [reload]);
 
   const toggle = async (userId, allowed) => {
     setLoading(p => ({ ...p, [userId]: true }));

--- a/frontend/src/v5/screens/AdminOnboardingPanel.jsx
+++ b/frontend/src/v5/screens/AdminOnboardingPanel.jsx
@@ -42,9 +42,13 @@ function ActivationStatus() {
   const [loading, setLoading] = React.useState(false);
   const [msg,     setMsg]     = React.useState('');
   const [err,     setErr]     = React.useState('');
+  const [loadErr, setLoadErr] = React.useState('');
 
   const load = () => {
-    api.get('/api/activation/status').then(r => setStatus(r.data)).catch(() => {});
+    setLoadErr('');
+    api.get('/api/activation/status')
+      .then(r => setStatus(r.data))
+      .catch(e => setLoadErr(e.response?.data?.detail || 'Unable to load activation status.'));
   };
   React.useEffect(load, []);
 
@@ -59,7 +63,15 @@ function ActivationStatus() {
     finally { setLoading(false); }
   };
 
-  if (!status) return <div style={{ fontSize:13, color:'rgba(255,255,255,0.30)', padding:'8px 0' }}>Loading…</div>;
+  if (!status) {
+    if (loadErr) return (
+      <div style={{ fontSize:13, color:'#ff8a97', padding:'8px 0' }}>
+        ⚠ {loadErr}{' '}
+        <button onClick={load} style={{ marginLeft:8, padding:'2px 10px', borderRadius:7, background:'rgba(93,162,255,0.10)', border:'1px solid rgba(93,162,255,0.25)', color:'#6CB0FF', fontSize:12, cursor:'pointer' }}>Retry</button>
+      </div>
+    );
+    return <div style={{ fontSize:13, color:'rgba(255,255,255,0.30)', padding:'8px 0' }}>Loading…</div>;
+  }
 
   return (
     <div>
@@ -120,10 +132,14 @@ function UserOnboardingTable() {
   const [newUid,  setNewUid]  = React.useState('');
   const [loading, setLoading] = React.useState({});
   const [status,  setStatus]  = React.useState(null);
+  const [loadErr, setLoadErr] = React.useState('');
 
-  const loadStatus = () => api.get('/api/activation/status').then(r => setStatus(r.data)).catch(() => {});
-  const loadUsers  = () => api.get('/api/activation/users').then(r => setUsers(r.data || [])).catch(() => {});
-  React.useEffect(() => { loadStatus(); loadUsers(); }, []);
+  const loadStatus = () => api.get('/api/activation/status').then(r => setStatus(r.data))
+    .catch(e => setLoadErr(e.response?.data?.detail || 'Unable to load activation status.'));
+  const loadUsers  = () => api.get('/api/activation/users').then(r => setUsers(r.data || []))
+    .catch(e => setLoadErr(e.response?.data?.detail || 'Unable to load users.'));
+  const reload = () => { setLoadErr(''); loadStatus(); loadUsers(); };
+  React.useEffect(() => { reload(); }, []);
 
   const toggle = async (userId, allowed) => {
     setLoading(p => ({ ...p, [userId]: true }));
@@ -142,6 +158,15 @@ function UserOnboardingTable() {
   };
 
   const activated = status?.activated;
+
+  if (loadErr) {
+    return (
+      <div style={{ padding:'12px 14px', borderRadius:12, background:'rgba(255,107,125,0.06)', border:'1px solid rgba(255,107,125,0.18)', fontSize:13, color:'#ff8a97' }}>
+        ⚠ {loadErr}{' '}
+        <button onClick={reload} style={{ marginLeft:8, padding:'2px 10px', borderRadius:7, background:'rgba(93,162,255,0.10)', border:'1px solid rgba(93,162,255,0.25)', color:'#6CB0FF', fontSize:12, cursor:'pointer' }}>Retry</button>
+      </div>
+    );
+  }
 
   if (!activated) {
     return (
@@ -207,10 +232,20 @@ function UserOnboardingTable() {
 // ── 3. Audit log ─────────────────────────────────────────────────────────────
 function AuditLog() {
   const [log, setLog] = React.useState([]);
-  React.useEffect(() => {
-    api.get('/api/activation/audit-log?limit=50').then(r => setLog(r.data || [])).catch(() => {});
-  }, []);
+  const [loadErr, setLoadErr] = React.useState('');
+  const load = () => {
+    setLoadErr('');
+    api.get('/api/activation/audit-log?limit=50').then(r => setLog(r.data || []))
+      .catch(e => setLoadErr(e.response?.data?.detail || 'Unable to load the audit log.'));
+  };
+  React.useEffect(load, []);
 
+  if (loadErr) return (
+    <div style={{ fontSize:13, color:'#ff8a97', padding:'8px 0' }}>
+      ⚠ {loadErr}{' '}
+      <button onClick={load} style={{ marginLeft:8, padding:'2px 10px', borderRadius:7, background:'rgba(93,162,255,0.10)', border:'1px solid rgba(93,162,255,0.25)', color:'#6CB0FF', fontSize:12, cursor:'pointer' }}>Retry</button>
+    </div>
+  );
   if (!log.length) return <div style={{ fontSize:13, color:'rgba(255,255,255,0.30)', padding:'8px 0' }}>No events yet.</div>;
 
   return (

--- a/frontend/src/version.js
+++ b/frontend/src/version.js
@@ -1,0 +1,12 @@
+// Single source of truth for the frontend version and brand.
+//
+// CRA's ModuleScopePlugin forbids importing ../package.json from src/, so this
+// literal is the canonical frontend value. Keep it in sync with the root
+// version.py and package.json via `python scripts/bump_version.py X.Y.Z`
+// (tests/test_version_consistency.py guards against drift).
+export const APP_VERSION = '5.0.0';
+export const APP_NAME = 'Agency Core';
+export const APP_TAGLINE = 'Autonomous AI Platform';
+
+// Human-facing label, e.g. "Agency Core v5.0".
+export const APP_LABEL = `${APP_NAME} v${APP_VERSION.split('.').slice(0, 2).join('.')}`;

--- a/scripts/activate.py
+++ b/scripts/activate.py
@@ -57,6 +57,7 @@ _KEYPAIR_FILE = _REPO_ROOT / ".activation_keypair.json"
 
 
 def _derive_public_b64(private_b64: str) -> str:
+    """Derive the base64 raw Ed25519 public key from a base64 raw private key."""
     raw_priv = base64.b64decode(private_b64)
     priv = Ed25519PrivateKey.from_private_bytes(raw_priv)
     pub_raw = priv.public_key().public_bytes(Encoding.Raw, PublicFormat.Raw)
@@ -85,6 +86,7 @@ def _load_or_create_keypair() -> tuple[str, str, bool]:
 
 
 def main() -> int:
+    """Mint an activation token for this instance and install it (or print it)."""
     parser = argparse.ArgumentParser(description="Self-mint and install an instance activation token.")
     parser.add_argument("--instance-id", default="", help="Instance ID (default: read/create .instance_id).")
     parser.add_argument("--email", default="self-hosted@localhost", help="Email stamped into the token.")

--- a/scripts/activate.py
+++ b/scripts/activate.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""Self-service instance activation for the owner / self-hoster.
+
+Mints an Ed25519-signed activation token for THIS instance and installs it so
+the onboarding wizard unlocks — no "email the owner and wait for a code" round
+trip required when you are the one running the box.
+
+Usage:
+    python scripts/activate.py                      # auto: instance id from .instance_id
+    python scripts/activate.py --email you@host.com # stamp an email into the token
+    python scripts/activate.py --print-only         # print the token, do not install it
+    python scripts/activate.py --instance-id <uuid> # activate a specific instance id
+
+Key handling (first match wins):
+  1. ACTIVATION_PRIVATE_KEY_B64 env var (base64 of the raw 32-byte Ed25519 private key)
+  2. .activation_keypair.json in the repo root (written by a previous run, git-ignored)
+  3. A fresh keypair is generated and persisted to .activation_keypair.json (chmod 600)
+
+If a fresh keypair is generated its PUBLIC key will not match the key embedded in
+activation.py. The script prints the public key and tells you to export
+ACTIVATION_PUBLIC_KEY_B64=<key> so the running server trusts tokens you mint.
+
+Tip: if you just want to disable the licensing gate entirely on your own server,
+set ACTIVATION_REQUIRED=false in the backend environment instead of running this.
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import os
+import sys
+from pathlib import Path
+
+# Allow running from repo root: python scripts/activate.py
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_REPO_ROOT))
+
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+from cryptography.hazmat.primitives.serialization import (
+    Encoding,
+    NoEncryption,
+    PrivateFormat,
+    PublicFormat,
+)
+
+from activation import (  # noqa: E402
+    _ACTIVATION_FILE,
+    _generate_token_for_owner,
+    get_or_create_instance_id,
+    owner_public_key_b64,
+    verify_activation_token,
+)
+
+_KEYPAIR_FILE = _REPO_ROOT / ".activation_keypair.json"
+
+
+def _derive_public_b64(private_b64: str) -> str:
+    raw_priv = base64.b64decode(private_b64)
+    priv = Ed25519PrivateKey.from_private_bytes(raw_priv)
+    pub_raw = priv.public_key().public_bytes(Encoding.Raw, PublicFormat.Raw)
+    return base64.b64encode(pub_raw).decode()
+
+
+def _load_or_create_keypair() -> tuple[str, str, bool]:
+    """Return (private_b64, public_b64, generated)."""
+    env_priv = os.environ.get("ACTIVATION_PRIVATE_KEY_B64", "").strip()
+    if env_priv:
+        return env_priv, _derive_public_b64(env_priv), False
+
+    if _KEYPAIR_FILE.exists():
+        data = json.loads(_KEYPAIR_FILE.read_text())
+        priv = data["private_key_b64"]
+        return priv, _derive_public_b64(priv), False
+
+    priv = Ed25519PrivateKey.generate()
+    priv_raw = priv.private_bytes(Encoding.Raw, PrivateFormat.Raw, NoEncryption())
+    pub_raw = priv.public_key().public_bytes(Encoding.Raw, PublicFormat.Raw)
+    priv_b64 = base64.b64encode(priv_raw).decode()
+    pub_b64 = base64.b64encode(pub_raw).decode()
+    _KEYPAIR_FILE.write_text(json.dumps({"private_key_b64": priv_b64, "public_key_b64": pub_b64}, indent=2))
+    _KEYPAIR_FILE.chmod(0o600)
+    return priv_b64, pub_b64, True
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Self-mint and install an instance activation token.")
+    parser.add_argument("--instance-id", default="", help="Instance ID (default: read/create .instance_id).")
+    parser.add_argument("--email", default="self-hosted@localhost", help="Email stamped into the token.")
+    parser.add_argument("--print-only", action="store_true", help="Print the token; do not write .activation_token.")
+    args = parser.parse_args()
+
+    iid = args.instance_id.strip() or get_or_create_instance_id()
+    # Capture the key the server currently trusts BEFORE we override the env below.
+    trusted_before = owner_public_key_b64()
+    priv_b64, pub_b64, generated = _load_or_create_keypair()
+
+    token = _generate_token_for_owner(iid, args.email, priv_b64)
+
+    # Verify against the public key we just used, so success means the running
+    # server will accept this token once it trusts that key.
+    os.environ["ACTIVATION_PUBLIC_KEY_B64"] = pub_b64
+    result = verify_activation_token(token, iid)
+    if not result.valid:
+        print(f"ERROR: minted token failed verification: {result.error}", file=sys.stderr)
+        return 1
+
+    embedded_match = pub_b64 == trusted_before
+
+    print(f"Instance ID : {iid}")
+    print(f"Public key  : {pub_b64}")
+    print()
+
+    if not args.print_only:
+        _ACTIVATION_FILE.write_text(token + "\n")
+        _ACTIVATION_FILE.chmod(0o600)
+        print(f"Installed activation token → {_ACTIVATION_FILE.name}")
+    else:
+        print("Activation token (paste into the Activation panel):")
+        print(token)
+
+    print()
+    if generated or not embedded_match:
+        print("This token was signed with a keypair that the server does not trust by default.")
+        print("Make the server trust it by exporting this in the backend environment:")
+        print()
+        print(f'    ACTIVATION_PUBLIC_KEY_B64="{pub_b64}"')
+        print()
+        print("Then restart the backend. (On Render: add it under Environment, then redeploy.)")
+    else:
+        print("Done — restart the backend and onboarding will be unlocked.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -27,6 +27,7 @@ _SEMVER = re.compile(r"^\d+\.\d+\.\d+$")
 
 
 def _replace(path: Path, pattern: str, repl: str, *, count: int = 0) -> int:
+    """Regex-replace ``pattern`` with ``repl`` in ``path``; return the match count."""
     text = path.read_text()
     new, n = re.subn(pattern, repl, text, count=count)
     if n:
@@ -35,6 +36,7 @@ def _replace(path: Path, pattern: str, repl: str, *, count: int = 0) -> int:
 
 
 def main() -> int:
+    """Bump the version across all version-bearing files; fail fast if any are missed."""
     parser = argparse.ArgumentParser(description="Bump the app version everywhere.")
     parser.add_argument("version", help="New semantic version, e.g. 5.1.0")
     args = parser.parse_args()
@@ -45,6 +47,8 @@ def main() -> int:
         return 2
     minor = ".".join(new.split(".")[:2])  # e.g. 5.1
 
+    missing: list[str] = []
+
     edits = {
         _ROOT / "version.py": (r'__version__ = "\d+\.\d+\.\d+"', f'__version__ = "{new}"'),
         _ROOT / "frontend/src/version.js": (r"APP_VERSION = '\d+\.\d+\.\d+'", f"APP_VERSION = '{new}'"),
@@ -52,6 +56,8 @@ def main() -> int:
     for path, (pat, repl) in edits.items():
         n = _replace(path, pat, repl)
         print(f"{'updated' if n else 'NO MATCH'}: {path.relative_to(_ROOT)}")
+        if not n:
+            missing.append(str(path.relative_to(_ROOT)))
 
     # package.json — parse/dump to avoid touching other fields.
     pkg_path = _ROOT / "frontend/package.json"
@@ -63,12 +69,22 @@ def main() -> int:
     # index.html — "Agency Core vX.Y" in title + description.
     n = _replace(_ROOT / "frontend/public/index.html", r"Agency Core v\d+\.\d+", f"Agency Core v{minor}")
     print(f"{'updated' if n else 'NO MATCH'}: frontend/public/index.html ({n} refs)")
+    if not n:
+        missing.append("frontend/public/index.html")
 
     # README badge + release tag link.
     readme = _ROOT / "README.md"
     n1 = _replace(readme, r"version-\d+\.\d+\.\d+-blue", f"version-{new}-blue")
     n2 = _replace(readme, r"releases/tag/v\d+\.\d+\.\d+", f"releases/tag/v{new}")
     print(f"{'updated' if (n1 or n2) else 'NO MATCH'}: README.md ({n1 + n2} refs)")
+    if not (n1 or n2):
+        missing.append("README.md")
+
+    if missing:
+        print("ERROR: version bump incomplete; patterns not found in:", file=sys.stderr)
+        for m in missing:
+            print(f"  - {m}", file=sys.stderr)
+        return 1
 
     print(f"\nVersion bumped to {new}. Run: pytest -k version")
     return 0

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -66,19 +66,27 @@ def main() -> int:
     pkg_path.write_text(json.dumps(pkg, indent=2) + "\n")
     print(f"updated: {pkg_path.relative_to(_ROOT)}")
 
-    # index.html — "Agency Core vX.Y" in title + description.
-    n = _replace(_ROOT / "frontend/public/index.html", r"Agency Core v\d+\.\d+", f"Agency Core v{minor}")
-    print(f"{'updated' if n else 'NO MATCH'}: frontend/public/index.html ({n} refs)")
-    if not n:
-        missing.append("frontend/public/index.html")
+    # index.html — update both <title> and <meta name="description"> independently.
+    html_path = _ROOT / "frontend/public/index.html"
+    n_title = _replace(html_path, r"(<title>Agency Core v)\d+\.\d+", f"\g<1>{minor}", count=1)
+    n_meta  = _replace(html_path, r'(content="Agency Core v)\d+\.\d+', f'\\g<1>{minor}', count=1)
+    print(f"{'updated' if n_title else 'NO MATCH'}: frontend/public/index.html <title> ({n_title} refs)")
+    print(f"{'updated' if n_meta  else 'NO MATCH'}: frontend/public/index.html <meta description> ({n_meta} refs)")
+    if not n_title:
+        missing.append("frontend/public/index.html (<title>)")
+    if not n_meta:
+        missing.append("frontend/public/index.html (<meta description>)")
 
-    # README badge + release tag link.
+    # README badge + release tag link — both patterns must match independently.
     readme = _ROOT / "README.md"
     n1 = _replace(readme, r"version-\d+\.\d+\.\d+-blue", f"version-{new}-blue")
     n2 = _replace(readme, r"releases/tag/v\d+\.\d+\.\d+", f"releases/tag/v{new}")
-    print(f"{'updated' if (n1 or n2) else 'NO MATCH'}: README.md ({n1 + n2} refs)")
-    if not (n1 or n2):
-        missing.append("README.md")
+    print(f"{'updated' if n1 else 'NO MATCH'}: README.md badge ({n1} refs)")
+    print(f"{'updated' if n2 else 'NO MATCH'}: README.md release link ({n2} refs)")
+    if not n1:
+        missing.append("README.md (version badge)")
+    if not n2:
+        missing.append("README.md (release tag link)")
 
     if missing:
         print("ERROR: version bump incomplete; patterns not found in:", file=sys.stderr)

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""Bump the application version in every place that hardcodes it.
+
+Usage:
+    python scripts/bump_version.py 5.1.0
+
+Updates (the single set of files that may legitimately carry the version):
+  - version.py                      (canonical Python source)
+  - frontend/src/version.js         (canonical frontend source — CRA can't import package.json)
+  - frontend/package.json           ("version")
+  - frontend/public/index.html      (title + description, static)
+  - README.md                       (version badge + release tag link)
+
+Run tests/test_version_consistency.py afterwards (or just `pytest -k version`) to confirm.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parent.parent
+_SEMVER = re.compile(r"^\d+\.\d+\.\d+$")
+
+
+def _replace(path: Path, pattern: str, repl: str, *, count: int = 0) -> int:
+    text = path.read_text()
+    new, n = re.subn(pattern, repl, text, count=count)
+    if n:
+        path.write_text(new)
+    return n
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Bump the app version everywhere.")
+    parser.add_argument("version", help="New semantic version, e.g. 5.1.0")
+    args = parser.parse_args()
+
+    new = args.version.strip().lstrip("v")
+    if not _SEMVER.match(new):
+        print(f"ERROR: '{new}' is not a X.Y.Z semantic version", file=sys.stderr)
+        return 2
+    minor = ".".join(new.split(".")[:2])  # e.g. 5.1
+
+    edits = {
+        _ROOT / "version.py": (r'__version__ = "\d+\.\d+\.\d+"', f'__version__ = "{new}"'),
+        _ROOT / "frontend/src/version.js": (r"APP_VERSION = '\d+\.\d+\.\d+'", f"APP_VERSION = '{new}'"),
+    }
+    for path, (pat, repl) in edits.items():
+        n = _replace(path, pat, repl)
+        print(f"{'updated' if n else 'NO MATCH'}: {path.relative_to(_ROOT)}")
+
+    # package.json — parse/dump to avoid touching other fields.
+    pkg_path = _ROOT / "frontend/package.json"
+    pkg = json.loads(pkg_path.read_text())
+    pkg["version"] = new
+    pkg_path.write_text(json.dumps(pkg, indent=2) + "\n")
+    print(f"updated: {pkg_path.relative_to(_ROOT)}")
+
+    # index.html — "Agency Core vX.Y" in title + description.
+    n = _replace(_ROOT / "frontend/public/index.html", r"Agency Core v\d+\.\d+", f"Agency Core v{minor}")
+    print(f"{'updated' if n else 'NO MATCH'}: frontend/public/index.html ({n} refs)")
+
+    # README badge + release tag link.
+    readme = _ROOT / "README.md"
+    n1 = _replace(readme, r"version-\d+\.\d+\.\d+-blue", f"version-{new}-blue")
+    n2 = _replace(readme, r"releases/tag/v\d+\.\d+\.\d+", f"releases/tag/v{new}")
+    print(f"{'updated' if (n1 or n2) else 'NO MATCH'}: README.md ({n1 + n2} refs)")
+
+    print(f"\nVersion bumped to {new}. Run: pytest -k version")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/sync_readme_gallery.py
+++ b/scripts/sync_readme_gallery.py
@@ -24,89 +24,88 @@ class GallerySection:
     screenshots: tuple[Screenshot, ...]
 
 
+# Paths point at the most recent captured screenshot set (docs/screenshots/readme/).
 GALLERY: tuple[GallerySection, ...] = (
+    GallerySection(
+        heading="### 🛰 Control Plane",
+        summary="The command center: live agent health, recent activity, and system metrics at a glance.",
+        screenshots=(Screenshot("docs/screenshots/readme/v4-control-plane.png", "Control Plane dashboard"),),
+    ),
     GallerySection(
         heading="### 🛬 Login",
         summary="People can sign in through a simple starting page instead of touching raw config files.",
-        screenshots=(Screenshot("docs/screenshots/readme/v3-login.png", "LLM Relay login"),),
+        screenshots=(Screenshot("docs/screenshots/readme/v4-login.png", "Login"),),
     ),
     GallerySection(
         heading="### 🧙 Setup Wizard",
         summary="The wizard helps you choose providers, models, runtimes, a default agent, and a cost policy.",
-        screenshots=(Screenshot("docs/screenshots/readme/v3-setup-wizard.png", "Setup Wizard"),),
+        screenshots=(Screenshot("docs/screenshots/readme/v4-setup-wizard.png", "Setup Wizard"),),
     ),
     GallerySection(
         heading="### 💬 Chat",
-        summary="This is where people talk to AI directly, using the providers and rules you set up.",
-        screenshots=(Screenshot("docs/screenshots/readme/v3-chat.png", "Direct Chat"),),
+        summary="This is where people talk to the CEO agent directly, using the providers and rules you set up.",
+        screenshots=(Screenshot("docs/screenshots/readme/v4-chat.png", "Chat"),),
     ),
     GallerySection(
         heading="### 🗂 Task Board",
         summary="This makes AI work visible. You can see what is waiting, running, blocked, in review, or done.",
-        screenshots=(Screenshot("docs/screenshots/readme/v3-tasks-kanban.png", "Kanban Task Board"),),
+        screenshots=(Screenshot("docs/screenshots/readme/v4-tasks-kanban.png", "Kanban Task Board"),),
     ),
     GallerySection(
         heading="### 🤖 Agent Roster",
         summary="This is your cast of AI helpers. Each agent can have its own model, runtime, specialty, and rules.",
-        screenshots=(Screenshot("docs/screenshots/readme/v3-agents.png", "Agent Roster"),),
+        screenshots=(Screenshot("docs/screenshots/readme/v4-agents.png", "Agent Roster"),),
     ),
     GallerySection(
         heading="### ⚙️ Runtimes",
         summary="This shows the engines behind the scenes that actually run your AI work.",
-        screenshots=(Screenshot("docs/screenshots/readme/v3-runtimes.png", "Agent Runtimes"),),
+        screenshots=(Screenshot("docs/screenshots/readme/v4-runtimes.png", "Agent Runtimes"),),
     ),
     GallerySection(
         heading="### 🛣 Routing Policy",
         summary="This is where you decide how smart, cheap, fast, or private the system should be when picking a model.",
-        screenshots=(Screenshot("docs/screenshots/readme/v3-routing.png", "Routing Policy"),),
+        screenshots=(Screenshot("docs/screenshots/readme/v4-routing.png", "Routing Policy"),),
     ),
     GallerySection(
         heading="### 🔌 Providers and Models",
         summary="This is where you connect local and cloud AI sources and decide what models are available.",
         screenshots=(
-            Screenshot("docs/screenshots/readme/v3-providers.png", "Providers", width="48%"),
-            Screenshot("docs/screenshots/readme/v3-models.png", "Models", width="48%"),
+            Screenshot("docs/screenshots/readme/v4-providers.png", "Providers", width="48%"),
+            Screenshot("docs/screenshots/readme/v4-models.png", "Models", width="48%"),
         ),
     ),
     GallerySection(
         heading="### 📚 Knowledge",
         summary="This is your team's memory: wiki pages, source material, and reusable context.",
-        screenshots=(Screenshot("docs/screenshots/readme/v3-knowledge.png", "Knowledge and Wiki"),),
+        screenshots=(Screenshot("docs/screenshots/readme/v4-knowledge.png", "Knowledge and Wiki"),),
     ),
     GallerySection(
         heading="### 🔭 Logs and activity",
-        summary="This helps you answer, ‘what just happened?’",
-        screenshots=(Screenshot("docs/screenshots/readme/v3-logs.png", "Logs"),),
+        summary="This helps you answer, ‘what just happened?’ — every LLM call, token count, latency, and cost.",
+        screenshots=(Screenshot("docs/screenshots/readme/v4-logs.png", "Logs"),),
     ),
     GallerySection(
         heading="### 🗓 Schedules",
         summary="This is how you make AI jobs run later or run again automatically.",
-        screenshots=(Screenshot("docs/screenshots/readme/v3-schedules.png", "Schedules"),),
+        screenshots=(Screenshot("docs/screenshots/readme/v4-schedules.png", "Schedules"),),
     ),
     GallerySection(
         heading="### 🧭 Settings and guardrails",
         summary="Central settings keep defaults, policies, and integrations in one place instead of scattered config files.",
-        screenshots=(Screenshot("docs/screenshots/readme/v3-settings.png", "Settings"),),
+        screenshots=(Screenshot("docs/screenshots/readme/v4-settings.png", "Settings"),),
     ),
     GallerySection(
         heading="### 🛡 Admin portal",
-        summary="This gives admins a simpler place to manage access, controls, and system behavior.",
-        screenshots=(Screenshot("docs/screenshots/readme/v3-admin.png", "Admin Portal"),),
+        summary="This gives admins a simpler place to manage access, instance activation, and system behavior.",
+        screenshots=(Screenshot("docs/screenshots/readme/v4-admin.png", "Admin Portal"),),
     ),
     GallerySection(
-        heading="### 🖥 Built-in web UI",
-        summary="The proxy also ships a lightweight built-in app at `/app`, so you can ship a useful UI without the separate hosted dashboard.",
-        screenshots=(Screenshot("docs/screenshots/webui/webui-app.png", "Built-in Web UI"),),
-    ),
-    GallerySection(
-        heading="### 🔐 Built-in admin login",
-        summary="The built-in admin surface has a dedicated login gate before exposing sensitive controls.",
-        screenshots=(Screenshot("docs/screenshots/webui/webui-admin-login.png", "Built-in admin login"),),
-    ),
-    GallerySection(
-        heading="### 🧰 Built-in admin workspace",
-        summary="Once authenticated, admins can manage providers, workspaces, and runtime metadata from the in-proxy UI.",
-        screenshots=(Screenshot("docs/screenshots/webui/webui-admin.png", "Built-in admin workspace"),),
+        heading="### 📱 Mobile",
+        summary="The dashboard is responsive — sign in, run the setup wizard, and monitor agents from a phone.",
+        screenshots=(
+            Screenshot("docs/screenshots/readme/v4-login-mobile.png", "Mobile login", width="32%"),
+            Screenshot("docs/screenshots/readme/v4-setup-mobile.png", "Mobile setup wizard", width="32%"),
+        ),
     ),
 )
 

--- a/scripts/sync_readme_gallery.py
+++ b/scripts/sync_readme_gallery.py
@@ -81,7 +81,7 @@ GALLERY: tuple[GallerySection, ...] = (
     ),
     GallerySection(
         heading="### 🔭 Logs and activity",
-        summary="This helps you answer, ‘what just happened?’ — every LLM call, token count, latency, and cost.",
+        summary="This helps you answer, 'what just happened?' — every LLM call, token count, latency, and cost.",
         screenshots=(Screenshot("docs/screenshots/readme/v4-logs.png", "Logs"),),
     ),
     GallerySection(

--- a/tests/test_activation_api.py
+++ b/tests/test_activation_api.py
@@ -1,0 +1,93 @@
+"""Tests for activation_api — instance status, OpenAPI schema, and role route.
+
+Regression coverage for two onboarding bugs:
+  1. ``/api/activation/status`` must return a non-empty instanceId so the
+     activation wizard can display it (frontend showed "unknown" when this
+     surface was unreachable).
+  2. ``change_user_role`` referenced undefined names (``_RoleUpdateResponse``,
+     ``get_db``), which crashed OpenAPI schema generation and the route itself.
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from fastapi import FastAPI, Request
+from fastapi.testclient import TestClient
+
+from activation_api import activation_router
+
+
+def _client(*, admin: bool) -> TestClient:
+    app = FastAPI()
+
+    @app.middleware("http")
+    async def inject_user(request: Request, call_next):
+        if admin:
+            request.state.user = {"email": "admin@example.com", "role": "admin"}
+        return await call_next(request)
+
+    app.include_router(activation_router)
+    return TestClient(app, raise_server_exceptions=False)
+
+
+def test_status_returns_non_empty_instance_id() -> None:
+    client = _client(admin=False)
+    r = client.get("/api/activation/status")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["instance_id"]  # must be truthy — frontend shows "unknown" otherwise
+    assert body["activated"] is False
+
+
+def test_openapi_schema_generates() -> None:
+    # Previously failed with 500 because change_user_role's return annotation
+    # (_RoleUpdateResponse) was undefined.
+    client = _client(admin=False)
+    r = client.get("/openapi.json")
+    assert r.status_code == 200
+    assert "/api/activation/users/{user_id}/role" in r.json()["paths"]
+
+
+def test_change_role_requires_authentication() -> None:
+    client = _client(admin=False)
+    r = client.post("/api/activation/users/someone@example.com/role", json={"role": "admin"})
+    assert r.status_code == 401
+
+
+def test_change_role_rejects_invalid_role() -> None:
+    client = _client(admin=True)
+    r = client.post("/api/activation/users/someone@example.com/role", json={"role": "wizard"})
+    assert r.status_code == 422
+
+
+def test_change_role_updates_existing_user() -> None:
+    class _FakeUsers:
+        async def update_one(self, query, update):
+            return SimpleNamespace(matched_count=1)
+
+    fake_store = SimpleNamespace(users=_FakeUsers())
+    client = _client(admin=True)
+    with patch("activation_api.get_store", return_value=fake_store):
+        r = client.post(
+            "/api/activation/users/someone@example.com/role",
+            json={"role": "power_user"},
+        )
+    assert r.status_code == 200
+    body = r.json()
+    assert body == {"user_id": "someone@example.com", "role": "power_user", "updated": True}
+
+
+def test_change_role_returns_404_for_missing_user() -> None:
+    class _FakeUsers:
+        async def update_one(self, query, update):
+            return SimpleNamespace(matched_count=0)
+
+    fake_store = SimpleNamespace(users=_FakeUsers())
+    client = _client(admin=True)
+    with patch("activation_api.get_store", return_value=fake_store):
+        r = client.post(
+            "/api/activation/users/ghost@example.com/role",
+            json={"role": "user"},
+        )
+    assert r.status_code == 404

--- a/tests/test_activation_selfservice.py
+++ b/tests/test_activation_selfservice.py
@@ -1,0 +1,112 @@
+"""Tests for self-service activation: env-overridable owner key, the
+ACTIVATION_REQUIRED escape hatch, and the scripts/activate.py CLI.
+
+These cover the onboarding-unblock fix: an owner/self-hoster can mint and
+install a valid activation token with their own keypair (or disable the gate
+outright) instead of emailing for a signed code.
+"""
+from __future__ import annotations
+
+import base64
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+from cryptography.hazmat.primitives.serialization import (
+    Encoding,
+    NoEncryption,
+    PrivateFormat,
+    PublicFormat,
+)
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+import activation
+from activation_api import activation_router
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _make_keypair() -> tuple[str, str]:
+    priv = Ed25519PrivateKey.generate()
+    priv_b64 = base64.b64encode(
+        priv.private_bytes(Encoding.Raw, PrivateFormat.Raw, NoEncryption())
+    ).decode()
+    pub_b64 = base64.b64encode(
+        priv.public_key().public_bytes(Encoding.Raw, PublicFormat.Raw)
+    ).decode()
+    return priv_b64, pub_b64
+
+
+def test_env_public_key_round_trip(monkeypatch) -> None:
+    priv_b64, pub_b64 = _make_keypair()
+    monkeypatch.setenv("ACTIVATION_PUBLIC_KEY_B64", pub_b64)
+
+    token = activation._generate_token_for_owner("iid-round-trip", "me@example.com", priv_b64)
+    result = activation.verify_activation_token(token, "iid-round-trip")
+
+    assert result.valid, result.error
+    assert result.email == "me@example.com"
+
+
+def test_token_bound_to_instance_id(monkeypatch) -> None:
+    priv_b64, pub_b64 = _make_keypair()
+    monkeypatch.setenv("ACTIVATION_PUBLIC_KEY_B64", pub_b64)
+
+    token = activation._generate_token_for_owner("iid-A", "me@example.com", priv_b64)
+    # A token minted for iid-A must not validate for a different instance.
+    assert not activation.verify_activation_token(token, "iid-B").valid
+
+
+def test_untrusted_key_rejected(monkeypatch) -> None:
+    # No env override → embedded owner key is trusted. A token from a random
+    # keypair must fail the signature check.
+    monkeypatch.delenv("ACTIVATION_PUBLIC_KEY_B64", raising=False)
+    priv_b64, _ = _make_keypair()
+    token = activation._generate_token_for_owner("iid-x", "x@example.com", priv_b64)
+    result = activation.verify_activation_token(token, "iid-x")
+    assert not result.valid
+    assert result.error == "Invalid signature"
+
+
+def test_activation_required_default(monkeypatch) -> None:
+    monkeypatch.delenv("ACTIVATION_REQUIRED", raising=False)
+    assert activation.activation_required() is True
+
+
+def test_activation_required_bypass(monkeypatch) -> None:
+    monkeypatch.setenv("ACTIVATION_REQUIRED", "false")
+    activation._bypass_warned = False
+    assert activation.activation_required() is False
+    assert activation.is_activated() is True
+
+
+def test_status_activated_when_gate_disabled(monkeypatch) -> None:
+    monkeypatch.setenv("ACTIVATION_REQUIRED", "false")
+    activation._bypass_warned = False
+    app = FastAPI()
+    app.include_router(activation_router)
+    client = TestClient(app, raise_server_exceptions=False)
+
+    r = client.get("/api/activation/status")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["activated"] is True
+    assert body["instance_id"]
+
+
+def test_activate_cli_mints_verifiable_token() -> None:
+    priv_b64, _ = _make_keypair()
+    env = {**os.environ, "ACTIVATION_PRIVATE_KEY_B64": priv_b64}
+    env.pop("ACTIVATION_PUBLIC_KEY_B64", None)
+
+    result = subprocess.run(
+        [sys.executable, "scripts/activate.py", "--instance-id", "cli-iid-1",
+         "--email", "cli@example.com", "--print-only"],
+        capture_output=True, text=True, env=env, cwd=str(_REPO_ROOT),
+    )
+    assert result.returncode == 0, result.stderr
+    assert "cli-iid-1" in result.stdout
+    assert "ACTIVATION_PUBLIC_KEY_B64" in result.stdout  # tells the user how to trust it

--- a/tests/test_quick_note_engine.py
+++ b/tests/test_quick_note_engine.py
@@ -1,0 +1,43 @@
+"""Guard that the quick-note engine agents use NVIDIA NIM as the primary engine
+(Anthropic/Opus is fallback-only).
+
+These scripts import the `openai` package at module load, which isn't a test
+dependency, so we assert the wiring structurally from source rather than importing
+them. The check is intentionally simple: in each model-selection site the NVIDIA
+branch must appear before the Anthropic branch.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+_SCRIPTS = Path(__file__).resolve().parent.parent / ".github" / "scripts"
+
+
+def _before(text: str, primary: str, fallback: str) -> bool:
+    i, j = text.find(primary), text.find(fallback)
+    assert i != -1, f"marker not found: {primary!r}"
+    assert j != -1, f"marker not found: {fallback!r}"
+    return i < j
+
+
+def test_implement_agent_nvidia_primary() -> None:
+    text = (_SCRIPTS / "implement_agent.py").read_text()
+    assert _before(text, "Using NVIDIA NIM as the primary engine", "Anthropic Claude Opus fallback")
+
+
+def test_implement_agent_primary_model_is_a_coder() -> None:
+    # Best-in-class coding engine: the first NVIDIA candidate should be a coder model.
+    text = (_SCRIPTS / "implement_agent.py").read_text()
+    start = text.index("NVIDIA_CANDIDATE_MODELS = [")
+    first_entry = text[start:text.index("]", start)]
+    assert "qwen/qwen3-coder" in first_entry.split("\n")[1]
+
+
+def test_review_agent_nvidia_primary() -> None:
+    text = (_SCRIPTS / "review_agent.py").read_text()
+    assert _before(text, "# Primary: NVIDIA NIM", "# Optional fallback: Anthropic")
+
+
+def test_apply_review_nvidia_primary() -> None:
+    text = (_SCRIPTS / "apply_review.py").read_text()
+    assert _before(text, "NVIDIA NIM — primary", "# Optional fallback: Claude Opus via Anthropic")

--- a/tests/test_sync_readme_gallery.py
+++ b/tests/test_sync_readme_gallery.py
@@ -11,9 +11,11 @@ from scripts.sync_readme_gallery import (
 def test_build_gallery_uses_grouped_screenshot_paths() -> None:
     gallery = build_gallery()
 
-    assert "docs/screenshots/readme/v3-login.png" in gallery
-    assert "docs/screenshots/webui/webui-admin.png" in gallery
-    assert "docs/screenshots/v3-login.png" not in gallery
+    assert "docs/screenshots/readme/v4-login.png" in gallery
+    assert "docs/screenshots/readme/v4-control-plane.png" in gallery
+    assert "docs/screenshots/v4-login.png" not in gallery
+    # webui-* screenshots don't exist in the repo and were dropped from the gallery.
+    assert "webui" not in gallery
 
 
 def test_replace_gallery_block_swaps_only_marker_region() -> None:

--- a/tests/test_version_consistency.py
+++ b/tests/test_version_consistency.py
@@ -1,0 +1,40 @@
+"""Guard the version single-source-of-truth: every place that hardcodes the
+version must agree with version.__version__. Bump them together with
+``python scripts/bump_version.py X.Y.Z``.
+"""
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+from version import __version__
+
+_ROOT = Path(__file__).resolve().parent.parent
+
+
+def test_frontend_package_json_matches() -> None:
+    pkg = json.loads((_ROOT / "frontend/package.json").read_text())
+    assert pkg["version"] == __version__
+
+
+def test_frontend_version_js_matches() -> None:
+    text = (_ROOT / "frontend/src/version.js").read_text()
+    m = re.search(r"APP_VERSION = '(\d+\.\d+\.\d+)'", text)
+    assert m, "APP_VERSION not found in frontend/src/version.js"
+    assert m.group(1) == __version__
+
+
+def test_readme_badge_matches() -> None:
+    text = (_ROOT / "README.md").read_text()
+    m = re.search(r"version-(\d+\.\d+\.\d+)-blue", text)
+    assert m, "version badge not found in README.md"
+    assert m.group(1) == __version__
+
+
+def test_index_html_has_no_stale_version() -> None:
+    text = (_ROOT / "frontend/public/index.html").read_text()
+    minor = ".".join(__version__.split(".")[:2])
+    assert f"Agency Core v{minor}" in text
+    # The old brand/version must be gone.
+    assert "LLM Relay v4.1" not in text

--- a/version.py
+++ b/version.py
@@ -1,0 +1,16 @@
+"""Single source of truth for the application version and brand.
+
+Bump with ``python scripts/bump_version.py X.Y.Z`` — that propagates this value to
+``frontend/src/version.js``, ``frontend/package.json``, ``frontend/public/index.html``,
+and the README version badge. ``tests/test_version_consistency.py`` guards against drift.
+"""
+
+from __future__ import annotations
+
+__version__ = "5.0.0"
+
+APP_NAME = "Agency Core"
+APP_TAGLINE = "Autonomous AI Platform"
+
+# Human-facing label, e.g. "Agency Core v5.0".
+APP_LABEL = f"{APP_NAME} v{'.'.join(__version__.split('.')[:2])}"


### PR DESCRIPTION
## Summary

Fixes four reported issues:

1. **Onboarding blocked (no way to activate as owner/admin).** The activation gate only
   accepted an Ed25519-signed token minted by the owner's private key, with no tool to mint
   one — locking the operator out of their own instance.
   - `scripts/activate.py`: self-mint + install an activation token for this instance (generates
     a keypair if none exists; git-ignored, `0600`).
   - `ACTIVATION_PUBLIC_KEY_B64`: trust your own keypair via env without editing source.
   - `ACTIVATION_REQUIRED=false`: opt-in (off by default) escape hatch to disable the gate.
   - `docs/runbooks/activation.md` + in-UI note document the procedure.

2. **Stale `v4.1` / wrong version everywhere.** Browser tab title, FastAPI app title, and
   `/api/platform` showed old/wrong versions.
   - `version.py` (canonical Python) + `frontend/src/version.js` (canonical frontend — CRA can't
     import `package.json` from `src/`).
   - `scripts/bump_version.py X.Y.Z` propagates to every version-bearing file in one command.
   - `tests/test_version_consistency.py` fails CI on drift.

3. **README screenshots missing.** The rewrite dropped the gallery + inject markers, and the sync
   script referenced non-existent `v3-*`/`webui-*` files. Restored a `## Screens` gallery from the
   current `docs/screenshots/readme/v4-*` set and regenerated the manifest.

4. **Opus/Bedrock quick-note engine never worked.** `implement_agent.py`, `review_agent.py`,
   `apply_review.py` now use **NVIDIA NIM as the primary engine** (Qwen3-Coder 480B first);
   Opus is optional fallback only. `tests/test_quick_note_engine.py` guards the wiring.

## Security note (activation gate — risky-module-review)
- **Changed:** added an env-configurable owner public key and an opt-in `ACTIVATION_REQUIRED=false` flag.
- **Risk:** an escape hatch could weaken the licensing gate.
- **Mitigation:** signature verification is unchanged; the flag defaults to enforced (`true`), is
  operator-only, and logs a warning when active. Reviewed via the `risky-module-review` skill.

## Test plan
- [x] `tests/test_activation_selfservice.py`, `test_activation_api.py` (13) pass
- [x] `tests/test_version_consistency.py` (4) pass
- [x] `tests/test_quick_note_engine.py` (4) pass
- [x] `tests/test_sync_readme_gallery.py` (2) pass
- [x] `scripts/activate.py` mints a verifiable token for a real instance ID
- [ ] CI (with MongoDB + admin env) green

https://claude.ai/code/session_013JGucmFEsWR8iXPcfyK898

---
_Generated by [Claude Code](https://claude.ai/code/session_013JGucmFEsWR8iXPcfyK898)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Instance activation system enabling self-service token generation for deployment security
  * Enhanced UI documentation showcasing Control Plane, activity logs, and mobile interface
  * Updated quick-note engine with improved routing options

* **Bug Fixes**
  * Fixed onboarding and activation flow issues
  * Resolved API client compatibility and response model problems

* **Branding**
  * Rebranded to Agency Core v5.0

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/strikersam/local-llm-server/pull/245?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->