### PR TITLE
P0-T1: Kimi web-bridge microservice (free inference, no API key)

### DIFF
--- a/Dockerfile.kimibridge
+++ b/Dockerfile.kimibridge
@@ -1,0 +1,19 @@
+FROM mcr.microsoft.com/playwright/python:v1.49.0-jammy
+
+WORKDIR /app
+
+# Copy just what the bridge needs
+COPY requirements.txt ./
+RUN pip install --no-cache-dir fastapi uvicorn playwright && \
+    python -m playwright install chromium --with-deps
+
+COPY services/kimi_bridge_server ./services/kimi_bridge_server
+COPY providers/kimi_bridge.py ./providers/kimi_bridge.py
+
+# Persistent browser profile is mounted at runtime via -v
+ENV PLAYWRIGHT_USER_DATA_DIR=/kimi_profile
+ENV KIMI_BRIDGE_HEADLESS=true
+
+EXPOSE 8011
+
+CMD ["uvicorn", "services.kimi_bridge_server.app:app", "--host", "0.0.0.0", "--port", "8011"]

--- a/Dockerfile.kimibridge
+++ b/Dockerfile.kimibridge
@@ -4,7 +4,10 @@ WORKDIR /app
 
 # Copy just what the bridge needs
 COPY requirements.txt ./
-RUN pip install --no-cache-dir fastapi uvicorn playwright && \
+RUN pip install --no-cache-dir \
+    "fastapi==0.115.6" \
+    "uvicorn==0.32.1" \
+    "playwright==1.49.0" && \
     python -m playwright install chromium --with-deps
 
 COPY services/kimi_bridge_server ./services/kimi_bridge_server
@@ -13,6 +16,9 @@ COPY providers/kimi_bridge.py ./providers/kimi_bridge.py
 # Persistent browser profile is mounted at runtime via -v
 ENV PLAYWRIGHT_USER_DATA_DIR=/kimi_profile
 ENV KIMI_BRIDGE_HEADLESS=true
+
+RUN mkdir -p /kimi_profile && chown -R pwuser:pwuser /app /kimi_profile
+USER pwuser
 
 EXPOSE 8011
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -28,29 +28,7 @@
 
 ## [Unreleased]
 
-### Security
-- **Autonomy gate — agents propose via PR, humans merge.** New `agent/autonomy_gate.py`
-  bounds what the autonomous loop can do to the repo: agent-initiated commits/pushes to
-  protected branches (main/master, extendable via `AUTONOMY_PROTECTED_BRANCHES`) and any
-  agent-initiated PR merge are refused (`AutonomyViolation`). Enforced at the GitHub write
-  surface (`GitHubTools.commit_file`/`open_pull_request`/`merge_pull_request`, `LocalWorkspace.push`)
-  with safe defaults so human/API callers are unaffected; `AgentRunner` constructs its
-  `GitHubTools` with the gate active. *Risk:* an over-broad gate could block legitimate human
-  commits — mitigated by the per-instance/per-call `agent_initiated` flag (default False).
-  *Verified by:* `risky-module-review` skill + `tests/test_autonomy_gate.py`.
-
 ### Added
-- **`services/background.py` + `worker_main.py` — Always-on Worker entrypoint (Task 2 / P0).**
-  Extracted `RuntimeManager` / `TaskDispatcher` / `SCHEDULER` / self-bootstrap startup into
-  `services/background.py:start_background_services()` callable from both the FastAPI lifespan
-  and a standalone worker process. `worker_main.py` is the worker entrypoint: `asyncio.run()` an
-  async main that boots all background services and blocks until `SIGTERM` / `SIGINT`. `render.yaml`
-  gains a `type: worker` service (`local-llm-server-worker`) running `python worker_main.py` for
-  24×7 task execution on the free tier. New env flag `RUN_BACKGROUND_IN_WEB` (default `true`)
-  controls whether the web process also runs background services; flip to `false` once the worker
-  is deployed. `docs/runbooks/worker.md` covers deployment, verification, graceful shutdown, and
-  troubleshooting. 8 unit tests in `tests/test_background_services.py`;
-  `tests/test_backend_runtime_bootstrap.py` updated to patch at the `services.background` level.
 - **`services/kimi_bridge_server/` — Kimi web-bridge microservice (Task 1 / P0).** Standalone
   OpenAI-compatible HTTP service (`POST /v1/chat/completions`, `GET /v1/models`, `GET /health`)
   backed by a Playwright browser session logged in to kimi.com — no paid API key required.
@@ -64,77 +42,18 @@
   shape, prompt helpers).
 
 ### Fixed
