### PR TITLE
fix(ui+e2e): surface approve/retry errors, expand browser E2E to 20 pages, fix flaky Playwright

### DIFF
--- a/docker/agent_runtime.py
+++ b/docker/agent_runtime.py
@@ -29,6 +29,8 @@ OLLAMA_FALLBACK_BASE = os.environ.get(
 )
 # Free cloud providers — tried in priority order before local Ollama
 _NVIDIA_KEY = (os.environ.get("NVIDIA_API_KEY") or os.environ.get("NVidiaApiKey") or "").strip()
+# NOTE: keep /v1 in the base URL — _chat_with_openai_compat appends /chat/completions
+# directly without injecting /v1, so the base must already contain /v1.
 _NVIDIA_BASE = os.environ.get("NVIDIA_BASE_URL", "https://integrate.api.nvidia.com/v1").rstrip("/")
 _NVIDIA_DEFAULT_MODEL = os.environ.get("NVIDIA_DEFAULT_MODEL", "nvidia/llama-3.1-nemotron-70b-instruct")
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -29,6 +29,12 @@
 ## [Unreleased]
 
 ### Fixed
+^- **All 20 V5 screens audited for swallowed errors; approve/retry now show inline error banners.** `handleRetry` previously had a bare `catch (_) {}` swallowing all errors silently; now shows a yellow click-to-dismiss actionError banner. `handleApprove` filters out expected 404/400 (optimistic: no checkpoint to approve) but surfaces real failures.
+
+- **Browser E2E now covers 20 pages (was 13).** Added 7 missing V5 routes: `/intelligence`, `/company`, `/github`, `/skills`, `/doctor`, `/onboarding`, `/admin`.
+
+- **Flaky Playwright browser E2E timeouts fixed.** Changed all `wait_until=networkidle` to `domcontentloaded` with adjusted timeouts -- pages with auto-refresh polling (Dashboard 15s, etc.) never settle to `networkidle`, causing intermittent CI failures.
+
 - **TaskBoardScreen create-task modal swallowed API errors with bare `console.error` — no user feedback.** Added `createError` state with an inline red error banner inside the modal (matching the existing error-styling pattern). Error is cleared on modal open, Cancel click, and at the start of each new create attempt to prevent stale error persistence. Error message now uses the `api.fmtErr?.()` fallback chain for readable messages.
 
 - **NVIDIA NIM double `/v1` URL causing task execution failures on production.** `agent/loop.py` line 911 hardcoded `f"{self.ollama_base}/v1/chat/completions"` — when `ollama_base` already contained `/v1` (from `runtimes/adapters/internal_agent.py` `_NVIDIA_BASE_URL = "https://integrate.api.nvidia.com/v1"`), the result was `/v1/v1/chat/completions` (404). Fix: (1) `agent/loop.py` now uses `_openai_url()` from `provider_router` which handles the `/v1` suffix correctly; (2) `_NVIDIA_BASE_URL` no longer includes `/v1`; `_best_cloud_primary_base()` and `_nvidia_provider_chain()` normalise the URL; (3) `setup/api.py`, `webui/providers.py`, `render.yaml`, `.env.example` updated to use the correct default URL without `/v1`. `docker/agent_runtime.py` intentionally unchanged — its `_chat_with_openai_compat` appends `/chat/completions` directly (does not inject `/v1`), so the base must contain it.

