### PR TITLE
fix(ui): show inline error when task creation fails instead of silent console.error

### DIFF
--- a/docker/agent_runtime.py
+++ b/docker/agent_runtime.py
@@ -29,6 +29,8 @@ OLLAMA_FALLBACK_BASE = os.environ.get(
 )
 # Free cloud providers — tried in priority order before local Ollama
 _NVIDIA_KEY = (os.environ.get("NVIDIA_API_KEY") or os.environ.get("NVidiaApiKey") or "").strip()
+# NOTE: keep /v1 in the base URL — _chat_with_openai_compat appends /chat/completions
+# directly without injecting /v1, so the base must already contain /v1.
 _NVIDIA_BASE = os.environ.get("NVIDIA_BASE_URL", "https://integrate.api.nvidia.com/v1").rstrip("/")
 _NVIDIA_DEFAULT_MODEL = os.environ.get("NVIDIA_DEFAULT_MODEL", "nvidia/llama-3.1-nemotron-70b-instruct")
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -29,6 +29,8 @@
 ## [Unreleased]
 
 ### Fixed
+- **TaskBoardScreen create-task modal swallowed API errors with bare `console.error` — no user feedback.** Added `createError` state with an inline red error banner inside the modal (matching the existing error-styling pattern). Error is cleared on modal open, Cancel click, and at the start of each new create attempt to prevent stale error persistence. Error message now uses the `api.fmtErr?.()` fallback chain for readable messages.
+
 - **NVIDIA NIM double `/v1` URL causing task execution failures on production.** `agent/loop.py` line 911 hardcoded `f"{self.ollama_base}/v1/chat/completions"` — when `ollama_base` already contained `/v1` (from `runtimes/adapters/internal_agent.py` `_NVIDIA_BASE_URL = "https://integrate.api.nvidia.com/v1"`), the result was `/v1/v1/chat/completions` (404). Fix: (1) `agent/loop.py` now uses `_openai_url()` from `provider_router` which handles the `/v1` suffix correctly; (2) `_NVIDIA_BASE_URL` no longer includes `/v1`; `_best_cloud_primary_base()` and `_nvidia_provider_chain()` normalise the URL; (3) `setup/api.py`, `webui/providers.py`, `render.yaml`, `.env.example` updated to use the correct default URL without `/v1`. `docker/agent_runtime.py` intentionally unchanged — its `_chat_with_openai_compat` appends `/chat/completions` directly (does not inject `/v1`), so the base must contain it.
 
 ### Added

--- a/frontend/src/v5/screens/TaskBoardScreen.jsx
+++ b/frontend/src/v5/screens/TaskBoardScreen.jsx
@@ -149,6 +149,7 @@ function TaskBoardScreen() {
   const [newTaskPriority, setNewTaskPriority] = React.useState('medium');
   const [newTaskType, setNewTaskType] = React.useState('task');
   const [creatingTask, setCreatingTask] = React.useState(false);
+  const [createError, setCreateError] = React.useState('');
 
   const [data, states, fetchAll] = useSafeData(null, {
     tasks: '/api/tasks/',
@@ -201,7 +202,7 @@ function TaskBoardScreen() {
                 textTransform: 'capitalize', transition: 'all 0.15s ease',
               }}>{f}</button>
             ))}
-            <button onClick={() => setShowNewTask(true)} style={{
+            <button onClick={() => { setShowNewTask(true); setCreateError(''); }} style={{
               padding: '5px 14px', borderRadius: 999, fontSize: 11, fontWeight: 700, cursor: 'pointer',
               background: 'rgba(70,217,164,0.12)', border: '1px solid rgba(70,217,164,0.28)',
               color: '#46d9a4', transition: 'all 0.15s ease',
@@ -240,16 +241,21 @@ function TaskBoardScreen() {
                 </select>
               </div>
             </div>
+            {createError && (
+              <div style={{ marginTop:14, padding:'9px 12px', borderRadius:10, background:'rgba(255,107,125,0.07)', border:'1px solid rgba(255,107,125,0.18)', fontSize:12, color:'#ff6b7d', lineHeight:1.5 }}>
+                {createError}
+              </div>
+            )}
             <div style={{ display:'flex', gap:10, justifyContent:'flex-end', marginTop:16 }}>
-              <button onClick={() => { setShowNewTask(false); setNewTaskTitle(''); setNewTaskDesc(''); }}
+              <button onClick={() => { setShowNewTask(false); setNewTaskTitle(''); setNewTaskDesc(''); setCreateError(''); }}
                 style={{ padding:'9px 18px', borderRadius:10, fontSize:13, fontWeight:700, background:'rgba(255,255,255,0.06)', border:'1px solid rgba(255,255,255,0.10)', color:'var(--text-secondary)', cursor:'pointer' }}>Cancel</button>
               <button disabled={!newTaskTitle.trim() || creatingTask} onClick={async () => {
-                setCreatingTask(true);
+                setCreateError(''); setCreatingTask(true);
                 try {
                   await api.createTask({ title: newTaskTitle.trim(), description: newTaskDesc.trim(), priority: newTaskPriority, task_type: newTaskType });
                   setShowNewTask(false); setNewTaskTitle(''); setNewTaskDesc('');
                   fetchAll();
-                } catch (e) { console.error('Create task failed', e); }
+                } catch (e) { setCreateError(api.fmtErr?.(e?.response?.data?.detail) || e?.message || 'Could not create task. Check your connection and try again.'); }
                 finally { setCreatingTask(false); }
               }}
                 style={{ padding:'9px 18px', borderRadius:10, fontSize:13, fontWeight:700, background:newTaskTitle.trim() && !creatingTask ? 'linear-gradient(135deg,#6CB0FF,#3A7FE8)' : 'rgba(93,162,255,0.2)', border:'none', color:'#fff', cursor: newTaskTitle.trim() && !creatingTask ? 'pointer' : 'not-allowed' }}>


### PR DESCRIPTION
## Summary

Previously, the Create Task modal swallowed API errors silently — the
modal stayed open with no feedback after a failed createTask call.
The only sign of failure was a console.error that the user never sees.

### Changes
- Added createError state to capture human-readable error messages
- Displayed an inline red error banner inside the modal (matching existing styling)
- Cleared error on modal open, Cancel click, and at start of each new create attempt
- docker/agent_runtime.py: added comment documenting why /v1 is kept in _NVIDIA_BASE