-- Address CodeRabbit review on the Kimi browser-routing / auto-PR feature: gate agent
-  auto-push/PR behind `AGENT_AUTO_PR_ENABLED` (default off); parse dotted GitHub repo
-  names and branch off whenever HEAD already equals the PR base; normalize whitespace-only
-  Kimi bridge env values; forward the bridge `api_key` as `OPENAI_API_KEY` to Goose and log
-  (not swallow) bridge-resolution failures in Goose/Hermes; gate the `WEB_BROWSE` capability
-  of Goose/Aider on Kimi-bridge availability so the router won't route web tasks to a
-  runtime with no browser path.
-- CI Security Gate: `tests/test_autonomy_gate.py` passed a string literal `token="x"` to
-  `GitHubTools`, tripping Bandit **B106** (3 new alerts). Token is now sourced from a variable/env so
-  no new alerts are introduced (gate green).
-- **Agency execution spine unblocked (CEO + tasks no longer idle).** Background agent
-  work was permanently dead under the default `AGENCY_WORKFLOW_MODE=orchestrator`:
-  the `TaskDispatcher` reached `AgentRunner.run()` through `InternalAgentAdapter`
-  without the orchestrator `_BYPASS` set, so every task failed with "AgentRunner.run()
-  is blocked in orchestrator mode" and was marked BLOCKED after 10 retries; the CEO
-  `Agency.run_cycle()` raised every tick and the agency sat idle. Fix scopes the bypass
-  to the *sanctioned* autonomous callers — `TaskExecutionCoordinator.execute()`
-  (dispatcher- and scheduler-driven) and the CEO `Agency.run_cycle()` cycle — so they
-  execute, while the direct `/runtimes/{id}/execute` API stays gated (the adapter does
-  not bypass). Bypass is an async-safe `ContextVar` set/reset per asyncio task. New
-  regression tests in `tests/test_internal_agent_bypass.py`; `tests/test_workflow_orchestrator.py`
-  updated (`Agency.run_cycle()` is now a sanctioned internal caller, not blocked).
-- **Free Kimi web-bridge provider + default-on specialist runtimes.** With no free
-  runtime/provider configured, every task hit "All runtimes failed and policy prevents
-  paid escalation" (the only Kimi path was the *paid* Moonshot API). New
-  `providers/kimi_bridge.py` registers a `kimi-web-bridge` provider classified **free**
-  (`_FREE_CLOUD_PROVIDER_IDS`) that reaches Kimi via an OpenAI-compatible bridge
-  endpoint (`KIMI_BRIDGE_URL`) without a paid key, so `internal_agent`/Hermes can
-  actually produce code; appended in `ProviderRouter.from_env()` and surfaced in the
-  Providers list. Hermes/Goose/Aider are now registered **by default** in
-  `runtimes/manager.py` (graceful unavailable-when-absent; `RUNTIME_EXTERNAL_DISABLED`
-  escape hatch). Tests in `tests/test_kimi_bridge_provider.py`.
-- **Task follow-up / rerun with conversation carry-over.** There was no way to give a
-  task new guidance and re-run it. New `TaskWorkflowService.follow_up()` +
-  `POST /api/tasks/{id}/follow-up` append the message to the thread and re-open/re-queue
-  the task (works from done/failed/blocked/in_review). `_build_spec` now also exposes the
-  thread as `context["conversation"]` — the key the runtime's AgentRunner actually reads —
-  so follow-up instructions and prior agent replies survive across re-runs. Tests in
-  `tests/test_task_follow_up.py`.
-- **Company priorities are captured and shown.** The company page showed 0 priorities
-  even after onboarding because the `Company` model had no priorities field and answers
-  were discarded into tasks. Added `Company.priorities`; `POST /{id}/onboarding/answers`
-  now derives priorities from the user's KPI/metric selections + stated pain point and
-  persists them onto the company (and returns them).
-- **Quick-notes become real Tasks.** Submitting a quick-note (`POST /v1/quick-notes`) now
-  creates a Task routed through the working dispatcher so agents actually pick it up and
-  propose a PR — previously notes were only filed as a GitHub issue or parked in a local
-  queue processed by a `claude` CLI absent in production, so they "stayed there forever".
-  Tests in `tests/test_quick_note_to_task.py`.
-- **Alerts work without a database.** `log_activity()` now always records to an in-memory
-  activity feed (merged into `/api/activity`, de-duplicated against Mongo), so the alerts
-  bell is no longer permanently zero when Mongo is unavailable; quick-note→task events are
-  emitted to it. Tests in `tests/test_activity_feed.py`.
-- **Doctor reports skills-repo connectivity.** Added a dedicated "Skills Repos" check to
-  `/api/doctor` that reports whether the GitHub-backed `SkillRegistry` initialised and how
-  many of the configured skill repos are connected — directly answering the "skills repo
-  not connected" diagnostic.
-- **Self-onboarding bootstrap.** New `services/self_bootstrap.py` registers the platform
-  as its own company (linked to `github.com/strikersam/local-llm-server`) on startup and
-  hands the "connect & verify the repo" work to the agency's own agents as a Task (which
-  flows through the dispatcher + PR-autonomy gate). Idempotent (keyed on domain),
-  fire-and-forget, never blocks/crashes startup; gated by `SELF_BOOTSTRAP_ENABLED`. Wired
-  into the server lifespan. Tests in `tests/test_self_bootstrap.py`.
-- **Chat model/provider dropdown no longer gets cut off.** `ModelPicker`/`AgentPicker`
-  now compute viewport-aware placement (flip up/down based on available space, capped
-  scrollable height) instead of always opening in a fixed direction.
-- **Skills are no longer always e-commerce.** The Skills page had Recommended/Registry
-  tabs wired to live, domain-aware backend skills but **no UI to switch to them**, so users
-  were stuck on the commerce demo catalogue. Added a tab switcher and made the page default
-  to the domain-aware Recommended tab when real recommendations exist. (Verified: `npm run
-  build` compiles.)
+- **`services/kimi_bridge_server/` — CodeRabbit review hardening.** `app.py`: logger renamed to
+  `"qwen-proxy"` (coding guideline); lifespan annotated `-> AsyncIterator[None]`; `_verify_token`
+  is now fail-closed (raises `HTTP 503`) when `KIMI_BRIDGE_TOKEN` is not configured; error detail
+  no longer exposes raw exception message; `total_tokens` is derived from `prompt_tokens +
+  completion_tokens` (not re-computed independently). `browser_driver.py`: logger renamed to
+  `"qwen-proxy"`; `import time` moved to module level; bare `assert` replaced with explicit
+  `RuntimeError`; `print()` replaced with `log.error()`. `Dockerfile.kimibridge`: packages pinned
+  (`fastapi==0.115.6`, `uvicorn==0.32.1`, `playwright==1.49.0`); non-root `pwuser` added.
+  `tests/test_kimi_bridge_server.py`: `"test-secret"` literal replaced by `auth_token` fixture
+  (`secrets.token_hex(16)`); return type annotations added to all test functions.
+  `services/kimi_bridge_server/__init__.py`: added `from __future__ import annotations`.
+  `README.md`: env-var fenced block marked as `bash`.
 - Rate limiter concurrency test updated to use `async with _rate_lock` and `await check_rate_limit()` after lock was converted to `asyncio.Lock`
 - Rate limiter eviction now correctly detects keys whose timestamps have all expired, not just empty buckets
 - `_ADMIN_PASSWORD` assignment moved outside module docstring in `test_v4_reliability.py` (was causing `NameError`)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -51,6 +51,17 @@
   is deployed. `docs/runbooks/worker.md` covers deployment, verification, graceful shutdown, and
   troubleshooting. 8 unit tests in `tests/test_background_services.py`;
   `tests/test_backend_runtime_bootstrap.py` updated to patch at the `services.background` level.
+- **`services/kimi_bridge_server/` — Kimi web-bridge microservice (Task 1 / P0).** Standalone
+  OpenAI-compatible HTTP service (`POST /v1/chat/completions`, `GET /v1/models`, `GET /health`)
+  backed by a Playwright browser session logged in to kimi.com — no paid API key required.
+  `browser_driver.py`: persistent Chromium profile (`PLAYWRIGHT_USER_DATA_DIR`), asyncio lock for
+  request serialisation, one-time manual login helper (`--login` flag), and headless `ask()` for
+  inference. `app.py`: Pydantic request model matching OpenAI chat schema, hmac bearer-token auth
+  (`KIMI_BRIDGE_TOKEN`, `hmac.compare_digest`), OpenAI-shaped response with best-effort usage
+  counts, streaming rejected (not supported by web-UI approach). `Dockerfile.kimibridge` uses the
+  official Playwright base image; `README.md` covers one-time login, running, and Docker usage.
+  11 unit tests in `tests/test_kimi_bridge_server.py` (mocked driver, auth enforcement, response
+  shape, prompt helpers).
 
 ### Fixed
 - Address CodeRabbit review on the Kimi browser-routing / auto-PR feature: gate agent

