### PR TITLE
fix: correct broken path references in agent skills

### DIFF
--- a/.agents/skills/cooldown-resume/SKILL.md
+++ b/.agents/skills/cooldown-resume/SKILL.md
@@ -11,9 +11,9 @@ triggers:
   - process restart during an AI coding session
   - "what was I doing?"
 references:
-  - .Codex/state/agent-state.json
-  - .Codex/state/NEXT_ACTION.md
-  - .Codex/state/checkpoint.jsonl
+  - .claude/state/agent-state.json
+  - .claude/state/NEXT_ACTION.md
+  - .claude/state/checkpoint.jsonl
   - docs/runbooks/auto-resume.md
   - scripts/ai_runner.py
 ---
@@ -34,13 +34,13 @@ Use this skill immediately after:
 
 ```bash
 # Human-readable next action
-cat .Codex/state/NEXT_ACTION.md
+cat .claude/state/NEXT_ACTION.md
 
 # Machine-readable full state
-cat .Codex/state/agent-state.json
+cat .claude/state/agent-state.json
 
 # Ordered log of completed steps
-cat .Codex/state/checkpoint.jsonl
+cat .claude/state/checkpoint.jsonl
 ```
 
 Or use the AI runner:
@@ -81,13 +81,13 @@ If tests fail after resuming:
 ### Step 5 — Continue from `next_step`
 
 Execute only the steps that are NOT in `completed_steps`.
-After each sub-step completes, append to `.Codex/state/checkpoint.jsonl`:
+After each sub-step completes, append to `.claude/state/checkpoint.jsonl`:
 
 ```json
 {"ts":"<ISO8601>","step":"<step-id>","status":"done","detail":"<what was done>"}
 ```
 
-And update `.Codex/state/agent-state.json`:
+And update `.claude/state/agent-state.json`:
 - Move the step from plan to `completed_steps`
 - Update `next_step` to the following step
 - Update `last_updated`

--- a/.agents/skills/duplicate-thread/SKILL.md
+++ b/.agents/skills/duplicate-thread/SKILL.md
@@ -32,12 +32,12 @@ Clone an existing plan, task thread, or agent session so you can explore an **al
 ### Manual duplication
 
 ```bash
-bash .claude/skills/duplicate-thread/duplicate.sh <source-thread-id> <reason>
+bash .agents/skills/duplicate-thread/duplicate.sh <source-thread-id> <reason>
 ```
 
 **Example:**
 ```bash
-bash .claude/skills/duplicate-thread/duplicate.sh plan-2025-01-15 "try-async-approach"
+bash .agents/skills/duplicate-thread/duplicate.sh plan-2025-01-15 "try-async-approach"
 # Creates: .claude/threads/plan-2025-01-15--fork-try-async-approach/
 ```
 

--- a/.agents/skills/duplicate-thread/duplicate.sh
+++ b/.agents/skills/duplicate-thread/duplicate.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # duplicate.sh — duplicate-thread skill
-# Usage: bash .claude/skills/duplicate-thread/duplicate.sh <source-thread-id> <reason>
+# Usage: bash .agents/skills/duplicate-thread/duplicate.sh <source-thread-id> <reason>
 # Creates a fork of the source thread under .claude/threads/
 
 set -euo pipefail

--- a/.agents/skills/prompt-transparency/SKILL.md
+++ b/.agents/skills/prompt-transparency/SKILL.md
@@ -14,7 +14,7 @@ Inspired by the CL4R1T4S project (github.com/elder-plinius/CL4R1T4S), this skill
 ### 1. Collect All Agent & Skill Definitions
 Scan and read every file that contains behavioral instructions:
 - `.claude/agents/*.md` — named agent personas and their directives
-- `.claude/skills/*/SKILL.md` — skill behavioral definitions
+- `.agents/skills/*/SKILL.md` — skill behavioral definitions
 - `.claude/commands/*.md` — slash command behaviors
 - `CLAUDE.md` (root) — global project-level instructions (if present)
 - `.claude/state/*` — current runtime state

--- a/.agents/skills/resource-panel/SKILL.md
+++ b/.agents/skills/resource-panel/SKILL.md
@@ -41,13 +41,13 @@ The resource panel is emitted as a fenced Markdown block:
 
 At the end of your task prompt, add:
 ```
-When done, emit a resource-panel summary following .claude/skills/resource-panel/SKILL.md
+When done, emit a resource-panel summary following .agents/skills/resource-panel/SKILL.md
 ```
 
 ### Automated via shell (git-based)
 
 ```bash
-bash .claude/skills/resource-panel/summarise.sh
+bash .agents/skills/resource-panel/summarise.sh
 ```
 
 This script uses `git diff --name-only` and `git status` to auto-generate the panel for the current working tree.

--- a/.agents/skills/resource-panel/summarise.sh
+++ b/.agents/skills/resource-panel/summarise.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # summarise.sh — resource-panel skill
 # Generates a resource panel from current git working tree state
-# Usage: bash .claude/skills/resource-panel/summarise.sh [base_ref]
+# Usage: bash .agents/skills/resource-panel/summarise.sh [base_ref]
 
 BASE_REF="${1:-HEAD}"
 

--- a/.claude/state/learnings.md
+++ b/.claude/state/learnings.md
@@ -1,0 +1,17 @@
+# Session Learnings
+
+Append one entry per session using the format below.
+Each entry compounds into a growing knowledge base for future sessions.
+
+## Format
+
+```markdown
+## YYYY-MM-DD — <short title>
+
+**Context:** What was being worked on.
+**Mistake / Discovery:** What went wrong or what was learned.
+**Correction:** What the right approach is.
+**Pattern:** One-line rule to remember.
+```
+
+---


### PR DESCRIPTION
## Summary

Fixes 5 broken references across 4 skills that caused them to point to non-existent paths.

### Changes

| Skill | Issue | Fix |
|---|---|---|
| `cooldown-resume` | All state refs pointed to `.Codex/state/` (does not exist) | Updated to `.claude/state/` |
| `duplicate-thread` | Script path said `.claude/skills/` | Updated to `.agents/skills/` |
| `resource-panel` | Same wrong `.claude/skills/` path in SKILL.md and summarise.sh | Updated to `.agents/skills/` |
| `prompt-transparency` | Skill scan path was `.claude/skills/` | Updated to `.agents/skills/` |
| `wrap-up` + `session-handoff` | Referenced `.claude/state/learnings.md` which did not exist | Created the file with expected format |

### Testing

No code logic changed — these are documentation/path fixes. Existing test suite passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated agent skill documentation to reflect reorganized directory structure and updated resource paths across multiple skills.

* **Chores**
  * Consolidated agent skill organization and directory structure.
  * Implemented new session learnings tracker to capture session insights, discoveries, and identified patterns.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/strikersam/local-llm-server/pull/282?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->