### PR TITLE
fix(docker): copy version.py into Dockerfile.backend for Render deploy

### DIFF
--- a/Dockerfile.backend
+++ b/Dockerfile.backend
@@ -30,6 +30,7 @@ COPY commercial_equivalent.py commercial_equivalent.py
 COPY langfuse_obs.py langfuse_obs.py
 COPY tokens.py tokens.py
 COPY key_store.py key_store.py
+COPY version.py version.py
 COPY activation.py activation.py
 COPY activation_api.py activation_api.py
 COPY infra_cost.py infra_cost.py

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,8 @@
 ## [Unreleased]
 
+### Fixed
+- **Render deploy fix.** `Dockerfile.backend` was missing `COPY version.py version.py`, causing `ModuleNotFoundError: No module named 'version'` on every deploy since the version SSOT refactor.
+
 ### Security
 - **Frontend dependency security patches.** Bumped `qs` 6.14.2→6.15.2, `postcss` 7.0.39→8.5.13, `serialize-javascript` 4.0.0→6.0.2, and `nth-check` to resolve known CVEs in frontend build dependencies.
 - **Self-service instance activation (unblocks the owner/self-hoster).** The activation gate


### PR DESCRIPTION
## Problem
Since the version SSOT refactor landed in PR #245, `backend/server.py` imports:
```python
from version import __version__, APP_NAME, APP_LABEL, APP_TAGLINE
```
But `Dockerfile.backend` never included `COPY version.py version.py`, so the module was absent inside the container → **`ModuleNotFoundError: No module named 'version'`** on every Render deploy.

## Fix
Add `COPY version.py version.py` alongside the other root-level module copies in `Dockerfile.backend`.

## Root cause
`version.py` lives at the repo root (not in `backend/`). The Dockerfile copies specific files explicitly — adding a new root-level module requires a matching `COPY` line, which was missed when the SSOT refactor moved version info out of `backend/`.
