### PR TITLE
fix(ci): fix CodeQL workflow - add push trigger, fix JS deps, disable default setup

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,6 +1,8 @@
 name: "Security CodeQL"
 
 on:
+  push:
+    branches: [master]
   pull_request:
     branches: [master]
   schedule:
@@ -34,8 +36,10 @@ jobs:
 
       - name: Install JS dependencies (for JavaScript analysis)
         if: matrix.language == 'javascript-typescript'
-        working-directory: frontend
-        run: npm install --legacy-peer-deps
+        run: |
+          if [ -f frontend/package.json ]; then
+            cd frontend && npm install --legacy-peer-deps
+          fi
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v3


### PR DESCRIPTION
## Changes
- Added `push` trigger so CodeQL scans default branch after merge
- Fixed JS dependency install path (was using `working-directory` which may not work with CodeQL's autobuild)
- Disabled default CodeQL setup (conflicted with advanced configuration, causing SARIF processing errors)

This unblocks the CodeQL workflow which was failing with: "CodeQL analyses from advanced configurations cannot be processed when the default setup is enabled"