### PR TITLE
chore: Friday maintenance — changelog + agent state reset (2026-05-29)

### DIFF
--- a/.claude/state/NEXT_ACTION.md
+++ b/.claude/state/NEXT_ACTION.md
@@ -1,22 +1,22 @@
-# NEXT ACTION — Agency Cycle Fresh Start
+# NEXT ACTION — Friday Maintenance Complete
 
-**Session:** `agency-cycle-fresh-2026-05-18`
+**Session:** `agency-cycle-fresh-2026-05-29`
 **Status:** Ready for next cycle
-**Last updated:** 2026-05-18T11:10:20Z
+**Last updated:** 2026-05-29T00:00:00Z
 
-## Completed this session
-- Fixed `auto-merge.yml` + `pull-request.yml`: removed non-existent `actions/setup-cli@v1`
-- Rewrote binary-corrupted `openclaw-security-automation.yml` as clean YAML
-- Fixed `agency-cycle.yml`: bumped `@v6` → `@v4`/`@v5` action versions
-- Merged PRs: #170 #171 #172 #173 #174 #180 #182 #183 #184 #186
-- Closed conflicted PR #185 (superseded by #186)
-- PR #175 (react-router-dom 7.15.1) left open — frontend test failure needs investigation
+## Completed this session (Friday maintenance sweep)
+- Audited all open PRs — none open at start of run
+- Scanned all `.github/workflows/` files for bad action versions / broken YAML / bad npm installs
+- Fixed `deploy-pages.yml`: bumped `configure-pages@v3`→`@v6`, `upload-pages-artifact@v2`→`@v5`, `deploy-pages@v2`→`@v5` (PR #287, merged)
+- All other workflow files confirmed on current action versions
+- Agent state confirmed healthy (status: ready, no blocked/failed checkpoints)
+- Changelog updated with maintenance entry
+- Agent state reset for fresh cycle
 
 ## Next cycle tasks
 1. Trigger `agency-cycle.yml` via `workflow_dispatch` or wait for 6-hour schedule
-2. Investigate PR #175 frontend test failure (`react-router-dom` 6→7 breaking changes)
-3. Monitor `openclaw-security-automation.yml` first hourly run post-fix
-4. Run `pytest -x` locally to confirm full test suite green
+2. Monitor `openclaw-security-automation.yml` hourly runs
+3. Run `pytest -x` locally to confirm full test suite green
 
 ## Resume command
 ```

--- a/.claude/state/agent-state.json
+++ b/.claude/state/agent-state.json
@@ -1,13 +1,9 @@
 {
   "schema_version": "1",
-  "session_id": "agency-cycle-fresh-2026-05-18",
+  "session_id": "agency-cycle-fresh-2026-05-29",
   "status": "ready",
-  "last_updated": "2026-05-18T21:38:25Z",
-  "next_step": "Wait for next high-priority task.",
-  "completed_steps": [
-    "fix-openclaw-security-2026-05-07",
-    "ci-workflow-fixes-2026-05-18",
-    "security-crash-correctness-fixes-2026-05-18"
-  ],
-  "notes": "Fresh start. All PRs merged (#170-#174, #180-#184, #186). Workflows fixed: auto-merge, pull-request, openclaw-security-automation, agency-cycle. Next: let agency-cycle.yml run on schedule (every 6h) or trigger via workflow_dispatch."
+  "last_updated": "2026-05-29T00:00:00Z",
+  "next_step": "Run agency-cycle.yml workflow — CEO assessment, pytest baseline, bandit scan.",
+  "completed_steps": ["weekly-maintenance-2026-05-29"],
+  "notes": "Fresh start after Friday maintenance sweep. Fixed deploy-pages.yml action versions (PR #287). No open PRs. Agent state was already healthy."
 }

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,10 @@
 ## [Unreleased]
 
+### Fixed
+- **GitHub Pages workflow action versions updated (deploy-pages.yml).** Bumped `actions/configure-pages` v3→v6, `actions/upload-pages-artifact` v2→v5, `actions/deploy-pages` v2→v5 to latest supported versions. (PR #287, Friday maintenance 2026-05-29.)
+
+
+
 ### Added
 - **Website scanner signature database expanded from 27 to ~1,270 technologies.** `services/technologies.json` is now generated from the Wappalyzer fingerprint dataset (see `scripts/build_tech_db.py`) instead of a hand-rolled 27-app stub, so the scanner identifies far more of a site's real stack — jQuery, HubSpot, Hotjar, WooCommerce, Fastly, CloudFront, webpack, modern analytics, and hundreds more. The matching engine is unchanged; this is a data fix for poor detection coverage.
 


### PR DESCRIPTION
## Friday Maintenance — 2026-05-29

- Updates changelog with PR #287 fix entry
- Resets agent state to "ready" for fresh agency cycle
- Updates NEXT_ACTION.md with maintenance summary

No code changes — docs and state files only.