### PR TITLE
feat(models): add Claude Opus 4.8 + Qwen3 base models, update routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,14 @@
 
 ---
 
+## What's New — 2026-05-29
+
+- **Claude Opus 4.8 support.** The `claude-opus-4-8` model alias and its 1M-token variant `claude-opus-4-8[1m]` are now wired into the model router. Set `ANTHROPIC_API_KEY` or AWS Bedrock credentials and the proxy automatically selects Opus 4.8 as the flagship Opus model, with the `anthropic.claude-opus-4-8` Bedrock passthrough registered for cloud deployments.
+- **`claude-haiku-4-5` convenience alias.** The dateless short-form alias now works alongside the full dated ID, matching the Anthropic convention.
+- **Qwen3 base models registered.** `qwen3:8b` and `qwen3:14b` are now in the model registry as lightweight local inference options for users pulling Qwen3 base models from Ollama.
+
+---
+
 ## What is Agency Core?
 
 Agency Core is a **self-hosted autonomous AI platform** that turns any server — your laptop, a $10 VPS, or a GPU box — into a private AI team. It ships a CEO orchestrator agent and a fleet of domain specialists that work together on real engineering and business tasks: writing code, opening pull requests, running tests, updating docs, and managing recurring operations — all without sending your data to the cloud.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,12 @@
 ## [Unreleased]
 
 ### Added
+- **Claude Opus 4.8 model support** (`router/model_router.py`, `router/registry.py`). Claude Opus 4.8 (released 2026-05-28) is now fully wired in: `claude-opus-4-8` and `claude-opus-4-8[1m]` (1M-token context variant) aliases route to the heaviest local model (deepseek-r1:671b or NIM equivalent). The `anthropic.claude-opus-4-8` Bedrock model ID is registered as a passthrough for Bedrock-configured deployments. Both entries reflect the 1M-token context window and cost_tier=3.
+- **`_opus_model()` updated to Opus 4.8** (`router/model_router.py`). When `ANTHROPIC_API_KEY` or AWS Bedrock credentials are present, the proxy now selects `claude-opus-4-8` / `anthropic.claude-opus-4-8` as the flagship Opus model instead of the previous Opus 4.6.
+- **`claude-haiku-4-5` dateless alias** (`router/model_router.py`). The dated `claude-haiku-4-5-20251001` alias now has a short dateless companion `claude-haiku-4-5`, matching the Anthropic-recommended convenience alias.
+- **Qwen3 base models in registry** (`router/registry.py`). `qwen3:8b` and `qwen3:14b` are now registered as lightweight local coder models, covering the most popular Ollama Qwen3 pull targets alongside the existing `qwen3-coder` variants.
+
+### Added
 - **Website scanner signature database expanded from 27 to ~1,270 technologies.** `services/technologies.json` is now generated from the Wappalyzer fingerprint dataset (see `scripts/build_tech_db.py`) instead of a hand-rolled 27-app stub, so the scanner identifies far more of a site's real stack — jQuery, HubSpot, Hotjar, WooCommerce, Fastly, CloudFront, webpack, modern analytics, and hundreds more. The matching engine is unchanged; this is a data fix for poor detection coverage.
 
 ### Changed

--- a/router/model_router.py
+++ b/router/model_router.py
@@ -102,9 +102,9 @@ def _opus_model() -> str | None:
     bedrock_key = os.environ.get("AWS_ACCESS_KEY_ID") or os.environ.get("BEDROCK_ACCESS_KEY")
     bedrock_secret = os.environ.get("AWS_SECRET_ACCESS_KEY") or os.environ.get("BEDROCK_SECRET_KEY")
     if bedrock_key and bedrock_secret:
-        return "us.anthropic.claude-opus-4-6-v1"
+        return "anthropic.claude-opus-4-8"
     if os.environ.get("ANTHROPIC_API_KEY"):
-        return "claude-opus-4-6"
+        return "claude-opus-4-8"
     return None
 
 