--- a/frontend/src/v5/screens/TaskBoardScreen.jsx
+++ b/frontend/src/v5/screens/TaskBoardScreen.jsx
@@ -150,6 +150,7 @@ function TaskBoardScreen() {
   const [newTaskType, setNewTaskType] = React.useState('task');
   const [creatingTask, setCreatingTask] = React.useState(false);
   const [createError, setCreateError] = React.useState('');
+  const [actionError, setActionError] = React.useState('');
 
   const [data, states, fetchAll] = useSafeData(null, {
     tasks: '/api/tasks/',
@@ -158,21 +159,26 @@ function TaskBoardScreen() {
   const rawTasks = data.tasks?.tasks || [];
 
   const handleApprove = async (taskId) => {
-    setPendingApprove(taskId);
+    setActionError(''); setPendingApprove(taskId);
     try {
       await api.approveTaskCheckpoint(taskId, { approved: true, reason: 'Approved via UI' });
-    } catch (_) {
-      // optimistic — backend may not have a pending checkpoint
+    } catch (e) {
+      // Only surface real failures — missing checkpoint (404/400) is expected in optimistic flow
+      if (e?.response?.status !== 404 && e?.response?.status !== 400) {
+        setActionError(api.fmtErr?.(e?.response?.data?.detail) || e?.message || 'Could not approve task.');
+      }
     }
     setPendingApprove(null);
     fetchAll();
   };
 
   const handleRetry = async (taskId) => {
-    setPendingRetry(taskId);
+    setActionError(''); setPendingRetry(taskId);
     try {
       await api.retryTask(taskId);
-    } catch (_) {}
+    } catch (e) {
+      setActionError(api.fmtErr?.(e?.response?.data?.detail) || e?.message || 'Could not retry task.');
+    }
     setPendingRetry(null);
     fetchAll();
   };
@@ -213,6 +219,11 @@ function TaskBoardScreen() {
         {error && (
           <div style={{ marginBottom: 10, padding: '8px 12px', borderRadius: 10, background: 'rgba(255,107,125,0.07)', border: '1px solid rgba(255,107,125,0.18)', fontSize: 12, color: '#ff6b7d' }}>
             Could not load tasks: {error}
+          </div>
+        )}
+        {actionError && (
+          <div style={{ marginBottom: 10, padding: '8px 12px', borderRadius: 10, background: 'rgba(255,189,102,0.07)', border: '1px solid rgba(255,189,102,0.18)', fontSize: 12, color: '#ffbd66', cursor: 'pointer' }} onClick={() => setActionError('')}>
+            {actionError} <span style={{ fontSize: 10, opacity: 0.6 }}>(click to dismiss)</span>
           </div>
         )}
         {loading && (

--- a/frontend/src/v5/screens/TaskBoardScreen.jsx
+++ b/frontend/src/v5/screens/TaskBoardScreen.jsx
@@ -149,6 +149,7 @@ function TaskBoardScreen() {
   const [newTaskPriority, setNewTaskPriority] = React.useState('medium');
   const [newTaskType, setNewTaskType] = React.useState('task');
   const [creatingTask, setCreatingTask] = React.useState(false);
+  const [createError, setCreateError] = React.useState('');
 
   const [data, states, fetchAll] = useSafeData(null, {
     tasks: '/api/tasks/',
@@ -201,7 +202,7 @@ function TaskBoardScreen() {
                 textTransform: 'capitalize', transition: 'all 0.15s ease',
               }}>{f}</button>
             ))}
-            <button onClick={() => setShowNewTask(true)} style={{
+            <button onClick={() => { setShowNewTask(true); setCreateError(''); }} style={{
               padding: '5px 14px', borderRadius: 999, fontSize: 11, fontWeight: 700, cursor: 'pointer',
               background: 'rgba(70,217,164,0.12)', border: '1px solid rgba(70,217,164,0.28)',
               color: '#46d9a4', transition: 'all 0.15s ease',
@@ -240,16 +241,21 @@ function TaskBoardScreen() {
                 </select>
               </div>
             </div>
+            {createError && (
+              <div style={{ marginTop:14, padding:'9px 12px', borderRadius:10, background:'rgba(255,107,125,0.07)', border:'1px solid rgba(255,107,125,0.18)', fontSize:12, color:'#ff6b7d', lineHeight:1.5 }}>
+                {createError}
+              </div>
+            )}
             <div style={{ display:'flex', gap:10, justifyContent:'flex-end', marginTop:16 }}>
-              <button onClick={() => { setShowNewTask(false); setNewTaskTitle(''); setNewTaskDesc(''); }}
+              <button onClick={() => { setShowNewTask(false); setNewTaskTitle(''); setNewTaskDesc(''); setCreateError(''); }}
                 style={{ padding:'9px 18px', borderRadius:10, fontSize:13, fontWeight:700, background:'rgba(255,255,255,0.06)', border:'1px solid rgba(255,255,255,0.10)', color:'var(--text-secondary)', cursor:'pointer' }}>Cancel</button>
               <button disabled={!newTaskTitle.trim() || creatingTask} onClick={async () => {
-                setCreatingTask(true);
+                setCreateError(''); setCreatingTask(true);
                 try {
                   await api.createTask({ title: newTaskTitle.trim(), description: newTaskDesc.trim(), priority: newTaskPriority, task_type: newTaskType });
                   setShowNewTask(false); setNewTaskTitle(''); setNewTaskDesc('');
                   fetchAll();
-                } catch (e) { console.error('Create task failed', e); }
+                } catch (e) { setCreateError(api.fmtErr?.(e?.response?.data?.detail) || e?.message || 'Could not create task. Check your connection and try again.'); }
                 finally { setCreatingTask(false); }
               }}
                 style={{ padding:'9px 18px', borderRadius:10, fontSize:13, fontWeight:700, background:newTaskTitle.trim() && !creatingTask ? 'linear-gradient(135deg,#6CB0FF,#3A7FE8)' : 'rgba(93,162,255,0.2)', border:'none', color:'#fff', cursor: newTaskTitle.trim() && !creatingTask ? 'pointer' : 'not-allowed' }}>

--- a/tests/e2e/test_browser.py
+++ b/tests/e2e/test_browser.py
@@ -2,7 +2,7 @@
 """
 Browser-based E2E tests — runs with Playwright against a live LLM Relay instance.
 
-Covers ALL 13 control plane pages in both desktop (1280x720) and mobile (375x812)
+Covers ALL 20 control plane pages in both desktop (1280x720) and mobile (375x812)
 viewports. Verifies pages load without console errors, key UI elements are present,
 and navigation works.
 
@@ -48,6 +48,13 @@ PAGES = [
     {"path": "/schedules", "name": "Schedules"},
     {"path": "/chat", "name": "Chat"},
     {"path": "/knowledge", "name": "Knowledge"},
+    {"path": "/skills", "name": "Skills"},
+    {"path": "/intelligence", "name": "Intelligence"},
+    {"path": "/company", "name": "Company"},
+    {"path": "/github", "name": "GitHub"},
+    {"path": "/doctor", "name": "Doctor"},
+    {"path": "/onboarding", "name": "Onboarding"},
+    {"path": "/admin", "name": "Admin"},
     {"path": "/runtimes", "name": "Runtimes"},
     {"path": "/routing", "name": "Routing"},
     {"path": "/providers", "name": "Providers"},
@@ -86,8 +93,8 @@ def do_login(page: Page, base_url: str) -> bool:
     """Log in and return True on success."""
     print(f"\n{'='*60}\n  Login\n{'='*60}")
 
-    page.goto(f"{base_url}/login", wait_until="networkidle", timeout=15000)
-    page.wait_for_timeout(1000)
+    page.goto(f"{base_url}/login", wait_until="domcontentloaded", timeout=15000)
+    page.wait_for_timeout(1500)
 
     # Check if already logged in (redirected away from login)
     if "login" not in page.url.lower():
@@ -131,8 +138,8 @@ def do_login(page: Page, base_url: str) -> bool:
 
     # Strategy 3: Try admin UI login page
     if email_field is None or pw_field is None:
-        page.goto(f"{base_url}/admin/ui/login", wait_until="networkidle", timeout=15000)
-        page.wait_for_timeout(500)
+        page.goto(f"{base_url}/admin/ui/login", wait_until="domcontentloaded", timeout=15000)
+        page.wait_for_timeout(800)
         email_field = page.locator('input[name="username"], input[type="text"]:visible').first
         pw_field = page.locator('input[type="password"]:visible').first
 
@@ -156,8 +163,8 @@ def do_login(page: Page, base_url: str) -> bool:
     else:
         pw_field.press("Enter")
 
-    page.wait_for_load_state("networkidle", timeout=15000)
-    page.wait_for_timeout(1000)
+    page.wait_for_load_state("domcontentloaded", timeout=15000)
+    page.wait_for_timeout(1500)
 
     # Verify we're logged in (not on login page anymore)
     current = page.url
@@ -190,8 +197,11 @@ def test_page(page: Page, base_url: str, page_info: dict, viewport_name: str) ->
     page.on("console", on_console)
 
     try:
-        page.goto(f"{base_url}{path}", wait_until="networkidle", timeout=15000)
-        time.sleep(0.5)
+        # Use domcontentloaded instead of networkidle — pages with auto-refresh
+        # (Dashboard polls every 15s, etc.) never reach networkidle, causing flaky
+        # timeouts in CI. domcontentloaded is reliable when the SPA shell loads.
+        page.goto(f"{base_url}{path}", wait_until="domcontentloaded", timeout=15000)
+        page.wait_for_timeout(800)
     except Exception as e:
         fail(f"{name} ({viewport_name})", f"navigation error: {e}")
         return


### PR DESCRIPTION
## Summary

### Audit and Error Handling
- Audited all 20 V5 screens for swallowed console.error-only catch blocks
- Found only 2 remaining issues (both in TaskBoardScreen), now fixed
- handleRetry: bare catch (_) {} now shows yellow click-to-dismiss actionError
- handleApprove: filters out expected 404/400 but surfaces real failures

### Browser E2E Expansion
- Added 7 missing V5 routes: /intelligence, /company, /github, /skills, /doctor, /onboarding, /admin
- Now covers 20 pages (was 13)

### Flaky Playwright Fix
- Changed all wait_until=networkidle to domcontentloaded
- Pages with auto-refresh polling (Dashboard 15s, etc.) never settle to networkidle
- Adjusted timeouts for reliability
