### PR TITLE
fix: scanner SSRF guard, fetch-failure status, BuiltWith detection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ __pycache__/
 *.py[cod]
 .venv/
 venv/
+.test-venv/
 .pytest_cache/
 .cache/
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,15 @@
 ## [Unreleased]
 
+### Security
+- **Scanner SSRF guard restored (`services/scanner.py`).** `WebsiteScanner.scan_website` now calls `_is_safe_url()` before any DNS/HTTP work and disables redirects on both the `curl_cffi` and `httpx` clients. An authenticated user can no longer point the scanner at loopback (`127.0.0.1`), the link-local cloud-metadata endpoint (`169.254.169.254`), or private/reserved ranges — directly or via a public URL that redirects inward. `_discover_sitemap` validates the derived `robots.txt` URL the same way.
+
+### Fixed
+- **Scanner no longer reports spurious success on unreachable hosts (`services/scanner.py`).** When both `curl_cffi` and the `httpx` fallback raise (DNS error, timeout, TLS failure), `scan_website` now returns `status="failed"` with the error instead of falling through to a `success` result with empty evidence (callers only reject non-success scans).
+- **Live scanner E2E tests excluded from the default suite.** `tests/test_scanner_e2e.py` is marked `integration` and `pytest.ini` excludes `-m "not integration"` by default, so CI no longer depends on third-party DNS/WAF/site availability. Run them explicitly with `pytest -m integration`.
+
+### Added
+- **BuiltWith/Wappalyzer signature detection in the website scanner.** Added the `builtwith` dependency as an extra detection source. It is fed the already-fetched HTML and headers so it never performs its own (unvalidated, redirect-following) network request, and the CPU-bound match runs in a worker thread. Results merge with the existing HTML/header and DNS heuristics. Covered by `tests/test_scanner_security.py`.
+
 ### Fixed
 - **PR #271 CodeRabbit review — CI/CD YAML fixes.** `ci.yml` pytest command was at wrong indentation (column 0 instead of 10) making the workflow invalid. `e2e.yml` had `STORAGE_BACKEND: sqlite` outside the `env:` mapping, breaking the job entirely.
 - **PR #271 CodeRabbit review — shell injection in `apply_review.py`.** Replaced `subprocess.run(cmd, shell=True)` + `# nosec B602` suppression with `shlex.split(cmd)` + `shell=False` to properly eliminate the command-injection risk.

--- a/pytest.ini
+++ b/pytest.ini
@@ -6,5 +6,8 @@ asyncio_default_fixture_loop_scope = session
 asyncio_default_test_loop_scope = session
 filterwarnings =
     ignore::pytest.PytestUnraisableExceptionWarning
+markers =
+    integration: tests that hit live external services/network (excluded by default; run with -m integration)
 # tests/e2e/ contains standalone scripts run directly (not pytest test functions)
-addopts = --ignore=tests/e2e
+# Live integration tests are excluded by default so CI does not depend on third-party site availability.
+addopts = --ignore=tests/e2e -m "not integration"

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,3 +35,4 @@ anthropic>=0.40.0
 aiosqlite>=0.19.0  # SQLite async adapter for STORAGE_BACKEND=sqlite
 curl_cffi>=0.15.0
 dnspython>=2.6.1
+builtwith>=1.3.4  # Wappalyzer-style tech signature DB; fed pre-fetched content only (no own network I/O)

--- a/services/scanner.py
+++ b/services/scanner.py
@@ -19,6 +19,7 @@ Usage:
 from __future__ import annotations
 from typing import List, Optional, Dict, Any
 from datetime import datetime
+import asyncio
 import logging
 import secrets
 import httpx
@@ -92,6 +93,24 @@ def _content_contains_domain(content: str, *domains: str) -> bool:
     return any(domain.lower() in content_lower for domain in domains)
 
 