@@ -132,12 +132,16 @@ def _build_builtin_model_map() -> dict[str, str]:
     _reason = "deepseek-ai/deepseek-v4-pro" if nvidia else "deepseek-r1:32b"
 
     return {
-        # Claude 4.7 family (largest → heaviest reasoning)
+        # Claude 4.8 family (released 2026-05-28 — latest flagship)
+        "claude-opus-4-8": _largest,
+        "claude-opus-4-8[1m]": _largest,          # 1M-token context variant
+        # Claude 4.7 family
         "claude-opus-4-7": _largest,
         # Claude 4.6 family
         "claude-opus-4-6": _heavy,
         "claude-sonnet-4-6": _coder,
         "claude-haiku-4-5-20251001": _fast,
+        "claude-haiku-4-5": _fast,                 # dateless convenience alias
         # Claude 4.5 family
         "claude-opus-4-5": _heavy,
         "claude-opus-4": _heavy,

--- a/router/registry.py
+++ b/router/registry.py
@@ -288,7 +288,66 @@ _DEFAULT_REGISTRY: dict[str, ModelCapability] = {
         cost_tier=1,
         tags=["lightweight", "fast", "installed"],
     ),
+    # ── Qwen3 base models (local Ollama) ─────────────────────────────────────
+    "qwen3:8b": ModelCapability(
+        name="qwen3:8b",
+        strengths=["code_generation", "code_debugging", "tool_use", "fast_response", "conversation"],
+        context_window=32768,
+        type="coder",
+        cost_tier=1,
+        tags=["qwen3", "lightweight", "fast"],
+    ),
+    "qwen3:14b": ModelCapability(
+        name="qwen3:14b",
+        strengths=["code_generation", "code_debugging", "tool_use", "reasoning", "conversation"],
+        context_window=32768,
+        type="coder",
+        cost_tier=1,
+        tags=["qwen3"],
+    ),
+    # ── Claude 4.8 — direct Anthropic API (released 2026-05-28) ─────────────
+    "claude-opus-4-8": ModelCapability(
+        name="claude-opus-4-8",
+        strengths=[
+            "reasoning",
+            "analysis",
+            "planning",
+            "complex_tasks",
+            "code_generation",
+            "code_debugging",
+            "code_review",
+            "tool_use",
+            "long_context",
+            "conversation",
+            "data_analysis",
+        ],
+        context_window=1048576,
+        type="reasoning",
+        cost_tier=3,
+        tags=["anthropic", "claude", "flagship", "claude4"],
+    ),
     # ── AWS Bedrock — Claude 4 family ─────────────────────────────────────────
+    # Opus 4.8: current flagship (released 2026-05-28)
+    "anthropic.claude-opus-4-8": ModelCapability(
+        name="anthropic.claude-opus-4-8",
+        strengths=[
+            "reasoning",
+            "analysis",
+            "planning",
+            "complex_tasks",
+            "code_generation",
+            "code_debugging",
+            "code_review",
+            "tool_use",
+            "long_context",
+            "conversation",
+            "data_analysis",
+        ],
+        context_window=1048576,
+        type="reasoning",
+        cost_tier=3,
+        tags=["bedrock", "claude", "flagship", "claude4"],
+    ),
     # Opus 4.7: requires AWS Sales approval; listed for when access is granted
     "us.anthropic.claude-opus-4-7": ModelCapability(
         name="us.anthropic.claude-opus-4-7",

--- a/tests/test_model_router.py
+++ b/tests/test_model_router.py
@@ -154,6 +154,8 @@ def test_unknown_model_falls_to_heuristic():
         "deepseek-r1:671b",
         "qwen3-coder:235b",
         "deepseek-v3:685b",
+        "claude-opus-4-8",
+        "anthropic.claude-opus-4-8",
     )
     assert decision.selection_source in ("heuristic", "default")
 
@@ -321,6 +323,7 @@ _BEDROCK_MODEL_IDS = [
     "us.anthropic.claude-opus-4-6-v1",
     "us.anthropic.claude-sonnet-4-6",
     "us.anthropic.claude-haiku-4-5-20251001-v1:0",
+    "anthropic.claude-opus-4-8",
 ]
 
 
@@ -601,3 +604,77 @@ def test_qwen3_coder_235b_in_registry():
     cap = reg["qwen3-coder:235b"]
     assert cap.cost_tier == 3
     assert "data_analysis" in cap.strengths
+
+
+# ── Claude 4.8 (2026-05-28) ───────────────────────────────────────────────────
+
+def test_claude_opus_48_maps_to_flagship_reasoning():
+    decision = _router().route(requested_model="claude-opus-4-8")
+    assert decision.resolved_model == "deepseek-r1:671b"
+    assert decision.selection_source == "model_map"
+
+
+def test_claude_opus_48_1m_variant_maps_to_flagship():
+    decision = _router().route(requested_model="claude-opus-4-8[1m]")
+    assert decision.resolved_model == "deepseek-r1:671b"
+    assert decision.selection_source == "model_map"
+
+
+def test_claude_haiku_45_dateless_alias_maps_to_fast():
+    decision = _router().route(requested_model="claude-haiku-4-5")
+    assert decision.resolved_model == "qwen3-coder:7b"
+    assert decision.selection_source == "model_map"
+
+
+def test_claude_opus_48_in_registry():
+    reg = get_registry()
+    assert "claude-opus-4-8" in reg
+    cap = reg["claude-opus-4-8"]
+    assert cap.type == "reasoning"
+    assert cap.cost_tier == 3
+    assert cap.context_window == 1048576
+    assert "flagship" in cap.tags
+    assert "claude4" in cap.tags
+
+
+def test_anthropic_bedrock_opus_48_in_registry():
+    reg = get_registry()
+    assert "anthropic.claude-opus-4-8" in reg
+    cap = reg["anthropic.claude-opus-4-8"]
+    assert cap.type == "reasoning"
+    assert cap.cost_tier == 3
+    assert cap.context_window == 1048576
+    assert "bedrock" in cap.tags
+    assert "flagship" in cap.tags
+
+
+def test_qwen3_8b_in_registry():
+    reg = get_registry()
+    assert "qwen3:8b" in reg
+    cap = reg["qwen3:8b"]
+    assert cap.type == "coder"
+    assert cap.cost_tier == 1
+    assert "fast_response" in cap.strengths
+
+
+def test_qwen3_14b_in_registry():
+    reg = get_registry()
+    assert "qwen3:14b" in reg
+    cap = reg["qwen3:14b"]
+    assert cap.type == "coder"
+    assert "reasoning" in cap.strengths
+
+
+def test_opus_model_returns_48_with_anthropic_key(monkeypatch):
+    from router.model_router import _opus_model
+    monkeypatch.delenv("AWS_ACCESS_KEY_ID", raising=False)
+    monkeypatch.delenv("BEDROCK_ACCESS_KEY", raising=False)
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test-key")
+    assert _opus_model() == "claude-opus-4-8"
+
+
+def test_opus_model_returns_bedrock_48_with_aws_keys(monkeypatch):
+    from router.model_router import _opus_model
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "AKIATEST")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "secrettest")
+    assert _opus_model() == "anthropic.claude-opus-4-8"


### PR DESCRIPTION
Adds Claude Opus 4.8 and Qwen3 base models to the model registry and updates routing configuration.