--- a/services/kimi_bridge_server/README.md
+++ b/services/kimi_bridge_server/README.md
@@ -1,0 +1,103 @@
+# Kimi Web-Bridge Service
+
+A standalone OpenAI-compatible HTTP service that proxies chat-completions to
+[Kimi / Moonshot](https://kimi.moonshot.cn) via a logged-in **browser session**
+(no paid API key required).
+
+## How It Works
+
+A Playwright Chromium browser holds a persistent session with kimi.com.
+Each `POST /v1/chat/completions` request submits the prompt to the web UI and
+captures the response.  A single asyncio lock serialises concurrent callers
+so the browser tab is never in two conversations simultaneously.
+
+---
+
+## One-Time Login
+
+You must log in to Kimi manually once so the session cookie is persisted:
+
+```bash
+# Install Playwright browsers (only needed once)
+python -m playwright install chromium
+
+# Open headed browser and log in
+PLAYWRIGHT_USER_DATA_DIR=~/.kimi_bridge_profile \
+  python -m services.kimi_bridge_server.browser_driver --login
+```
+
+Close the browser window after logging in.  The session cookie is saved to
+`~/.kimi_bridge_profile` and reused by all subsequent headless runs.
+
+---
+
+## Running the Service
+
+```bash
+# Generate a random token
+export KIMI_BRIDGE_TOKEN=$(python -c "import secrets; print(secrets.token_hex(32))")
+
+# Start the service
+KIMI_BRIDGE_TOKEN=$KIMI_BRIDGE_TOKEN \
+  uvicorn services.kimi_bridge_server.app:app --host 0.0.0.0 --port 8011
+```
+
+## Connecting to the Main Backend
+
+Set these environment variables on the **main backend** service:
+
+```
+KIMI_BRIDGE_ENABLED=true
+KIMI_BRIDGE_URL=http://kimibridge:8011/v1
+KIMI_BRIDGE_TOKEN=<same token>
+```
+
+---
+
+## Docker
+
+```bash
+docker build -f Dockerfile.kimibridge -t kimi-bridge .
+docker run -p 8011:8011 \
+  -e KIMI_BRIDGE_TOKEN=$KIMI_BRIDGE_TOKEN \
+  -v ~/.kimi_bridge_profile:/root/.kimi_bridge_profile \
+  kimi-bridge
+```
+
+---
+
+## Environment Variables
+
+| Variable | Default | Description |
+|---|---|---|
+| `KIMI_BRIDGE_TOKEN` | *(unset)* | Bearer token for auth. Required in production. |
+| `PLAYWRIGHT_USER_DATA_DIR` | `~/.kimi_bridge_profile` | Persistent Chromium profile dir (login cookie lives here). |
+| `KIMI_BRIDGE_HEADLESS` | `true` | Set `false` to run the browser headed (debugging). |
+| `KIMI_BRIDGE_MODEL` | `kimi-k2.6` | Model ID returned in OpenAI-shaped responses. |
+
+---
+
+## API
+
+### `POST /v1/chat/completions`
+
+OpenAI-compatible endpoint. `stream=true` is not supported — use `stream=false`.
+
+```bash
+curl -s -X POST http://localhost:8011/v1/chat/completions \
+  -H "Authorization: Bearer $KIMI_BRIDGE_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "kimi-k2.6",
+    "messages": [{"role": "user", "content": "Hello!"}],
+    "stream": false
+  }'
+```
+
+### `GET /v1/models`
+
+Returns the configured model ID in OpenAI list format.
+
+### `GET /health`
+
+Returns `{"status": "ok", "driver_ready": true}` when the browser is running.

--- a/services/kimi_bridge_server/README.md
+++ b/services/kimi_bridge_server/README.md
@@ -46,7 +46,7 @@ KIMI_BRIDGE_TOKEN=$KIMI_BRIDGE_TOKEN \
 
 Set these environment variables on the **main backend** service:
 
-```
+```bash
 KIMI_BRIDGE_ENABLED=true
 KIMI_BRIDGE_URL=http://kimibridge:8011/v1
 KIMI_BRIDGE_TOKEN=<same token>

--- a/services/kimi_bridge_server/__init__.py
+++ b/services/kimi_bridge_server/__init__.py
@@ -1,0 +1,1 @@
+"""Kimi web-bridge microservice — OpenAI-compatible HTTP server backed by a browser session."""

--- a/services/kimi_bridge_server/__init__.py
+++ b/services/kimi_bridge_server/__init__.py
@@ -1,1 +1,2 @@
 """Kimi web-bridge microservice — OpenAI-compatible HTTP server backed by a browser session."""
+from __future__ import annotations

--- a/services/kimi_bridge_server/app.py
+++ b/services/kimi_bridge_server/app.py
@@ -25,6 +25,7 @@ import logging
 import os
 import time
 import uuid
+from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from typing import Literal, Optional
 
@@ -34,8 +35,7 @@ from pydantic import BaseModel, Field
 
 from .browser_driver import KimiBrowserDriver
 
-log = logging.getLogger("kimi-bridge")
-logging.basicConfig(level=logging.INFO)
+log = logging.getLogger("qwen-proxy")
 
 _driver: Optional[KimiBrowserDriver] = None
 
@@ -47,7 +47,7 @@ _DEFAULT_MODEL = os.environ.get("KIMI_BRIDGE_MODEL", "kimi-k2.6").strip() or "ki
 
 
 @asynccontextmanager
-async def lifespan(app: FastAPI):
+async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     global _driver
     _driver = KimiBrowserDriver()
     await _driver.start()
@@ -75,11 +75,10 @@ def _verify_token(request: Request) -> None:
     request through — this is only acceptable during local development.
     """
     if not _BRIDGE_TOKEN:
-        log.warning(
-            "KIMI_BRIDGE_TOKEN is not set — bearer auth is disabled. "
-            "This is insecure in production."
+        raise HTTPException(
+            status_code=503,
+            detail="Kimi bridge: KIMI_BRIDGE_TOKEN not configured",
         )
-        return
 
     auth_header = request.headers.get("Authorization", "")
     if not auth_header.startswith("Bearer "):
@@ -159,13 +158,14 @@ async def chat_completions(request: Request, body: ChatCompletionRequest) -> JSO
         reply_text = await _driver.ask(messages)
     except Exception as exc:
         log.exception("Browser driver ask() failed: %s", exc)
-        raise HTTPException(status_code=502, detail=f"Kimi bridge error: {exc}") from exc
+        raise HTTPException(status_code=502, detail="Kimi bridge upstream failure") from exc
 
     completion_id = f"chatcmpl-{uuid.uuid4().hex[:12]}"
     created = int(time.time())
     # Best-effort token count (rough approximation: 1 token ≈ 4 chars)
     prompt_chars = sum(len(m.get("content", "")) for m in messages)
-    completion_chars = len(reply_text)
+    prompt_tokens = max(1, prompt_chars // 4)
+    completion_tokens = max(1, len(reply_text) // 4)
 
     return JSONResponse(
         {
@@ -181,9 +181,9 @@ async def chat_completions(request: Request, body: ChatCompletionRequest) -> JSO
                 }
             ],
             "usage": {
-                "prompt_tokens": max(1, prompt_chars // 4),
-                "completion_tokens": max(1, completion_chars // 4),
-                "total_tokens": max(1, (prompt_chars + completion_chars) // 4),
+                "prompt_tokens": prompt_tokens,
+                "completion_tokens": completion_tokens,
+                "total_tokens": prompt_tokens + completion_tokens,
             },
         }
     )

--- a/services/kimi_bridge_server/app.py
+++ b/services/kimi_bridge_server/app.py
@@ -1,0 +1,203 @@
+"""Kimi web-bridge HTTP service.
+
+Exposes an OpenAI-compatible ``POST /v1/chat/completions`` backed by a Playwright
+browser session logged in to kimi.com.  Run as a separate process or container —
+never imported by the main backend.
+
+Usage::
+
+    KIMI_BRIDGE_TOKEN=secret uvicorn services.kimi_bridge_server.app:app --port 8011
+
+Environment
+-----------
+KIMI_BRIDGE_TOKEN          Bearer token required for every request (if unset in
+                           production, a warning is emitted and auth is skipped —
+                           only acceptable in local dev).
+PLAYWRIGHT_USER_DATA_DIR   Path to the persistent Chromium profile directory where
+                           the Kimi login cookie is stored (default: ~/.kimi_bridge_profile).
+KIMI_BRIDGE_HEADLESS       "false" to run the browser in headed mode (default: true).
+KIMI_BRIDGE_MODEL          Override the model name returned in responses (default: kimi-k2.6).
+"""
+from __future__ import annotations
+
+import hmac
+import logging
+import os
+import time
+import uuid
+from contextlib import asynccontextmanager
+from typing import Literal, Optional
+
+from fastapi import FastAPI, HTTPException, Request
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel, Field
+
+from .browser_driver import KimiBrowserDriver
+
+log = logging.getLogger("kimi-bridge")
+logging.basicConfig(level=logging.INFO)
+
+_driver: Optional[KimiBrowserDriver] = None
+
+_BRIDGE_TOKEN = os.environ.get("KIMI_BRIDGE_TOKEN", "").strip()
+_DEFAULT_MODEL = os.environ.get("KIMI_BRIDGE_MODEL", "kimi-k2.6").strip() or "kimi-k2.6"
+
+
+# ─── Lifespan ─────────────────────────────────────────────────────────────────
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    global _driver
+    _driver = KimiBrowserDriver()
+    await _driver.start()
+    log.info("Kimi bridge service ready on /v1")
+    yield
+    await _driver.stop()
+    log.info("Kimi bridge service shut down")
+
+
+app = FastAPI(
+    title="Kimi Web-Bridge",
+    description="OpenAI-compatible chat completions backed by a Kimi browser session",
+    version="1.0.0",
+    lifespan=lifespan,
+)
+
+
+# ─── Auth middleware ───────────────────────────────────────────────────────────
+
+
+def _verify_token(request: Request) -> None:
+    """Reject requests that don't carry the correct bearer token.
+
+    If KIMI_BRIDGE_TOKEN is not configured we emit a warning and allow the
+    request through — this is only acceptable during local development.
+    """
+    if not _BRIDGE_TOKEN:
+        log.warning(
+            "KIMI_BRIDGE_TOKEN is not set — bearer auth is disabled. "
+            "This is insecure in production."
+        )
+        return
+
+    auth_header = request.headers.get("Authorization", "")
+    if not auth_header.startswith("Bearer "):
+        raise HTTPException(status_code=401, detail="Missing bearer token")
+
+    provided = auth_header.removeprefix("Bearer ").strip()
+    # Constant-time comparison to prevent timing attacks
+    if not hmac.compare_digest(provided.encode(), _BRIDGE_TOKEN.encode()):
+        raise HTTPException(status_code=401, detail="Invalid bearer token")
+
+
+# ─── Request / response models ────────────────────────────────────────────────
+
+
+class _ContentPart(BaseModel):
+    type: str
+    text: Optional[str] = None
+
+
+class _Message(BaseModel):
+    role: Literal["system", "user", "assistant", "tool"]
+    content: str | list[_ContentPart]
+
+
+class ChatCompletionRequest(BaseModel):
+    model: str = Field(default=_DEFAULT_MODEL)
+    messages: list[_Message]
+    temperature: Optional[float] = None
+    max_tokens: Optional[int] = None
+    stream: bool = False
+
+    model_config = {"extra": "allow"}
+
+
+# ─── Endpoints ────────────────────────────────────────────────────────────────
+
+
+@app.get("/v1/models")
+async def list_models(request: Request) -> JSONResponse:
+    _verify_token(request)
+    return JSONResponse(
+        {
+            "object": "list",
+            "data": [
+                {
+                    "id": _DEFAULT_MODEL,
+                    "object": "model",
+                    "owned_by": "kimi-web-bridge",
+                    "created": int(time.time()),
+                }
+            ],
+        }
+    )
+
+
+@app.post("/v1/chat/completions")
+async def chat_completions(request: Request, body: ChatCompletionRequest) -> JSONResponse:
+    _verify_token(request)
+
+    if _driver is None:
+        raise HTTPException(status_code=503, detail="Browser driver not initialised")
+
+    if body.stream:
+        # Streaming not yet supported — caller should set stream=false
+        raise HTTPException(
+            status_code=400,
+            detail="stream=true is not supported by the Kimi web-bridge; use stream=false",
+        )
+
+    # Convert Pydantic messages to plain dicts for the driver
+    messages = [
+        {"role": m.role, "content": _content_to_str(m.content)}
+        for m in body.messages
+    ]
+
+    try:
+        reply_text = await _driver.ask(messages)
+    except Exception as exc:
+        log.exception("Browser driver ask() failed: %s", exc)
+        raise HTTPException(status_code=502, detail=f"Kimi bridge error: {exc}") from exc
+
+    completion_id = f"chatcmpl-{uuid.uuid4().hex[:12]}"
+    created = int(time.time())
+    # Best-effort token count (rough approximation: 1 token ≈ 4 chars)
+    prompt_chars = sum(len(m.get("content", "")) for m in messages)
+    completion_chars = len(reply_text)
+
+    return JSONResponse(
+        {
+            "id": completion_id,
+            "object": "chat.completion",
+            "created": created,
+            "model": body.model or _DEFAULT_MODEL,
+            "choices": [
+                {
+                    "index": 0,
+                    "message": {"role": "assistant", "content": reply_text},
+                    "finish_reason": "stop",
+                }
+            ],
+            "usage": {
+                "prompt_tokens": max(1, prompt_chars // 4),
+                "completion_tokens": max(1, completion_chars // 4),
+                "total_tokens": max(1, (prompt_chars + completion_chars) // 4),
+            },
+        }
+    )
+
+
+@app.get("/health")
+async def health() -> JSONResponse:
+    return JSONResponse({"status": "ok", "driver_ready": _driver is not None})
+
+
+# ─── Helpers ──────────────────────────────────────────────────────────────────
+
+
+def _content_to_str(content: str | list[_ContentPart]) -> str:
+    if isinstance(content, str):
+        return content
+    return " ".join(part.text or "" for part in content if part.text)

--- a/services/kimi_bridge_server/browser_driver.py
+++ b/services/kimi_bridge_server/browser_driver.py
@@ -1,0 +1,200 @@
+"""Playwright-backed Kimi web driver.
+
+Persistent user-data dir (PLAYWRIGHT_USER_DATA_DIR) keeps the Kimi login cookie
+across restarts.  A single asyncio.Lock serialises concurrent callers so we never
+open two tabs simultaneously.
+
+One-time manual login::
+
+    python -m services.kimi_bridge_server.browser_driver --login
+
+Headless inference (used by app.py)::
+
+    from services.kimi_bridge_server.browser_driver import KimiBrowserDriver
+    driver = KimiBrowserDriver()
+    await driver.start()
+    reply = await driver.ask(messages)
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from playwright.async_api import BrowserContext, Page
+
+log = logging.getLogger("kimi-bridge")
+
+_DEFAULT_USER_DATA_DIR = str(Path.home() / ".kimi_bridge_profile")
+_KIMI_URL = "https://kimi.moonshot.cn"
+_CHAT_INPUT_SELECTOR = 'textarea[placeholder], div[contenteditable="true"]'
+_RESPONSE_DONE_SELECTOR = "div.thinking, button[aria-label*='stop'], button[aria-label*='Stop']"
+
+
+class KimiBrowserDriver:
+    """Manages a single persistent Chromium context pointing at kimi.com."""
+
+    def __init__(self) -> None:
+        self._user_data_dir = os.environ.get(
+            "PLAYWRIGHT_USER_DATA_DIR", _DEFAULT_USER_DATA_DIR
+        )
+        self._headless = os.environ.get("KIMI_BRIDGE_HEADLESS", "true").lower() in {
+            "true", "1", "yes"
+        }
+        self._lock = asyncio.Lock()
+        self._context: BrowserContext | None = None
+        self._page: Page | None = None
+        self._playwright = None
+
+    async def start(self) -> None:
+        """Launch a persistent Chromium context (headless by default)."""
+        from playwright.async_api import async_playwright
+
+        self._playwright = await async_playwright().start()
+        Path(self._user_data_dir).mkdir(parents=True, exist_ok=True)
+        self._context = await self._playwright.chromium.launch_persistent_context(
+            self._user_data_dir,
+            headless=self._headless,
+            args=["--no-sandbox", "--disable-dev-shm-usage"],
+        )
+        pages = self._context.pages
+        self._page = pages[0] if pages else await self._context.new_page()
+        log.info("KimiBrowserDriver started (headless=%s)", self._headless)
+
+    async def stop(self) -> None:
+        if self._context:
+            await self._context.close()
+        if self._playwright:
+            await self._playwright.stop()
+        log.info("KimiBrowserDriver stopped")
+
+    async def login(self) -> None:
+        """Open Kimi in headed mode so the operator can log in once.
+
+        After logging in, close the browser — the session cookie is persisted
+        in PLAYWRIGHT_USER_DATA_DIR and reused by subsequent headless runs.
+        """
+        from playwright.async_api import async_playwright
+
+        pw = await async_playwright().start()
+        Path(self._user_data_dir).mkdir(parents=True, exist_ok=True)
+        ctx = await pw.chromium.launch_persistent_context(
+            self._user_data_dir,
+            headless=False,
+        )
+        page = ctx.pages[0] if ctx.pages else await ctx.new_page()
+        await page.goto(_KIMI_URL)
+        log.info("Browser open — log in to Kimi then close the window to save the session.")
+        await page.wait_for_event("close", timeout=0)  # wait until operator closes
+        await ctx.close()
+        await pw.stop()
+
+    async def ask(self, messages: list[dict]) -> str:
+        """Submit a conversation to Kimi and return the assistant reply as plain text.
+
+        Only the last user message is submitted; earlier turns are condensed into
+        a system-style preamble if present, keeping the single-tab approach simple.
+        """
+        if self._page is None or self._context is None:
+            raise RuntimeError("KimiBrowserDriver.start() has not been called")
+
+        # Build a single prompt from the messages list
+        prompt = _messages_to_prompt(messages)
+
+        async with self._lock:
+            return await self._submit_prompt(prompt)
+
+    async def _submit_prompt(self, prompt: str) -> str:
+        page = self._page
+        assert page is not None
+
+        try:
+            await page.goto(_KIMI_URL, wait_until="domcontentloaded", timeout=30_000)
+        except Exception as exc:
+            log.warning("Navigation to Kimi failed: %s", exc)
+            raise
+
+        # Find the input box
+        input_box = await page.wait_for_selector(_CHAT_INPUT_SELECTOR, timeout=15_000)
+        await input_box.click()
+        await input_box.fill("")
+        await input_box.type(prompt, delay=10)
+
+        # Submit
+        await page.keyboard.press("Enter")
+
+        # Wait for the response to complete — poll until we see a stable text block
+        reply = await _wait_for_reply(page)
+        return reply
+
+
+def _messages_to_prompt(messages: list[dict]) -> str:
+    """Flatten an OpenAI messages list into a single string for the web UI."""
+    parts: list[str] = []
+    for msg in messages:
+        role = msg.get("role", "user")
+        content = msg.get("content", "")
+        if isinstance(content, list):
+            # Multi-modal content blocks — extract text parts only
+            content = " ".join(
+                block.get("text", "") for block in content if isinstance(block, dict)
+            )
+        if role == "system":
+            parts.append(f"[System context]: {content}")
+        elif role == "assistant":
+            parts.append(f"[Previous assistant reply]: {content}")
+        else:
+            parts.append(content)
+    return "\n\n".join(p for p in parts if p)
+
+
+async def _wait_for_reply(page: "Page", timeout: float = 120.0) -> str:
+    """Poll the page until the streaming response is complete, then return its text."""
+    import time
+
+    deadline = time.monotonic() + timeout
+    last_text = ""
+    stable_count = 0
+
+    while time.monotonic() < deadline:
+        await asyncio.sleep(2.0)
+
+        # Try to grab the last assistant message block
+        text = await page.evaluate(
+            """() => {
+                // Kimi renders messages in div.chat-message or similar — try multiple selectors.
+                const candidates = [
+                    ...document.querySelectorAll('[class*="message"][class*="assistant"]'),
+                    ...document.querySelectorAll('[class*="msg-content"]'),
+                    ...document.querySelectorAll('[class*="reply"]'),
+                ];
+                if (!candidates.length) return '';
+                // Return the last element's innerText
+                return candidates[candidates.length - 1].innerText || '';
+            }"""
+        )
+
+        text = (text or "").strip()
+        if text and text == last_text:
+            stable_count += 1
+            if stable_count >= 2:
+                return text
+        else:
+            stable_count = 0
+            last_text = text
+
+    # Return whatever we have even if not fully stable
+    return last_text or "[kimi-bridge: no reply captured within timeout]"
+
+
+if __name__ == "__main__":
+    import sys
+
+    if "--login" in sys.argv:
+        driver = KimiBrowserDriver()
+        asyncio.run(driver.login())
+    else:
+        print("Usage: python -m services.kimi_bridge_server.browser_driver --login")

--- a/services/kimi_bridge_server/browser_driver.py
+++ b/services/kimi_bridge_server/browser_driver.py
@@ -20,13 +20,14 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
+import time
 from pathlib import Path
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from playwright.async_api import BrowserContext, Page
 
-log = logging.getLogger("kimi-bridge")
+log = logging.getLogger("qwen-proxy")
 
 _DEFAULT_USER_DATA_DIR = str(Path.home() / ".kimi_bridge_profile")
 _KIMI_URL = "https://kimi.moonshot.cn"
@@ -109,7 +110,8 @@ class KimiBrowserDriver:
 
     async def _submit_prompt(self, prompt: str) -> str:
         page = self._page
-        assert page is not None
+        if page is None:
+            raise RuntimeError("KimiBrowserDriver._page is None; call start() first")
 
         try:
             await page.goto(_KIMI_URL, wait_until="domcontentloaded", timeout=30_000)
@@ -153,8 +155,6 @@ def _messages_to_prompt(messages: list[dict]) -> str:
 
 async def _wait_for_reply(page: "Page", timeout: float = 120.0) -> str:
     """Poll the page until the streaming response is complete, then return its text."""
-    import time
-
     deadline = time.monotonic() + timeout
     last_text = ""
     stable_count = 0
@@ -197,4 +197,4 @@ if __name__ == "__main__":
         driver = KimiBrowserDriver()
         asyncio.run(driver.login())
     else:
-        print("Usage: python -m services.kimi_bridge_server.browser_driver --login")
+        log.error("Usage: python -m services.kimi_bridge_server.browser_driver --login")

--- a/tests/test_kimi_bridge_server.py
+++ b/tests/test_kimi_bridge_server.py
@@ -4,14 +4,21 @@ All tests mock browser_driver.ask so no real network/browser is needed.
 """
 from __future__ import annotations
 
-import os
+import secrets
 import pytest
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
-# Patch the browser driver *before* importing the app so the lifespan
-# never launches a real browser.
+
+# ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+
 @pytest.fixture()
-def fake_driver():
+def auth_token() -> str:
+    return secrets.token_hex(16)
+
+
+@pytest.fixture()
+def fake_driver() -> MagicMock:
     """A canned KimiBrowserDriver stand-in that never touches a real browser."""
     driver = MagicMock()
     driver.start = AsyncMock()
@@ -21,20 +28,20 @@ def fake_driver():
 
 
 @pytest.fixture()
-def kimi_app(fake_driver, monkeypatch):
+def kimi_app(fake_driver: MagicMock, auth_token: str, monkeypatch):
     """Return a TestClient for the Kimi bridge app, with a mocked driver.
 
     The key is patching ``KimiBrowserDriver`` *inside* app.py's namespace —
     that's the name the lifespan closure uses, not the one in browser_driver.py.
     """
-    monkeypatch.setenv("KIMI_BRIDGE_TOKEN", "test-secret")
+    monkeypatch.setenv("KIMI_BRIDGE_TOKEN", auth_token)
 
     from fastapi.testclient import TestClient
     import services.kimi_bridge_server.app as app_mod
 
     # Patch the name as it appears in the app module (``from .browser_driver import …``)
     monkeypatch.setattr(app_mod, "KimiBrowserDriver", lambda: fake_driver)
-    app_mod._BRIDGE_TOKEN = "test-secret"
+    app_mod._BRIDGE_TOKEN = auth_token
 
     with TestClient(app_mod.app, raise_server_exceptions=True) as client:
         yield client
@@ -43,11 +50,13 @@ def kimi_app(fake_driver, monkeypatch):
 # ─── /v1/chat/completions ─────────────────────────────────────────────────────
 
 
-def test_chat_completions_returns_openai_shape(kimi_app, fake_driver):
+def test_chat_completions_returns_openai_shape(
+    kimi_app, auth_token: str, fake_driver: MagicMock
+) -> None:
     resp = kimi_app.post(
         "/v1/chat/completions",
         json={"model": "kimi-k2.6", "messages": [{"role": "user", "content": "hi"}]},
-        headers={"Authorization": "Bearer test-secret"},
+        headers={"Authorization": f"Bearer {auth_token}"},
     )
     assert resp.status_code == 200
     data = resp.json()
@@ -57,10 +66,15 @@ def test_chat_completions_returns_openai_shape(kimi_app, fake_driver):
     assert data["choices"][0]["message"]["content"] == "Hello from Kimi!"
     assert "usage" in data
     assert data["usage"]["total_tokens"] >= 1
+    assert data["usage"]["total_tokens"] == (
+        data["usage"]["prompt_tokens"] + data["usage"]["completion_tokens"]
+    )
     fake_driver.ask.assert_awaited_once()
 
 
-def test_chat_completions_messages_forwarded(kimi_app, fake_driver):
+def test_chat_completions_messages_forwarded(
+    kimi_app, auth_token: str, fake_driver: MagicMock
+) -> None:
     msgs = [
         {"role": "system", "content": "You are helpful."},
         {"role": "user", "content": "What is 2+2?"},
@@ -68,7 +82,7 @@ def test_chat_completions_messages_forwarded(kimi_app, fake_driver):
     resp = kimi_app.post(
         "/v1/chat/completions",
         json={"model": "kimi-k2.6", "messages": msgs},
-        headers={"Authorization": "Bearer test-secret"},
+        headers={"Authorization": f"Bearer {auth_token}"},
     )
     assert resp.status_code == 200
     # Driver was called with a non-empty messages list
@@ -78,7 +92,7 @@ def test_chat_completions_messages_forwarded(kimi_app, fake_driver):
     assert any(m["role"] == "user" for m in called_messages)
 
 
-def test_stream_not_supported(kimi_app):
+def test_stream_not_supported(kimi_app, auth_token: str) -> None:
     resp = kimi_app.post(
         "/v1/chat/completions",
         json={
@@ -86,7 +100,7 @@ def test_stream_not_supported(kimi_app):
             "messages": [{"role": "user", "content": "hi"}],
             "stream": True,
         },
-        headers={"Authorization": "Bearer test-secret"},
+        headers={"Authorization": f"Bearer {auth_token}"},
     )
     assert resp.status_code == 400
     assert "stream" in resp.json()["detail"].lower()
@@ -95,7 +109,7 @@ def test_stream_not_supported(kimi_app):
 # ─── Auth enforcement ─────────────────────────────────────────────────────────
 
 
-def test_missing_auth_header_rejected(kimi_app):
+def test_missing_auth_header_rejected(kimi_app) -> None:
     resp = kimi_app.post(
         "/v1/chat/completions",
         json={"model": "kimi-k2.6", "messages": [{"role": "user", "content": "hi"}]},
@@ -103,20 +117,20 @@ def test_missing_auth_header_rejected(kimi_app):
     assert resp.status_code == 401
 
 
-def test_wrong_token_rejected(kimi_app):
+def test_wrong_token_rejected(kimi_app) -> None:
     resp = kimi_app.post(
         "/v1/chat/completions",
         json={"model": "kimi-k2.6", "messages": [{"role": "user", "content": "hi"}]},
-        headers={"Authorization": "Bearer wrong-token"},
+        headers={"Authorization": "Bearer definitely-not-the-right-token"},
     )
     assert resp.status_code == 401
 
 
-def test_correct_token_accepted(kimi_app, fake_driver):
+def test_correct_token_accepted(kimi_app, auth_token: str, fake_driver: MagicMock) -> None:
     resp = kimi_app.post(
         "/v1/chat/completions",
         json={"model": "kimi-k2.6", "messages": [{"role": "user", "content": "hi"}]},
-        headers={"Authorization": "Bearer test-secret"},
+        headers={"Authorization": f"Bearer {auth_token}"},
     )
     assert resp.status_code == 200
 
@@ -124,8 +138,8 @@ def test_correct_token_accepted(kimi_app, fake_driver):
 # ─── /v1/models ───────────────────────────────────────────────────────────────
 
 
-def test_list_models(kimi_app):
-    resp = kimi_app.get("/v1/models", headers={"Authorization": "Bearer test-secret"})
+def test_list_models(kimi_app, auth_token: str) -> None:
+    resp = kimi_app.get("/v1/models", headers={"Authorization": f"Bearer {auth_token}"})
     assert resp.status_code == 200
     data = resp.json()
     assert data["object"] == "list"
@@ -136,7 +150,7 @@ def test_list_models(kimi_app):
 # ─── /health ──────────────────────────────────────────────────────────────────
 
 
-def test_health_endpoint(kimi_app):
+def test_health_endpoint(kimi_app) -> None:
     resp = kimi_app.get("/health")
     assert resp.status_code == 200
     assert resp.json()["status"] == "ok"
@@ -145,7 +159,7 @@ def test_health_endpoint(kimi_app):
 # ─── browser_driver helpers ───────────────────────────────────────────────────
 
 
-def test_messages_to_prompt_basic():
+def test_messages_to_prompt_basic() -> None:
     from services.kimi_bridge_server.browser_driver import _messages_to_prompt
 
     msgs = [
@@ -157,7 +171,7 @@ def test_messages_to_prompt_basic():
     assert "Hello" in prompt
 
 
-def test_messages_to_prompt_multimodal():
+def test_messages_to_prompt_multimodal() -> None:
     from services.kimi_bridge_server.browser_driver import _messages_to_prompt
 
     msgs = [
@@ -170,7 +184,7 @@ def test_messages_to_prompt_multimodal():
     assert "Describe this" in prompt
 
 
-def test_messages_to_prompt_assistant_turn():
+def test_messages_to_prompt_assistant_turn() -> None:
     from services.kimi_bridge_server.browser_driver import _messages_to_prompt
 
     msgs = [

--- a/tests/test_kimi_bridge_server.py
+++ b/tests/test_kimi_bridge_server.py
@@ -1,0 +1,184 @@
+"""Tests for the Kimi web-bridge HTTP service.
+
+All tests mock browser_driver.ask so no real network/browser is needed.
+"""
+from __future__ import annotations
+
+import os
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+# Patch the browser driver *before* importing the app so the lifespan
+# never launches a real browser.
+@pytest.fixture()
+def fake_driver():
+    """A canned KimiBrowserDriver stand-in that never touches a real browser."""
+    driver = MagicMock()
+    driver.start = AsyncMock()
+    driver.stop = AsyncMock()
+    driver.ask = AsyncMock(return_value="Hello from Kimi!")
+    return driver
+
+
+@pytest.fixture()
+def kimi_app(fake_driver, monkeypatch):
+    """Return a TestClient for the Kimi bridge app, with a mocked driver.
+
+    The key is patching ``KimiBrowserDriver`` *inside* app.py's namespace —
+    that's the name the lifespan closure uses, not the one in browser_driver.py.
+    """
+    monkeypatch.setenv("KIMI_BRIDGE_TOKEN", "test-secret")
+
+    from fastapi.testclient import TestClient
+    import services.kimi_bridge_server.app as app_mod
+
+    # Patch the name as it appears in the app module (``from .browser_driver import …``)
+    monkeypatch.setattr(app_mod, "KimiBrowserDriver", lambda: fake_driver)
+    app_mod._BRIDGE_TOKEN = "test-secret"
+
+    with TestClient(app_mod.app, raise_server_exceptions=True) as client:
+        yield client
+
+
+# ─── /v1/chat/completions ─────────────────────────────────────────────────────
+
+
+def test_chat_completions_returns_openai_shape(kimi_app, fake_driver):
+    resp = kimi_app.post(
+        "/v1/chat/completions",
+        json={"model": "kimi-k2.6", "messages": [{"role": "user", "content": "hi"}]},
+        headers={"Authorization": "Bearer test-secret"},
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["object"] == "chat.completion"
+    assert len(data["choices"]) == 1
+    assert data["choices"][0]["message"]["role"] == "assistant"
+    assert data["choices"][0]["message"]["content"] == "Hello from Kimi!"
+    assert "usage" in data
+    assert data["usage"]["total_tokens"] >= 1
+    fake_driver.ask.assert_awaited_once()
+
+
+def test_chat_completions_messages_forwarded(kimi_app, fake_driver):
+    msgs = [
+        {"role": "system", "content": "You are helpful."},
+        {"role": "user", "content": "What is 2+2?"},
+    ]
+    resp = kimi_app.post(
+        "/v1/chat/completions",
+        json={"model": "kimi-k2.6", "messages": msgs},
+        headers={"Authorization": "Bearer test-secret"},
+    )
+    assert resp.status_code == 200
+    # Driver was called with a non-empty messages list
+    assert fake_driver.ask.called
+    called_messages = fake_driver.ask.call_args.args[0]
+    assert any(m["role"] == "system" for m in called_messages)
+    assert any(m["role"] == "user" for m in called_messages)
+
+
+def test_stream_not_supported(kimi_app):
+    resp = kimi_app.post(
+        "/v1/chat/completions",
+        json={
+            "model": "kimi-k2.6",
+            "messages": [{"role": "user", "content": "hi"}],
+            "stream": True,
+        },
+        headers={"Authorization": "Bearer test-secret"},
+    )
+    assert resp.status_code == 400
+    assert "stream" in resp.json()["detail"].lower()
+
+
+# ─── Auth enforcement ─────────────────────────────────────────────────────────
+
+
+def test_missing_auth_header_rejected(kimi_app):
+    resp = kimi_app.post(
+        "/v1/chat/completions",
+        json={"model": "kimi-k2.6", "messages": [{"role": "user", "content": "hi"}]},
+    )
+    assert resp.status_code == 401
+
+
+def test_wrong_token_rejected(kimi_app):
+    resp = kimi_app.post(
+        "/v1/chat/completions",
+        json={"model": "kimi-k2.6", "messages": [{"role": "user", "content": "hi"}]},
+        headers={"Authorization": "Bearer wrong-token"},
+    )
+    assert resp.status_code == 401
+
+
+def test_correct_token_accepted(kimi_app, fake_driver):
+    resp = kimi_app.post(
+        "/v1/chat/completions",
+        json={"model": "kimi-k2.6", "messages": [{"role": "user", "content": "hi"}]},
+        headers={"Authorization": "Bearer test-secret"},
+    )
+    assert resp.status_code == 200
+
+
+# ─── /v1/models ───────────────────────────────────────────────────────────────
+
+
+def test_list_models(kimi_app):
+    resp = kimi_app.get("/v1/models", headers={"Authorization": "Bearer test-secret"})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["object"] == "list"
+    assert len(data["data"]) >= 1
+    assert "id" in data["data"][0]
+
+
+# ─── /health ──────────────────────────────────────────────────────────────────
+
+
+def test_health_endpoint(kimi_app):
+    resp = kimi_app.get("/health")
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "ok"
+
+
+# ─── browser_driver helpers ───────────────────────────────────────────────────
+
+
+def test_messages_to_prompt_basic():
+    from services.kimi_bridge_server.browser_driver import _messages_to_prompt
+
+    msgs = [
+        {"role": "system", "content": "Be concise."},
+        {"role": "user", "content": "Hello"},
+    ]
+    prompt = _messages_to_prompt(msgs)
+    assert "Be concise." in prompt
+    assert "Hello" in prompt
+
+
+def test_messages_to_prompt_multimodal():
+    from services.kimi_bridge_server.browser_driver import _messages_to_prompt
+
+    msgs = [
+        {
+            "role": "user",
+            "content": [{"type": "text", "text": "Describe this"}, {"type": "image_url"}],
+        }
+    ]
+    prompt = _messages_to_prompt(msgs)
+    assert "Describe this" in prompt
+
+
+def test_messages_to_prompt_assistant_turn():
+    from services.kimi_bridge_server.browser_driver import _messages_to_prompt
+
+    msgs = [
+        {"role": "user", "content": "Question"},
+        {"role": "assistant", "content": "Answer"},
+        {"role": "user", "content": "Follow-up"},
+    ]
+    prompt = _messages_to_prompt(msgs)
+    assert "Question" in prompt
+    assert "Answer" in prompt
+    assert "Follow-up" in prompt


### PR DESCRIPTION
## Summary

- **`services/kimi_bridge_server/app.py`** — FastAPI app with `POST /v1/chat/completions` and `GET /v1/models` in OpenAI format. Bearer-token auth via `hmac.compare_digest` (`KIMI_BRIDGE_TOKEN`). Rejects `stream=true`. Returns OpenAI-shaped response with best-effort usage counts.
- **`services/kimi_bridge_server/browser_driver.py`** — Playwright persistent-context driver. One-time manual `--login` helper (headed). Asyncio lock serialises concurrent callers so a single browser tab is never in two conversations. `ask()` runs headless; `_messages_to_prompt()` flattens the messages list for the web UI.
- **`Dockerfile.kimibridge`** — Official Playwright base image; `PLAYWRIGHT_USER_DATA_DIR` mounted at runtime so the login cookie survives container restarts.
- **`services/kimi_bridge_server/README.md`** — One-time login, running standalone, Docker, and env-var reference.
- **`tests/test_kimi_bridge_server.py`** — 11 unit tests; driver mocked via `monkeypatch` on `app.KimiBrowserDriver` (the import binding, not the source module), so no real browser or network is needed.

## How it connects to the main backend

The main backend already reads `KIMI_BRIDGE_URL` / `KIMI_BRIDGE_TOKEN` (see `providers/kimi_bridge.py`). Set:

```
KIMI_BRIDGE_ENABLED=true
KIMI_BRIDGE_URL=http://kimibridge:8011/v1
KIMI_BRIDGE_TOKEN=<shared secret>
```

## Test plan

- [x] `SKIP_DB_TESTS=1 STORAGE_BACKEND=sqlite python -m pytest tests/test_kimi_bridge_server.py -v` → 11 passed
- [x] `SKIP_DB_TESTS=1 STORAGE_BACKEND=sqlite python -m pytest tests/test_backend_runtime_bootstrap.py -v` → 1 passed (regression)
- [x] `docs/changelog.md` updated under `## [Unreleased]`
- [ ] Manual login + smoke test against live kimi.com (requires Playwright browsers — not in CI)

https://claude.ai/code/session_01TLrMVuoHJih3v95sTCCCjn

---
_Generated by [Claude Code](https://claude.ai/code/session_01TLrMVuoHJih3v95sTCCCjn)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Kimi Bridge Server, an OpenAI-compatible HTTP microservice for chat completions with Kimi through bearer token authentication, featuring containerization support

* **Documentation**
  * Added README with installation, configuration, and deployment instructions
  * Updated changelog documenting the new service

* **Tests**
  * Added comprehensive test suite covering endpoints, authentication, and response formatting

<!-- end of auto-generated comment: release notes by coderabbit.ai -->