+# Maps BuiltWith/Wappalyzer category slugs to this codebase's SystemType literal.
+# Anything not listed falls back to "custom" (a valid SystemType).
+_BUILTWITH_CATEGORY_MAP: Dict[str, str] = {
+    "cms": "CMS",
+    "ecommerce": "CMS",
+    "blogs": "CMS",
+    "wikis": "CMS",
+    "message-boards": "CMS",
+    "analytics": "analytics",
+    "payment-processors": "payment_gateway",
+    "databases": "database",
+    "cache-tools": "cache",
+    "search-engines": "search",
+    "marketing-automation": "marketing_automation",
+    "video-players": "video",
+}
+
+
 class WebsiteScanner:
     """
     Advanced Scanner for detecting technology stack and systems from websites.
@@ -132,6 +151,17 @@ class WebsiteScanner:
                 )
             
             _safe_url = parsed._replace(fragment="").geturl()
+
+            # SSRF guard: block loopback/link-local/private/reserved targets (and any
+            # host that resolves to one) before performing any DNS or HTTP work.
+            if not _is_safe_url(_safe_url):
+                return WebsiteScanResult(
+                    scan_id=scan_id, website_url=website_url, company_id=self.company_id,
+                    status="failed",
+                    errors=["Blocked: URL resolves to a private, loopback, or disallowed address"],
+                    started_at=started_at.isoformat(), completed_at=datetime.utcnow().isoformat()
+                )
+
             domain = parsed.hostname.replace('www.', '') if parsed.hostname else ""
 
             # 1. DNS Analysis (BuiltWith-level off-site detection)
@@ -142,11 +172,14 @@ class WebsiteScanner:
             headers = {}
             cookies = {}
             status_code = 0
-            
+            fetch_error: Optional[str] = None
+
+            # Redirects are disabled so a public URL cannot bounce the request to an
+            # internal/link-local address that bypasses the SSRF check above.
             try:
                 import curl_cffi.requests
                 async with curl_cffi.requests.AsyncSession(impersonate="chrome120", timeout=self.timeout) as client:
-                    response = await client.get(_safe_url, allow_redirects=True)
+                    response = await client.get(_safe_url, allow_redirects=False)
                     html = response.text
                     headers = response.headers
                     cookies = response.cookies
@@ -155,7 +188,7 @@ class WebsiteScanner:
                 log.warning(f"curl_cffi failed, falling back to httpx: {curl_e}")
                 async with httpx.AsyncClient(
                     timeout=self.timeout,
-                    follow_redirects=True,
+                    follow_redirects=False,
                     max_redirects=self.max_redirects,
                     headers={
                         "User-Agent": self.user_agent,
@@ -170,22 +203,36 @@ class WebsiteScanner:
                         cookies = response.cookies
                         status_code = response.status_code
                     except Exception as e:
+                        fetch_error = str(e)
                         log.error(f"HTTPX failed: {e}")
+
+            # If both the primary (curl_cffi) and fallback (httpx) clients failed to
+            # reach the host, surface the failure instead of returning a spurious
+            # "success" with empty evidence — callers only reject non-success scans.
+            if fetch_error is not None and not html:
+                return WebsiteScanResult(
+                    scan_id=scan_id, website_url=website_url, company_id=self.company_id,
+                    status="failed",
+                    errors=[f"Failed to fetch website: {fetch_error}"],
+                    started_at=started_at.isoformat(), completed_at=datetime.utcnow().isoformat()
+                )
 
             # Even if we get a 403, we still analyze headers and DNS!
             soup = BeautifulSoup(html, 'html.parser') if html else BeautifulSoup("", 'html.parser')
             
-            # Combine detected systems
+            # Combine detected systems from HTML/header heuristics, DNS records, and
+            # the bundled BuiltWith/Wappalyzer signature database. For a given system
+            # name the highest-confidence detection wins; ties keep the earlier source
+            # (HTML > DNS > BuiltWith).
             html_systems = await self._detect_systems(soup, html, headers, cookies, website_url)
-            
-            all_systems_map = {sys.name: sys for sys in html_systems}
-            for dns_sys in dns_systems:
-                if dns_sys.name in all_systems_map:
-                    if dns_sys.confidence > all_systems_map[dns_sys.name].confidence:
-                        all_systems_map[dns_sys.name] = dns_sys
-                else:
-                    all_systems_map[dns_sys.name] = dns_sys
-                    
+            builtwith_systems = await self._detect_with_builtwith(html, headers, _safe_url)
+
+            all_systems_map: Dict[str, DetectedSystem] = {}
+            for sys in [*html_systems, *dns_systems, *builtwith_systems]:
+                existing = all_systems_map.get(sys.name)
+                if existing is None or sys.confidence > existing.confidence:
+                    all_systems_map[sys.name] = sys
+
             detected_systems = list(all_systems_map.values())
             
             stack_inference = await self._infer_stack(soup, html, headers, website_url)
@@ -360,8 +407,52 @@ class WebsiteScanner:
         # SEARCH & VIDEO & CONSENT
         if 'algolia' in html_lower or 'algoliasearch' in html_lower: add_system('algolia', 'search', 'Algolia', 0.98, 'html', 'algolia js', 'HTML')
         if 'onetrust.com' in html_lower or 'optanon.com' in html_lower: add_system('onetrust', 'custom', 'OneTrust', 0.98, 'html', 'onetrust js', 'HTML')
-            
+
         return list(systems_map.values())
+
+    async def _detect_with_builtwith(self, html: str, headers: Any, url: str) -> List[DetectedSystem]:
+        """Run the bundled BuiltWith/Wappalyzer signature database over already-fetched
+        content.
+
+        Both ``html`` and ``headers`` are passed so the library never issues its own
+        (unvalidated, redirect-following) network request, which would otherwise bypass
+        the SSRF protections applied to the primary fetch path. The match is pure CPU
+        work over a large dataset, so it runs in a worker thread.
+        """
+        if not html:
+            return []
+        try:
+            import builtwith as builtwith_lib
+        except Exception as e:  # pragma: no cover - import guard
+            log.warning(f"builtwith library unavailable: {e}")
+            return []
+
+        headers_dict = {str(k): str(v) for k, v in dict(headers).items()} if headers else {}
+
+        def _run() -> Dict[str, List[str]]:
+            # Passing both html and headers prevents builtwith from fetching the URL.
+            return builtwith_lib.parse(url, headers=headers_dict, html=html) or {}
+
+        try:
+            results = await asyncio.to_thread(_run)
+        except Exception as e:
+            log.warning(f"builtwith analysis failed: {e}")
+            return []
+
+        systems: List[DetectedSystem] = []
+        for category, app_names in results.items():
+            sys_type = _BUILTWITH_CATEGORY_MAP.get(category, "custom")
+            for app_name in app_names:
+                if not app_name:
+                    continue
+                systems.append(DetectedSystem(
+                    system_type=sys_type, name=str(app_name), confidence=0.8,
+                    evidence=[Evidence(
+                        type="builtwith", value=f"{category}: {app_name}",
+                        location="BuiltWith signature DB", confidence=0.8,
+                    )],
+                ))
+        return systems
 
     async def _infer_stack(self, soup: BeautifulSoup, html: str, headers: Any, url: str) -> StackInference:
         html_lower = html.lower() if html else ""
@@ -423,8 +514,10 @@ class WebsiteScanner:
         # Using a fast httpx fallback just for quick sitemaps
         sitemap_urls = []
         try:
-            async with httpx.AsyncClient(timeout=5) as client:
-                robots_url = f"{base_url.rstrip('/')}/robots.txt"
+            robots_url = f"{base_url.rstrip('/')}/robots.txt"
+            if not _is_safe_url(robots_url):
+                return []
+            async with httpx.AsyncClient(timeout=5, follow_redirects=False) as client:
                 response = await client.get(robots_url)
                 if response.status_code == 200:
                     for line in response.text.split('\n'):

--- a/services/scanner.py
+++ b/services/scanner.py
@@ -43,30 +43,44 @@ import socket
 from urllib.parse import urlparse
 
 
+def _resolve_and_validate(hostname: str) -> Optional[str]:
+    """
+    Resolve hostname to an IP, validate it is not private/loopback/link-local,
+    and return the validated IP string.  Returns None if the host is unsafe or
+    unresolvable.  Callers should connect to this IP (with a Host header) so the
+    same address that was validated is the one actually used — preventing DNS
+    rebinding attacks.
+    """
+    try:
+        if not hostname:
+            return None
+        if hostname in ("localhost", "127.0.0.1", "::1", "0.0.0.0"):
+            return None
+        if hostname.endswith(".local") or hostname.endswith(".internal"):
+            return None
+        resolved = socket.getaddrinfo(hostname, None, socket.AF_UNSPEC, socket.SOCK_STREAM)
+        for _family, _, _, _, sockaddr in resolved:
+            ip = ipaddress.ip_address(sockaddr[0])
+            if ip.is_private or ip.is_loopback or ip.is_link_local or ip.is_reserved:
+                return None
+            return str(ip)  # return first safe IP
+    except (socket.gaierror, ValueError):
+        return None
+    return None
+
+
 def _is_safe_url(url: str) -> bool:
     """Block SSRF: reject loopback, link-local, private, and non-HTTP schemes."""
     try:
         parsed = urlparse(url)
-        # Only allow http/https
         if parsed.scheme not in ("http", "https"):
             return False
         hostname = parsed.hostname
         if not hostname:
             return False
-        # Block obvious internal hostnames
-        if hostname in ("localhost", "127.0.0.1", "::1", "0.0.0.0"):
-            return False
-        if hostname.endswith(".local") or hostname.endswith(".internal"):
-            return False
-        # Resolve and check IP ranges
-        resolved = socket.getaddrinfo(hostname, None, socket.AF_UNSPEC, socket.SOCK_STREAM)
-        for family, _, _, _, sockaddr in resolved:
-            ip = ipaddress.ip_address(sockaddr[0])
-            if ip.is_private or ip.is_loopback or ip.is_link_local or ip.is_reserved:
-                return False
+        return _resolve_and_validate(hostname) is not None
     except (socket.gaierror, ValueError):
         return False
-    return True
 
 
 def _hostname_is(url: str, domain: str) -> bool:
@@ -97,7 +111,7 @@ def _content_contains_domain(content: str, *domains: str) -> bool:
 # Anything not listed falls back to "custom" (a valid SystemType).
 _BUILTWITH_CATEGORY_MAP: Dict[str, str] = {
     "cms": "CMS",
-    "ecommerce": "CMS",
+    "ecommerce": "ecommerce",
     "blogs": "CMS",
     "wikis": "CMS",
     "message-boards": "CMS",
@@ -174,37 +188,75 @@ class WebsiteScanner:
             status_code = 0
             fetch_error: Optional[str] = None
 
-            # Redirects are disabled so a public URL cannot bounce the request to an
-            # internal/link-local address that bypasses the SSRF check above.
-            try:
-                import curl_cffi.requests
-                async with curl_cffi.requests.AsyncSession(impersonate="chrome120", timeout=self.timeout) as client:
-                    response = await client.get(_safe_url, allow_redirects=False)
-                    html = response.text
-                    headers = response.headers
-                    cookies = response.cookies
-                    status_code = response.status_code
-            except Exception as curl_e:
-                log.warning(f"curl_cffi failed, falling back to httpx: {curl_e}")
-                async with httpx.AsyncClient(
-                    timeout=self.timeout,
-                    follow_redirects=False,
-                    max_redirects=self.max_redirects,
-                    headers={
-                        "User-Agent": self.user_agent,
-                        "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8",
-                        "Accept-Language": "en-US,en;q=0.9",
-                    }
-                ) as client:
-                    try:
-                        response = await client.get(_safe_url)
+            # Redirects are followed manually so every hop is validated by the SSRF
+            # guard before connecting — this prevents a public URL from bouncing the
+            # request to an internal/link-local address that bypasses the check above.
+            # We also pin the resolved IP for each hop to prevent DNS rebinding.
+            fetch_url = _safe_url
+            for _redirect_hop in range(self.max_redirects + 1):
+                hop_parsed = urlparse(fetch_url)
+                hop_hostname = hop_parsed.hostname or ""
+                pinned_ip = _resolve_and_validate(hop_hostname)
+                if pinned_ip is None:
+                    fetch_error = f"Blocked: {hop_hostname} resolves to a private/unsafe address"
+                    log.warning(fetch_error)
+                    break
+
+                # Build a URL that connects to the pinned IP but preserves the Host header
+                pinned_url = fetch_url.replace(hop_hostname, pinned_ip, 1)
+                host_header = hop_hostname
+
+                try:
+                    import curl_cffi.requests
+                    async with curl_cffi.requests.AsyncSession(impersonate="chrome120", timeout=self.timeout) as client:
+                        response = await client.get(pinned_url, allow_redirects=False, headers={"Host": host_header})
                         html = response.text
                         headers = response.headers
                         cookies = response.cookies
                         status_code = response.status_code
-                    except Exception as e:
-                        fetch_error = str(e)
-                        log.error(f"HTTPX failed: {e}")
+                except Exception as curl_e:
+                    log.warning(f"curl_cffi failed, falling back to httpx: {curl_e}")
+                    async with httpx.AsyncClient(
+                        timeout=self.timeout,
+                        follow_redirects=False,
+                        headers={
+                            "Host": host_header,
+                            "User-Agent": self.user_agent,
+                            "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8",
+                            "Accept-Language": "en-US,en;q=0.9",
+                        }
+                    ) as client:
+                        try:
+                            response = await client.get(pinned_url)
+                            html = response.text
+                            headers = response.headers
+                            cookies = response.cookies
+                            status_code = response.status_code
+                        except Exception as e:
+                            fetch_error = str(e)
+                            log.error(f"HTTPX failed: {e}")
+                            break
+
+                # Follow safe redirects manually
+                if status_code in (301, 302, 303, 307, 308):
+                    location = dict(headers).get("location") or dict(headers).get("Location")
+                    if not location:
+                        break
+                    # Resolve relative redirects
+                    if location.startswith("/"):
+                        p = urlparse(fetch_url)
+                        location = f"{p.scheme}://{p.netloc}{location}"
+                    # SSRF-validate the redirect target before following
+                    if not _is_safe_url(location):
+                        log.warning(f"Blocked redirect to unsafe URL: {location}")
+                        break
+                    fetch_url = location
+                    html = ""
+                    headers = {}
+                    cookies = {}
+                    status_code = 0
+                else:
+                    break
 
             # If both the primary (curl_cffi) and fallback (httpx) clients failed to
             # reach the host, surface the failure instead of returning a spurious
@@ -514,7 +566,11 @@ class WebsiteScanner:
         # Using a fast httpx fallback just for quick sitemaps
         sitemap_urls = []
         try:
-            robots_url = f"{base_url.rstrip('/')}/robots.txt"
+            # Always fetch robots.txt from the site origin (scheme + netloc), not from
+            # the requested page path — otherwise a non-root URL like
+            # https://example.com/blog/post would probe /blog/post/robots.txt.
+            _parsed_base = urlparse(base_url)
+            robots_url = f"{_parsed_base.scheme}://{_parsed_base.netloc}/robots.txt"
             if not _is_safe_url(robots_url):
                 return []
             async with httpx.AsyncClient(timeout=5, follow_redirects=False) as client:

--- a/tests/test_scanner_e2e.py
+++ b/tests/test_scanner_e2e.py
@@ -2,6 +2,12 @@ import pytest
 import pytest_asyncio
 from services.scanner import WebsiteScanner
 
+# These tests perform live scans against third-party websites and depend on external
+# DNS/WAF/network availability. They are excluded from the default suite (see pytest.ini)
+# and only run with `pytest -m integration`.
+pytestmark = pytest.mark.integration
+
+
 @pytest.mark.asyncio
 async def test_scanner_tech_platform():
     """Test technology platform detection (e.g., Docker)"""

--- a/tests/test_scanner_security.py
+++ b/tests/test_scanner_security.py
@@ -1,0 +1,106 @@
+"""Offline regression tests for the website scanner security fixes.
+
+Covers:
+- SSRF guard (`_is_safe_url` + `scan_website` blocking internal targets).
+- Surfacing fetch failures instead of returning a spurious "success".
+- BuiltWith signature detection over pre-fetched content (no network I/O).
+
+All tests are deterministic and do not require external network access.
+"""
+import pytest
+
+from services import scanner as scanner_mod
+from services.scanner import WebsiteScanner, _is_safe_url
+
+
+def test_is_safe_url_blocks_dangerous_targets():
+    # Non-http(s) schemes
+    assert _is_safe_url("ftp://example.com") is False
+    assert _is_safe_url("file:///etc/passwd") is False
+    # Loopback / unspecified
+    assert _is_safe_url("http://127.0.0.1") is False
+    assert _is_safe_url("http://localhost") is False
+    assert _is_safe_url("http://0.0.0.0") is False
+    # Link-local (cloud metadata endpoint) and private ranges
+    assert _is_safe_url("http://169.254.169.254/latest/meta-data/") is False
+    assert _is_safe_url("http://10.0.0.5") is False
+    assert _is_safe_url("http://192.168.1.1") is False
+    # Internal-looking suffixes
+    assert _is_safe_url("http://service.internal") is False
+    assert _is_safe_url("http://db.local") is False
+
+
+def test_is_safe_url_allows_public_ip():
+    # Numeric public IP resolves to itself (no DNS needed) and is allowed.
+    assert _is_safe_url("https://8.8.8.8") is True
+
+
+@pytest.mark.asyncio
+async def test_scan_blocks_internal_target():
+    scanner = WebsiteScanner()
+    res = await scanner.scan_website("http://127.0.0.1:8000/admin")
+    assert res.status == "failed"
+    assert res.errors
+    assert any("block" in e.lower() for e in res.errors)
+
+
+@pytest.mark.asyncio
+async def test_scan_returns_failed_when_all_fetch_clients_fail(monkeypatch):
+    """When both curl_cffi and the httpx fallback raise, the scan must report
+    failure rather than a success with empty evidence."""
+    scanner = WebsiteScanner()
+
+    # Bypass the SSRF gate and DNS lookups so we exercise only the fetch path.
+    monkeypatch.setattr(scanner_mod, "_is_safe_url", lambda url: True)
+    monkeypatch.setattr(WebsiteScanner, "_analyze_dns", lambda self, domain: [])
+
+    class _FailingClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *exc):
+            return False
+
+        async def get(self, *args, **kwargs):
+            raise RuntimeError("network unreachable")
+
+    import curl_cffi.requests
+    import httpx
+
+    monkeypatch.setattr(curl_cffi.requests, "AsyncSession", _FailingClient)
+    monkeypatch.setattr(httpx, "AsyncClient", _FailingClient)
+
+    res = await scanner.scan_website("https://example.com")
+    assert res.status == "failed"
+    assert any("failed to fetch" in e.lower() for e in res.errors)
+
+
+@pytest.mark.asyncio
+async def test_detect_with_builtwith_parses_prefetched_content():
+    """BuiltWith detection runs over already-fetched html/headers and never
+    performs its own network request."""
+    scanner = WebsiteScanner()
+    html = (
+        '<html><head>'
+        '<meta name="generator" content="WordPress 5.8" />'
+        '<script src="/wp-content/themes/x/jquery.js"></script>'
+        '<script src="https://js.stripe.com/v3/"></script>'
+        "</head><body>hello</body></html>"
+    )
+    systems = await scanner._detect_with_builtwith(html, {"Server": "nginx"}, "http://example.com")
+    names = {s.name.lower() for s in systems}
+    assert "wordpress" in names
+    assert "stripe" in names
+    # Every emitted system carries a valid SystemType and builtwith evidence.
+    for s in systems:
+        assert s.confidence == 0.8
+        assert s.evidence and s.evidence[0].type == "builtwith"
+
+
+@pytest.mark.asyncio
+async def test_detect_with_builtwith_handles_empty_html():
+    scanner = WebsiteScanner()
+    assert await scanner._detect_with_builtwith("", {}, "http://example.com") == []


### PR DESCRIPTION
## Summary

Lands the security/quality fixes that PR #277's review flagged, applied directly to current `master` (where the `curl_cffi`/DNS scanner already lives — `services/scanner.py` is byte-identical on master and PR #277's branch, so master itself currently carries these bugs). Also integrates the `builtwith` library as requested.

- **SSRF guard restored (P1).** `WebsiteScanner.scan_website` now calls `_is_safe_url()` *before* any DNS/HTTP work and disables redirects on both the `curl_cffi` and `httpx` clients, so a request can't be pointed at — or redirected into — loopback (`127.0.0.1`), the link-local cloud-metadata endpoint (`169.254.169.254`), or private/reserved ranges. `_discover_sitemap` validates the derived `robots.txt` URL the same way.
- **Fetch failures surfaced (P2).** When both `curl_cffi` and the `httpx` fallback raise (DNS error, timeout, TLS failure), the scan returns `status="failed"` instead of falling through to a `success` result with empty evidence (callers only reject non-success scans).
- **Live E2E tests isolated (P2).** `tests/test_scanner_e2e.py` is marked `integration` and `pytest.ini` excludes `-m "not integration"` by default, so CI no longer depends on third-party DNS/WAF/site availability. Run them with `pytest -m integration`.
- **BuiltWith/Wappalyzer detection added.** `builtwith` is fed the already-fetched HTML and headers so it never performs its own (unvalidated) network request; the CPU-bound match runs in a worker thread and merges with the existing HTML/DNS heuristics.

This supersedes **#277**, which is now obsolete: its scanner rewrite + deps already merged to master, and its only remaining unique content reverts the deliberate brand-name anonymization from #278. #277 should be closed.

## Test plan

- [x] `pytest tests/test_scanner_security.py` — 6 offline regression tests (SSRF block, fetch-failure status, BuiltWith over pre-fetched content) pass.
- [x] `pytest.ini` change verified: live E2E tests are deselected by default (`4 deselected`).
- [x] `python -m py_compile` clean on changed files.
- [ ] CI green (Test / Lint / Bandit / CodeQL / changelog check).

https://claude.ai/code/session_01HMYwJbqCQrQsCBALMqxrns

---
_Generated by [Claude Code](https://claude.ai/code/session_01HMYwJbqCQrQsCBALMqxrns)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added signature-based technology detection using pre-fetched page content.

* **Bug Fixes**
  * Strengthened URL validation and redirect handling to block unsafe targets and prevent SSRF.
  * Scanner now reports failure when network fetches fail instead of producing spurious success.

* **Tests**
  * Marked live scanner tests as integration and added deterministic offline security tests.

* **Documentation**
  * Updated changelog with security and reliability improvements.

* **Chores**
  * Added dependency for signature detection and updated ignore rules for local virtual env.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/strikersam/local-llm-server/pull/279?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->