### PR TITLE
feat: issue-context automation + draft-PR CI guards

### DIFF
--- a/.github/scripts/generate_context.py
+++ b/.github/scripts/generate_context.py
@@ -1,0 +1,392 @@
+"""
+.github/scripts/generate_context.py
+
+Generates a rich context document (implementation prompt + prioritized TODO list)
+for any GitHub issue. Runs inside the issue-context-generator workflow.
+
+Usage (environment vars set by the workflow):
+  ISSUE_NUMBER, ISSUE_TITLE, ISSUE_BODY, ISSUE_LABELS must be set.
+  NVIDIA_API_KEY or ANTHROPIC_API_KEY must be set (NVIDIA tried first).
+
+Outputs /tmp/context_result.json:
+  {
+    "pr_description": str,   # Full Markdown PR body (prompt + TODOs)
+    "context_doc": str,      # Markdown for docs/context/issue-N.md
+    "title": str             # Suggested short PR title
+  }
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+import subprocess  # nosec B404 - used only to invoke the trusted local fetch_url.py script
+import sys
+import textwrap
+import time
+from pathlib import Path
+
+logging.basicConfig(level=logging.INFO, format="%(message)s", stream=sys.stdout)
+log = logging.getLogger("generate_context")
+
+RESULT_FILE = "/tmp/context_result.json"  # nosec: B108 - predictable temp path; matches implement_agent.py convention for inter-step communication
+# Allow callers to override REPO_ROOT so the script works when copied to /tmp
+# and executed after a git branch switch removes it from the working tree.
+REPO_ROOT = Path(os.environ.get("REPO_ROOT", str(Path(__file__).parent.parent.parent)))
+
+# NVIDIA NIM models tried in order.
+# nvidia/llama-3.1-nemotron-ultra-253b-v1 removed — returns 404 on this account.
+NVIDIA_MODELS = [
+    "qwen/qwen3-coder-480b-a35b-instruct",
+    "nvidia/llama-3.3-nemotron-super-49b-v1",
+    "meta/llama-3.3-70b-instruct",
+    "qwen/qwen2.5-coder-32b-instruct",
+]
+CLAUDE_MODEL = "claude-opus-4-8"
+
+
+# ---------------------------------------------------------------------------
+# Codebase context loader
+# ---------------------------------------------------------------------------
+
+def _load_codebase_context() -> str:
+    """Load CLAUDE.md + GRAPH_REPORT summary for LLM context."""
+    parts: list[str] = []
+
+    claude_md = REPO_ROOT / "CLAUDE.md"
+    if claude_md.exists():
+        parts.append("=== CLAUDE.md (project guide) ===")
+        parts.append(claude_md.read_text()[:4000])
+
+    graph_report = REPO_ROOT / "graphify-out" / "GRAPH_REPORT.md"
+    if graph_report.exists():
+        # Only first 2000 chars — the god-nodes section is the useful part
+        parts.append("\n=== GRAPH_REPORT (codebase map) ===")
+        parts.append(graph_report.read_text()[:2000])
+
+    # Module map from CLAUDE.md codebase section (already included above)
+    return "\n".join(parts)
+
+
+# ---------------------------------------------------------------------------
+# URL article fetcher — reuses the battle-tested fetch_url.py multi-strategy
+# fetcher so quick-note context is grounded in the ACTUAL article, not a guess.
+# ---------------------------------------------------------------------------
+
+def _extract_url(title: str, body: str) -> str | None:
+    """Return the first http(s) URL found in the issue title or body."""
+    m = re.search(r"https?://[^\s>)\]]+", f"{title}\n{body}")
+    return m.group(0) if m else None
+
+
+def _fetch_url_content(url: str) -> str:
+    """Fetch article text via the shared fetch_url.py script (multi-strategy).
+
+    Returns up to 6000 chars of plain text, or "" if the fetch fails. The fetch
+    script writes to /tmp/note_content.txt; we read it back. FETCH_URL_SCRIPT
+    overrides the script path so this works after the bulk workflow copies the
+    scripts to /tmp (git branch switches remove them from the working tree).
+    """
+    script = os.environ.get(
+        "FETCH_URL_SCRIPT", str(Path(__file__).parent / "fetch_url.py")
+    )
+    out_file = "/tmp/note_content.txt"  # nosec: B108 - shared convention with fetch_url.py
+    try:
+        if os.path.exists(out_file):
+            os.remove(out_file)
+    except OSError:
+        pass
+
+    log.info("Fetching article content from %s ...", url)
+    try:
+        subprocess.run(  # nosec B603 - sys.executable + fixed script path, url is the only arg
+            [sys.executable, script, url], timeout=150, check=False,
+            capture_output=True, text=True,
+        )
+    except (subprocess.TimeoutExpired, OSError) as exc:
+        log.warning("URL fetch failed for %s: %s", url, exc)
+        return ""
+
+    if os.path.exists(out_file):
+        try:
+            content = Path(out_file).read_text()[:6000]
+            log.info("Fetched %d chars of article content", len(content))
+            return content
+        except OSError:
+            return ""
+    log.warning("URL fetch produced no content for %s", url)
+    return ""
+
+
+# ---------------------------------------------------------------------------
+# Prompt builder
+# ---------------------------------------------------------------------------
+
+SYSTEM_PROMPT = textwrap.dedent("""\
+    You are a senior engineering architect for the local-llm-server project —
+    a self-hosted, OpenAI-compatible proxy for Ollama with FastAPI, async I/O,
+    Bearer-token auth, model routing, Langfuse observability, multi-agent
+    orchestration, Telegram bot, and a React/Next.js admin dashboard.
+
+    Your job: given a GitHub issue, produce:
+    1. A rich **implementation prompt** for an AI coding agent (Claude Code / NIM).
+       Be specific: name files, functions, patterns. Reference the codebase map.
+    2. A **prioritized TODO list** — ordered, actionable, concrete steps with
+       estimated complexity (S/M/L). Cover implementation, tests, docs, changelog.
+    3. **Relevant files** — list of files the implementer must read first.
+    4. **Risk flags** — note any risky modules (auth, key_store, agent/tools.py).
+    5. A one-line **PR title** suggestion.
+
+    Coding rules to embed in the prompt:
+    - Type annotations on all public functions; `from __future__ import annotations`
+    - No secrets in source; all config via env vars
+    - Pydantic models for all API I/O
+    - Async for all I/O; log with `logging`, not `print`
+    - Update docs/changelog.md under [Unreleased]
+    - Run `pytest -x` before and after changes
+""")
+
+
+def _build_user_message(
+    issue_number: str,
+    title: str,
+    body: str,
+    labels: list[str],
+    codebase_ctx: str,
+    article_content: str = "",
+) -> str:
+    label_str = ", ".join(labels) if labels else "none"
+
+    # Built as a list of lines (no source indentation) to avoid textwrap.dedent
+    # failing when interpolated multi-line values have zero leading whitespace.
+    article_section = (
+        f"---\n## Linked Article Content (fetched from the issue URL)\n\n"
+        f"{article_content}\n\n"
+        f"Base your prompt and TODOs on what this article ACTUALLY describes — "
+        f"do not guess or assume.\n\n"
+        if article_content
+        else "---\n## Linked Article Content\n\n"
+        "_No URL content available — base the plan on the issue body and your "
+        "knowledge of the topic, and state assumptions explicitly._\n\n"
+    )
+
+    output_format = (
+        "{\n"
+        '  "title": "<one-line PR title, max 70 chars, prefix feat:/fix:/refactor:>",\n'
+        '  "prompt": "<full implementation prompt for the AI coding agent, 300-600 words>",\n'
+        '  "todos": [\n'
+        '    {"step": 1, "task": "<task>", "complexity": "S|M|L", "file": "<primary file or null>"}\n'
+        "  ],\n"
+        '  "relevant_files": ["<file1>", "<file2>"],\n'
+        '  "risk_flags": ["<only modules actually touched by the plan>"],\n'
+        '  "notes": "<any architectural notes or open questions>"\n'
+        "}"
+    )
+
+    return (
+        f"## GitHub Issue #{issue_number}\n\n"
+        f"**Title:** {title}\n"
+        f"**Labels:** {label_str}\n\n"
+        f"**Body:**\n{body or '(no body provided)'}\n\n"
+        f"{article_section}"
+        f"---\n## Codebase Context\n\n{codebase_ctx}\n\n"
+        f"---\n## Your Output Format\n\n"
+        f"Return **valid JSON only** — no markdown fences, no preamble. "
+        f"Only list a module in risk_flags if your plan actually modifies it:\n\n"
+        f"{output_format}\n"
+    )
+
+
+# ---------------------------------------------------------------------------
+# LLM callers
+# ---------------------------------------------------------------------------
+
+def _call_nvidia(prompt: str, user_msg: str) -> dict:
+    from openai import OpenAI
+
+    api_key = os.environ.get("NVIDIA_API_KEY", "")
+    if not api_key:
+        raise RuntimeError("NVIDIA_API_KEY not set")
+
+    client = OpenAI(
+        base_url="https://integrate.api.nvidia.com/v1",
+        api_key=api_key,
+    )
+
+    for model in NVIDIA_MODELS:
+        log.info("Trying NVIDIA model: %s", model)
+        try:
+            resp = client.chat.completions.create(
+                model=model,
+                messages=[
+                    {"role": "system", "content": prompt},
+                    {"role": "user", "content": user_msg},
+                ],
+                temperature=0.3,
+                max_tokens=2048,
+                timeout=240,
+            )
+            text = resp.choices[0].message.content or ""
+            return _parse_json(text)
+        except Exception as exc:
+            log.warning("Model %s failed: %s — trying next", model, exc)
+            time.sleep(2)
+
+    raise RuntimeError("All NVIDIA models exhausted")
+
+
+def _call_claude(prompt: str, user_msg: str) -> dict:
+    import anthropic
+
+    api_key = os.environ.get("ANTHROPIC_API_KEY", "")
+    if not api_key:
+        raise RuntimeError("ANTHROPIC_API_KEY not set")
+
+    client = anthropic.Anthropic(api_key=api_key)
+    resp = client.messages.create(
+        model=CLAUDE_MODEL,
+        max_tokens=2048,
+        system=prompt,
+        messages=[{"role": "user", "content": user_msg}],
+    )
+    text = resp.content[0].text if resp.content else ""
+    return _parse_json(text)
+
+
+def _parse_json(text: str) -> dict:
+    """Extract JSON from LLM output, stripping any markdown fences."""
+    text = text.strip()
+    # Strip ```json ... ``` fences if present
+    if text.startswith("```"):
+        lines = text.splitlines()
+        text = "\n".join(lines[1:-1] if lines[-1].strip() == "```" else lines[1:])
+    # Find first { and last }
+    start = text.find("{")
+    end = text.rfind("}") + 1
+    if start == -1 or end == 0:
+        raise ValueError(f"No JSON object found in response: {text[:200]}")
+    return json.loads(text[start:end])
+
+
+# ---------------------------------------------------------------------------
+# Output builder
+# ---------------------------------------------------------------------------
+
+def _build_pr_description(issue_number: str, title: str, result: dict) -> str:
+    todos_md = "\n".join(
+        f"- [ ] **[{t.get('complexity','?')}]** {t.get('task','')} "
+        f"`{t.get('file','') or ''}`"
+        for t in result.get("todos", [])
+    )
+    relevant = "\n".join(f"- `{f}`" for f in result.get("relevant_files", []))
+    risks = result.get("risk_flags", [])
+    risk_md = (
+        "\n".join(f"- ⚠️ {r}" for r in risks)
+        if risks
+        else "_No risky modules flagged._"
+    )
+    notes = result.get("notes", "")
+
+    # Built by joining lines with no source indentation — textwrap.dedent does
+    # NOT work here because the interpolated multi-line values (todos_md, prompt)
+    # start at column 0, which defeats dedent's common-whitespace detection and
+    # leaves the template lines indented (renders as a code block on GitHub).
+    return (
+        f"## Context Plan — Issue #{issue_number}: {title}\n\n"
+        f"> Auto-generated by the **issue-context-generator** workflow.\n"
+        f"> This is a **DRAFT PR** — implement by triggering the Process Quick Note\n"
+        f"> workflow or by opening a Claude Code session on this branch.\n\n"
+        f"---\n\n"
+        f"## Implementation Prompt\n\n"
+        f"{result.get('prompt', '(prompt generation failed)')}\n\n"
+        f"---\n\n"
+        f"## TODO List\n\n"
+        f"{todos_md or '_No TODOs generated._'}\n\n"
+        f"---\n\n"
+        f"## Relevant Files to Read First\n\n"
+        f"{relevant or '_None identified._'}\n\n"
+        f"---\n\n"
+        f"## Risk Flags\n\n"
+        f"{risk_md}\n\n"
+        f"---\n\n"
+        f"## Architectural Notes\n\n"
+        f"{notes or '_None._'}\n\n"
+        f"---\n\n"
+        f"*Closes #{issue_number}*\n"
+    )
+
+
+def _build_context_doc(issue_number: str, title: str, result: dict, pr_description: str) -> str:
+    return (
+        f"# Issue #{issue_number}: {title}\n\n"
+        f"_Generated: {time.strftime('%Y-%m-%d')}_\n\n"
+        f"{pr_description}\n"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main() -> None:
+    issue_number = sys.argv[1] if len(sys.argv) > 1 else os.environ.get("ISSUE_NUMBER", "?")
+    title = os.environ.get("ISSUE_TITLE", "Untitled issue")
+    body = os.environ.get("ISSUE_BODY", "")
+    labels_raw = os.environ.get("ISSUE_LABELS", "[]")
+
+    try:
+        label_objs = json.loads(labels_raw)
+        labels = [l.get("name", "") if isinstance(l, dict) else str(l) for l in label_objs]
+    except (json.JSONDecodeError, TypeError):
+        labels = []
+
+    log.info("Generating context for issue #%s: %s", issue_number, title)
+
+    codebase_ctx = _load_codebase_context()
+
+    # Fetch the linked article so the plan is grounded in real content, not a
+    # guess. Quick-note issues carry their entire value in the URL.
+    article_content = ""
+    url = _extract_url(title, body)
+    if url:
+        article_content = _fetch_url_content(url)
+
+    user_msg = _build_user_message(
+        issue_number, title, body, labels, codebase_ctx, article_content
+    )
+
+    result: dict = {}
+    errors: list[str] = []
+
+    # Try NVIDIA first, Claude as fallback
+    for caller_name, caller in [("NVIDIA NIM", _call_nvidia), ("Claude", _call_claude)]:
+        try:
+            log.info("Calling %s ...", caller_name)
+            result = caller(SYSTEM_PROMPT, user_msg)
+            log.info("Success with %s", caller_name)
+            break
+        except Exception as exc:
+            log.warning("%s failed: %s", caller_name, exc)
+            errors.append(f"{caller_name}: {exc}")
+
+    if not result:
+        log.error("All LLM providers failed: %s", errors)
+        sys.exit(1)
+
+    pr_description = _build_pr_description(issue_number, title, result)
+    context_doc = _build_context_doc(issue_number, title, result, pr_description)
+
+    output = {
+        "title": result.get("title", f"plan: {title[:60]} (#{issue_number})"),
+        "pr_description": pr_description,
+        "context_doc": context_doc,
+    }
+
+    Path(RESULT_FILE).write_text(json.dumps(output, indent=2))
+    log.info("Context written to %s", RESULT_FILE)
+    log.info("Generated title: %s", output["title"])
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/browser-e2e.yml
+++ b/.github/workflows/browser-e2e.yml
@@ -3,8 +3,10 @@ name: Browser E2E — Playwright (desktop + mobile)
 on:
   push:
     branches: ["**"]
+    paths-ignore: ["docs/context/**"]
   pull_request:
     branches: ["main", "master"]
+    paths-ignore: ["docs/context/**"]
   workflow_dispatch:
 
 permissions:
@@ -18,6 +20,8 @@ jobs:
   browser-e2e:
     name: Playwright browser tests (desktop + mobile)
     runs-on: ubuntu-latest
+    # Skip on draft PRs (e.g. auto-generated context plans).
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
 
     steps:
       - name: Checkout

--- a/.github/workflows/bulk-issue-context.yml
+++ b/.github/workflows/bulk-issue-context.yml
@@ -1,0 +1,403 @@
+name: Bulk Issue Context Generator
+
+# Processes ALL open issues that don't already have a context draft PR.
+# For each eligible issue:
+#   generate prompt + TODO → branch → commit context doc → DRAFT PR → close issue
+#
+# Run this manually to backfill all existing issues, or after bulk imports.
+# New issues going forward are handled automatically by issue-context-generator.yml.
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Dry run — list issues but do NOT create PRs or close issues"
+        required: false
+        type: boolean
+        default: false
+      skip_labels:
+        description: "Comma-separated labels to skip (default: quick-note:exhausted,agency-escalation)"
+        required: false
+        type: string
+        default: "quick-note:exhausted,agency-escalation"
+      max_issues:
+        description: "Max issues to process (0 = all)"
+        required: false
+        type: string
+        default: "20"
+      issue_numbers:
+        description: "Comma-separated issue numbers to target (blank = auto-discover all open). Bypasses skip-label and existing-branch filters."
+        required: false
+        type: string
+        default: ""
+      regenerate:
+        description: "Regenerate context for issues that already have a branch/PR — updates the existing PR in place (no new PR, issue state untouched)"
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
+concurrency:
+  group: bulk-issue-context
+  cancel-in-progress: false
+
+jobs:
+  bulk-process:
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+
+    steps:
+      # ── 1. Checkout ──────────────────────────────────────────────────────────
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GH_PAT }}
+          fetch-depth: 0
+
+      - name: Configure git
+        run: |
+          git config user.email "claude-actions@github.com"
+          git config user.name "Claude Actions [bot]"
+
+      # ── 2. Python setup ──────────────────────────────────────────────────────
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install dependencies
+        run: pip install openai requests anthropic --quiet
+
+      # ── 3. Fetch all open issues ─────────────────────────────────────────────
+      - name: Fetch open issues
+        id: issues
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
+          REPO: ${{ github.repository }}
+          SKIP_LABELS: ${{ github.event.inputs.skip_labels }}
+          SKIP_CSV: ${{ github.event.inputs.skip_labels }}
+          MAX_ISSUES: ${{ github.event.inputs.max_issues }}
+          DRY_RUN: ${{ github.event.inputs.dry_run }}
+          ISSUE_NUMBERS: ${{ github.event.inputs.issue_numbers }}
+          REGENERATE: ${{ github.event.inputs.regenerate }}
+        run: |
+          SKIP_CSV="${SKIP_CSV:-${SKIP_LABELS:-quick-note:exhausted,agency-escalation}}"
+
+          # When explicit issue numbers are given, fetch each one (any state, so
+          # closed issues can be regenerated). Otherwise list all open issues.
+          if [ -n "$ISSUE_NUMBERS" ]; then
+            echo "Targeting explicit issues: $ISSUE_NUMBERS"
+            echo "[]" > /tmp/all_issues.json
+            IFS=',' read -ra NUMS <<< "$ISSUE_NUMBERS"
+            python3 -c "import json; json.dump([], open('/tmp/all_issues.json','w'))"
+            for n in "${NUMS[@]}"; do
+              n=$(echo "$n" | tr -d ' ')
+              [ -z "$n" ] && continue
+              gh issue view "$n" --repo "$REPO" \
+                --json number,title,body,labels > "/tmp/issue_${n}.json" 2>/dev/null || continue
+              python3 -c "
+          import json
+          all_issues = json.load(open('/tmp/all_issues.json'))
+          all_issues.append(json.load(open('/tmp/issue_${n}.json')))
+          json.dump(all_issues, open('/tmp/all_issues.json','w'))
+          "
+            done
+          else
+            gh issue list \
+              --repo "$REPO" \
+              --state open \
+              --limit 200 \
+              --json number,title,body,labels \
+              > /tmp/all_issues.json
+          fi
+
+          # Filter: apply skip-labels and existing-branch checks, unless an
+          # explicit issue list or regenerate mode bypasses them.
+          python3 - <<'PYEOF'
+          import json, os, subprocess
+
+          with open('/tmp/all_issues.json') as f:
+              issues = json.load(f)
+
+          skip_labels = set(x.strip() for x in os.environ.get('SKIP_CSV', '').split(',') if x.strip())
+          max_n = int(os.environ.get('MAX_ISSUES', '20') or '20')
+          dry_run = os.environ.get('DRY_RUN', 'false').lower() == 'true'
+          explicit = bool(os.environ.get('ISSUE_NUMBERS', '').strip())
+          regenerate = os.environ.get('REGENERATE', 'false').lower() == 'true'
+
+          def branch_exists(name):
+              return subprocess.run(
+                  ['git', 'ls-remote', '--exit-code', 'origin', f'refs/heads/{name}'],
+                  capture_output=True
+              ).returncode == 0
+
+          eligible = []
+          for issue in issues:
+              num = issue['number']
+              labels = {l['name'] for l in issue.get('labels', [])}
+
+              # Explicit targeting bypasses skip-label filtering entirely.
+              if not explicit and (labels & skip_labels):
+                  print(f"  SKIP #{num} (labels: {labels & skip_labels})")
+                  continue
+
+              ctx_branch = f"claude/context-issue-{num}"
+              impl_branch = f"quick-note/issue-{num}"
+              has_branch = branch_exists(ctx_branch) or branch_exists(impl_branch)
+
+              if has_branch and not regenerate and not explicit:
+                  print(f"  SKIP #{num} — branch already exists (use regenerate=true to update)")
+                  continue
+
+              # Mark whether this is an in-place regeneration of an existing branch.
+              issue['_regenerate'] = bool(has_branch and (regenerate or explicit))
+              eligible.append(issue)
+
+          if max_n > 0:
+              eligible = eligible[:max_n]
+
+          mode = "REGENERATE" if (regenerate or explicit) else "CREATE"
+          print(f"\nEligible issues ({len(eligible)}) — mode: {mode}:")
+          for i in eligible:
+              tag = " [regen]" if i.get('_regenerate') else ""
+              print(f"  #{i['number']}: {i['title'][:60]}{tag}")
+
+          with open('/tmp/eligible_issues.json', 'w') as f:
+              json.dump(eligible, f, indent=2)
+
+          with open(os.environ['GITHUB_ENV'], 'a') as f:
+              f.write(f"ELIGIBLE_COUNT={len(eligible)}\n")
+              f.write(f"DRY_RUN_MODE={'true' if dry_run else 'false'}\n")
+          PYEOF
+
+          echo "Eligible issue count: $ELIGIBLE_COUNT"
+
+      # ── 4. Process each eligible issue ───────────────────────────────────────
+      - name: Process all eligible issues
+        if: env.ELIGIBLE_COUNT != '0' && env.DRY_RUN_MODE == 'false'
+        env:
+          NVIDIA_API_KEY: ${{ secrets.NVIDIA_API_KEY }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          GH_TOKEN: ${{ secrets.GH_PAT }}
+          REPO: ${{ github.repository }}
+        run: |
+          # Copy the scripts to /tmp BEFORE any git branch switches.
+          # git checkout master removes them (they only live on the feature
+          # branch), so we need stable paths for the whole loop.
+          cp .github/scripts/generate_context.py /tmp/generate_context.py
+          cp .github/scripts/fetch_url.py /tmp/fetch_url.py
+          export REPO_ROOT_PATH="$(pwd)"
+          export FETCH_URL_SCRIPT="/tmp/fetch_url.py"
+
+          python3 - <<'PYEOF'
+          import json, os, re, subprocess, sys, time
+          from pathlib import Path
+
+          issues = json.load(open('/tmp/eligible_issues.json'))
+          repo = os.environ['REPO']
+          gh_token = os.environ['GH_TOKEN']
+          repo_root = os.environ.get('REPO_ROOT_PATH', os.getcwd())
+          results = []
+
+          def run(cmd, **kw):
+              return subprocess.run(cmd, **kw, text=True, capture_output=True)
+
+          for issue in issues:
+              num = str(issue['number'])
+              title = issue['title']
+              body = issue.get('body') or ''
+              labels = json.dumps(issue.get('labels', []))
+              branch = f"claude/context-issue-{num}"
+
+              print(f"\n{'='*60}")
+              print(f"Processing issue #{num}: {title[:60]}")
+              print(f"{'='*60}")
+
+              # ── Generate context ──────────────────────────────────────────
+              # Use /tmp copy of script so it survives git branch switches,
+              # and pass REPO_ROOT so CLAUDE.md / graphify paths still resolve.
+              env = dict(os.environ)
+              env.update({
+                  'ISSUE_NUMBER': num,
+                  'ISSUE_TITLE': title,
+                  'ISSUE_BODY': body[:4000],
+                  'ISSUE_LABELS': labels,
+                  'REPO_ROOT': repo_root,
+              })
+              try:
+                  r = subprocess.run(
+                      ['python3', '/tmp/generate_context.py', num],
+                      env=env, text=True, capture_output=False, timeout=300
+                  )
+                  gen_ok = r.returncode == 0 and Path('/tmp/context_result.json').exists()
+              except subprocess.TimeoutExpired:
+                  print(f"  ✗ Context generation timed out for #{num} (>300s) — skipping")
+                  results.append({'number': num, 'status': 'context_timeout'})
+                  continue
+              if not gen_ok:
+                  print(f"  ✗ Context generation failed for #{num}")
+                  results.append({'number': num, 'status': 'context_failed'})
+                  continue
+
+              result = json.load(open('/tmp/context_result.json'))
+              pr_description = result.get('pr_description', '')
+              context_doc = result.get('context_doc', pr_description)
+              # Context PRs only add docs/context/*.md, so they must carry a
+              # `docs:` title — the changelog-check gate exempts docs:/chore:/etc
+              # prefixes. Strip any feat:/fix: prefix the LLM emitted, then force docs:.
+              raw_title = result.get('title', f'{title[:55]} (#{num})')
+              clean_title = re.sub(
+                  r'^(feat|fix|refactor|chore|docs|style|ci|test|perf|build)(\([^)]*\))?:\s*',
+                  '', raw_title,
+              )
+              pr_title = f"docs: {clean_title}"[:70]
+              is_regen = bool(issue.get('_regenerate'))
+
+              # ── Prepare branch ────────────────────────────────────────────
+              # Regenerate mode updates the EXISTING branch in place (preserves
+              # the open draft PR + its number). Create mode starts fresh from
+              # master. generate_context.py is in /tmp so branch switches are safe.
+              run(['git', 'checkout', 'master'])
+              if is_regen:
+                  fetched = run(['git', 'fetch', 'origin', branch])
+                  if fetched.returncode == 0:
+                      run(['git', 'checkout', '-B', branch, f'origin/{branch}'])
+                  else:
+                      # Branch vanished — fall back to creating it fresh.
+                      is_regen = False
+                      run(['git', 'checkout', '-b', branch])
+              else:
+                  run(['git', 'push', 'origin', '--delete', branch], check=False)
+                  run(['git', 'checkout', '-b', branch])
+
+              # ── Write context doc ─────────────────────────────────────────
+              Path('docs/context').mkdir(parents=True, exist_ok=True)
+              Path(f'docs/context/issue-{num}.md').write_text(context_doc)
+
+              run(['git', 'add', '-A'])
+              diff = run(['git', 'diff', '--staged', '--quiet'])
+              verb = 'regenerate' if is_regen else 'generate'
+              if diff.returncode != 0:
+                  run(['git', 'commit', '-m', f'docs(context): {verb} plan for issue #{num}'])
+                  push = run(['git', 'push', '-u', 'origin', branch])
+                  if push.returncode != 0:
+                      print(f"  ✗ Push failed for #{num}: {push.stderr}")
+                      results.append({'number': num, 'status': 'push_failed'})
+                      continue
+              elif not is_regen:
+                  # New branch with no diff — push an empty commit so a PR can open.
+                  run(['git', 'commit', '--allow-empty', '-m', f'docs(context): init plan branch for #{num}'])
+                  run(['git', 'push', '-u', 'origin', branch])
+              else:
+                  print(f"  • #{num}: regenerated context identical to existing — no change")
+
+              # ── Regenerate: update existing PR body in place ───────────────
+              if is_regen:
+                  existing = subprocess.run(
+                      ['gh', 'pr', 'list', '--repo', repo, '--head', branch,
+                       '--state', 'open', '--json', 'url,number', '--jq', '.[0]'],
+                      capture_output=True, text=True
+                  )
+                  pr_url = ''
+                  if existing.stdout.strip():
+                      pr_obj = json.loads(existing.stdout)
+                      pr_url = pr_obj.get('url', '')
+                  if pr_url:
+                      # Refresh title + body on the existing draft PR.
+                      subprocess.run(
+                          ['gh', 'pr', 'edit', pr_url, '--repo', repo,
+                           '--title', pr_title[:70], '--body', pr_description],
+                          capture_output=True, text=True
+                      )
+                      pr_num = pr_url.rstrip('/').split('/')[-1]
+                      print(f"  ✓ Updated existing draft PR #{pr_num} in place: {pr_url}")
+                      results.append({'number': num, 'status': 'regenerated', 'pr': pr_url})
+                      time.sleep(3)
+                      continue
+                  # No open PR found — fall through to create one.
+                  print(f"  • #{num}: no open PR on branch — creating a fresh draft PR")
+
+              # ── Create draft PR ───────────────────────────────────────────
+              pr = subprocess.run(
+                  ['gh', 'pr', 'create',
+                   '--repo', repo,
+                   '--title', pr_title[:70],
+                   '--body', pr_description,
+                   '--base', 'master',
+                   '--head', branch,
+                   '--draft'],
+                  capture_output=True, text=True
+              )
+              if pr.returncode != 0:
+                  # Try to recover existing PR
+                  existing = subprocess.run(
+                      ['gh', 'pr', 'list', '--repo', repo, '--head', branch,
+                       '--state', 'open', '--json', 'url', '--jq', '.[0].url'],
+                      capture_output=True, text=True
+                  )
+                  pr_url = existing.stdout.strip()
+                  if not pr_url:
+                      print(f"  ✗ PR creation failed for #{num}: {pr.stderr}")
+                      results.append({'number': num, 'status': 'pr_failed'})
+                      continue
+              else:
+                  pr_url = pr.stdout.strip()
+
+              pr_num = pr_url.rstrip('/').split('/')[-1]
+              print(f"  ✓ Draft PR #{pr_num}: {pr_url}")
+
+              # ── Comment on and close issue (only for newly-created PRs) ────
+              comment_body = (
+                  f"🧠 **Context generated** — Draft PR #{pr_num} created with implementation prompt and TODO list.\n\n"
+                  f"**Draft PR:** {pr_url}\n\n"
+                  f"PR is in **draft** status (no code-review bots). "
+                  f"Trigger _Process Quick Note_ or open Claude Code on branch `{branch}` to implement."
+              )
+              subprocess.run(
+                  ['gh', 'issue', 'comment', num, '--repo', repo, '--body', comment_body],
+                  capture_output=True
+              )
+              subprocess.run(
+                  ['gh', 'issue', 'close', num, '--repo', repo, '--reason', 'completed'],
+                  capture_output=True
+              )
+
+              results.append({'number': num, 'status': 'done', 'pr': pr_url})
+              print(f"  ✓ Issue #{num} closed.")
+
+              # Be gentle with API rate limits
+              time.sleep(3)
+
+          print(f"\n\n{'='*60}")
+          print("SUMMARY:")
+          for r in results:
+              status = r['status']
+              pr = r.get('pr', '')
+              print(f"  #{r['number']}: {status} {pr}")
+
+          done = [r for r in results if r['status'] == 'done']
+          failed = [r for r in results if r['status'] != 'done']
+          print(f"\n  ✓ Done: {len(done)}  ✗ Failed: {len(failed)}")
+          PYEOF
+
+      # ── 5. Dry-run summary ────────────────────────────────────────────────────
+      - name: Dry run — list eligible issues (no changes made)
+        if: env.DRY_RUN_MODE == 'true'
+        run: |
+          echo "=== DRY RUN MODE — no PRs created, no issues closed ==="
+          echo ""
+          python3 -c "
+          import json
+          issues = json.load(open('/tmp/eligible_issues.json'))
+          print(f'Would process {len(issues)} issues:')
+          for i in issues:
+              print(f\"  #{i['number']}: {i['title'][:70]}\")
+          "
+
+      # ── 6. No issues to process ───────────────────────────────────────────────
+      - name: Nothing to process
+        if: env.ELIGIBLE_COUNT == '0'
+        run: echo "No eligible open issues found — all issues already have context branches or are excluded."

--- a/.github/workflows/changelog-check.yml
+++ b/.github/workflows/changelog-check.yml
@@ -3,6 +3,7 @@ name: Changelog check
 on:
   pull_request:
     branches: ["main", "master"]
+    paths-ignore: ["docs/context/**"]
 
 permissions:
   contents: read
@@ -11,8 +12,11 @@ jobs:
   changelog:
     name: Require changelog entry
     runs-on: ubuntu-latest
-    # Dependabot PRs never touch changelog — exempt them
-    if: github.actor != 'dependabot[bot]'
+    # Skip Dependabot PRs (never touch changelog) and draft PRs (e.g.
+    # auto-generated context plans, which only add docs/context/*.md).
+    if: >
+      github.actor != 'dependabot[bot]' &&
+      github.event.pull_request.draft == false
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,11 @@ name: CI
 on:
   push:
     branches: ["**"]
+    # Pure-docs context commits (auto-generated issue plans) don't need CI.
+    paths-ignore: ["docs/context/**"]
   pull_request:
     branches: ["main", "master"]
+    paths-ignore: ["docs/context/**"]
 
 concurrency:
   group: ci-${{ github.ref }}
@@ -17,6 +20,9 @@ jobs:
   test:
     name: Test (Python ${{ matrix.python-version }})
     runs-on: ubuntu-latest
+    # Skip CI on draft PRs (e.g. auto-generated context plans). Runs on push
+    # and once a PR is marked ready for review.
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
 
     services:
       mongodb:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -3,8 +3,11 @@ name: E2E — Live server tests (no mocks)
 on:
   push:
     branches: ["**"]
+    # Pure-docs context commits (auto-generated issue plans) don't need E2E.
+    paths-ignore: ["docs/context/**"]
   pull_request:
     branches: ["main", "master"]
+    paths-ignore: ["docs/context/**"]
 
 # Least-privilege token — this job only reads the repo; it writes nothing to
 # GitHub (no deployments, no packages, no issues). Satisfies CodeQL rule
@@ -20,6 +23,8 @@ jobs:
   e2e:
     name: End-to-end live server
     runs-on: ubuntu-latest
+    # Skip on draft PRs (e.g. auto-generated context plans).
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     env:
       STORAGE_BACKEND: sqlite
       KEYS_FILE: e2e-keys.json

--- a/.github/workflows/issue-context-generator.yml
+++ b/.github/workflows/issue-context-generator.yml
@@ -1,0 +1,240 @@
+name: Issue Context Generator
+
+# Triggers whenever a new issue is opened (quick-note OR any issue).
+# Also fires when the 'quick-note' label is added to an existing issue.
+#
+# Pipeline:
+#   open issue → generate prompt + TODO → branch → commit context doc → DRAFT PR → close issue
+#
+# PRs are created in DRAFT status to prevent CodeRabbit / Copilot reviews
+# until a human or the process-quick-note workflow converts to ready.
+
+on:
+  issues:
+    types: [opened, labeled]
+
+# One run per issue at a time; newer events cancel older pending runs for the
+# same issue (e.g. a label added right after open).
+concurrency:
+  group: issue-context-${{ github.event.issue.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
+jobs:
+  generate-context:
+    # Skip labeled events unless the added label is 'quick-note'.
+    # This prevents spurious reruns when unrelated labels are added.
+    if: >
+      github.event.action == 'opened' ||
+      (github.event.action == 'labeled' &&
+       github.event.label.name == 'quick-note')
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      # ── 1. Checkout ──────────────────────────────────────────────────────────
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GH_PAT }}
+          fetch-depth: 0
+
+      # ── 2. Python setup ──────────────────────────────────────────────────────
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install dependencies
+        run: |
+          pip install openai requests anthropic --quiet
+
+      # ── 3. Generate context (prompt + TODO list) ─────────────────────────────
+      - name: Generate context via LLM
+        id: context
+        env:
+          NVIDIA_API_KEY: ${{ secrets.NVIDIA_API_KEY }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          ISSUE_TITLE: ${{ github.event.issue.title }}
+          ISSUE_BODY: ${{ github.event.issue.body }}
+          ISSUE_LABELS: ${{ toJson(github.event.issue.labels) }}
+        run: |
+          python3 .github/scripts/generate_context.py \
+            "$ISSUE_NUMBER" \
+            2>&1 | tee /tmp/context_output.txt
+
+          if [ -f /tmp/context_result.json ]; then
+            echo "generated=true" >> "$GITHUB_OUTPUT"
+            SUGGESTED_TITLE=$(python3 -c "
+          import json, sys
+          d = json.load(open('/tmp/context_result.json'))
+          print(d.get('title', '')[:70])
+            " 2>/dev/null || echo "")
+            echo "title=$SUGGESTED_TITLE" >> "$GITHUB_OUTPUT"
+          else
+            echo "generated=false" >> "$GITHUB_OUTPUT"
+            echo "Context generation failed — see log above."
+          fi
+
+      # ── 4. Create context branch ─────────────────────────────────────────────
+      - name: Create context branch
+        id: branch
+        if: steps.context.outputs.generated == 'true'
+        env:
+          ISSUE_NUM: ${{ github.event.issue.number }}
+        run: |
+          BRANCH="claude/context-issue-${ISSUE_NUM}"
+          git config user.email "claude-actions@github.com"
+          git config user.name "Claude Actions [bot]"
+
+          # Remove any stale branch from a previous run
+          git push origin --delete "$BRANCH" 2>/dev/null || true
+          git checkout -b "$BRANCH"
+          echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
+
+      # ── 5. Write context document and commit ALL logical artifacts ────────────
+      # Any file written by the context script or this step is committed here.
+      # This ensures the draft PR always reflects a logically-complete snapshot.
+      - name: Commit context doc to branch
+        id: commit
+        if: steps.branch.outputs.branch != ''
+        env:
+          ISSUE_NUM: ${{ github.event.issue.number }}
+          BRANCH: ${{ steps.branch.outputs.branch }}
+        run: |
+          mkdir -p docs/context
+
+          # Write the context markdown file
+          python3 - <<'PYEOF'
+          import json, os
+          result = json.load(open('/tmp/context_result.json'))
+          issue = os.environ['ISSUE_NUM']
+          content = result.get('context_doc', result.get('pr_description', ''))
+          with open(f'docs/context/issue-{issue}.md', 'w') as f:
+              f.write(content)
+          print(f"Wrote docs/context/issue-{issue}.md ({len(content)} chars)")
+          PYEOF
+
+          git add -A
+          if git diff --staged --quiet; then
+            echo "No changes to commit."
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            git commit -m "docs(context): generate implementation plan for issue #${ISSUE_NUM}"
+            git push -u origin "$BRANCH"
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo "Context doc committed and pushed to $BRANCH"
+          fi
+
+      # ── 6. Create DRAFT pull request ─────────────────────────────────────────
+      # Draft status prevents CodeRabbit, Copilot, and other review bots from
+      # triggering until the PR is explicitly marked ready for review.
+      - name: Create draft PR
+        id: pr
+        if: steps.branch.outputs.branch != ''
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
+          REPO: ${{ github.repository }}
+          ISSUE_NUM: ${{ github.event.issue.number }}
+          ISSUE_TITLE: ${{ github.event.issue.title }}
+          BRANCH: ${{ steps.branch.outputs.branch }}
+          SUGGESTED_TITLE: ${{ steps.context.outputs.title }}
+        run: |
+          PR_BODY=$(python3 -c "
+          import json, os, sys
+          try:
+              d = json.load(open('/tmp/context_result.json'))
+              print(d.get('pr_description', '(context generation failed)'))
+          except Exception as e:
+              print(f'Error reading context: {e}')
+              sys.exit(1)
+          ")
+
+          # Use LLM-suggested title if available, else derive from issue title
+          if [ -n "$SUGGESTED_TITLE" ]; then
+            RAW_TITLE="$SUGGESTED_TITLE"
+          else
+            RAW_TITLE="${ISSUE_TITLE:0:55} (#${ISSUE_NUM})"
+          fi
+          # Context PRs only add docs/context/*.md — force a `docs:` prefix so the
+          # changelog-check gate exempts them. Strip any feat:/fix: prefix first.
+          CLEAN_TITLE=$(echo "$RAW_TITLE" | sed -E 's/^(feat|fix|refactor|chore|docs|style|ci|test|perf|build)(\([^)]*\))?:[[:space:]]*//')
+          PR_TITLE="docs: ${CLEAN_TITLE}"
+
+          PR_URL=$(gh pr create \
+            --repo "$REPO" \
+            --title "$PR_TITLE" \
+            --body "$PR_BODY" \
+            --base master \
+            --head "$BRANCH" \
+            --draft 2>&1) || {
+            # Recover existing draft PR if one already exists for this branch
+            echo "WARN: gh pr create failed — checking for existing PR"
+            PR_URL=$(gh pr list \
+              --repo "$REPO" \
+              --head "$BRANCH" \
+              --state open \
+              --json url \
+              --jq '.[0].url' 2>/dev/null || echo "")
+          }
+
+          PR_NUM=$(echo "$PR_URL" | grep -oE '[0-9]+$')
+          echo "pr_number=$PR_NUM" >> "$GITHUB_OUTPUT"
+          echo "pr_url=$PR_URL"    >> "$GITHUB_OUTPUT"
+          echo "Draft PR: #$PR_NUM — $PR_URL"
+
+      # ── 7. Close issue — draft PR created ────────────────────────────────────
+      - name: Close issue with draft PR reference
+        if: steps.pr.outputs.pr_number != ''
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
+          REPO: ${{ github.repository }}
+          ISSUE_NUM: ${{ github.event.issue.number }}
+          PR_NUM: ${{ steps.pr.outputs.pr_number }}
+          PR_URL: ${{ steps.pr.outputs.pr_url }}
+        run: |
+          gh issue comment "$ISSUE_NUM" \
+            --repo "$REPO" \
+            --body "$(cat <<MSG
+          🧠 **Context generated** — Draft PR #${PR_NUM} created with a full implementation prompt and TODO list.
+
+          **Draft PR:** ${PR_URL}
+
+          The PR is in **draft** status (no code-review bots triggered). Next steps:
+          - **Auto-implement:** trigger the _Process Quick Note_ workflow with issue \`${ISSUE_NUM}\`
+          - **Manual:** open the branch in Claude Code or your editor and implement against the plan
+
+          The branch \`claude/context-issue-${ISSUE_NUM}\` is ready. When implementation is complete, mark the PR as ready for review.
+          MSG
+          )"
+          gh issue close "$ISSUE_NUM" \
+            --repo "$REPO" \
+            --reason completed
+
+      # ── 8. Failure fallback ───────────────────────────────────────────────────
+      - name: Comment — context generation failed
+        if: >
+          always() &&
+          steps.context.outputs.generated != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
+          REPO: ${{ github.repository }}
+          ISSUE_NUM: ${{ github.event.issue.number }}
+        run: |
+          TAIL=$(tail -30 /tmp/context_output.txt 2>/dev/null || echo "(no log)")
+          gh issue comment "$ISSUE_NUM" \
+            --repo "$REPO" \
+            --body "$(cat <<MSG
+          ⚠️ Context generation failed — no draft PR was created.
+
+          \`\`\`
+          $TAIL
+          \`\`\`
+
+          Please trigger the workflow manually once NVIDIA_API_KEY or ANTHROPIC_API_KEY is confirmed.
+          MSG
+          )" 2>/dev/null || true

--- a/.github/workflows/process-quick-note.yml
+++ b/.github/workflows/process-quick-note.yml
@@ -186,22 +186,36 @@ jobs:
           echo "fetch_chars=$CHARS" >> "$GITHUB_OUTPUT"
           echo "Fetched $CHARS chars"
 
-      # ── 7. Create feature branch ───────────────────────────────────────────
-      - name: Create feature branch
+      # ── 7. Create / reuse feature branch ─────────────────────────────────────
+      # If a context branch was already created by the issue-context-generator
+      # workflow (claude/context-issue-N), reuse it so implementation commits
+      # land on the existing draft PR rather than opening a second PR.
+      - name: Create or reuse feature branch
         id: branch
         if: steps.pick.outputs.found == 'true' && steps.fetch.outputs.fetch_chars != ''
         env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
           ISSUE_NUM: ${{ steps.issue.outputs.number }}
+          REPO: ${{ github.repository }}
         run: |
-          BRANCH="quick-note/issue-$ISSUE_NUM"
           git config user.email "claude-actions@github.com"
           git config user.name "Claude Actions [bot]"
 
-          # Clean up any stale branch
-          git push origin --delete "$BRANCH" 2>/dev/null || true
-          git checkout -b "$BRANCH"
+          CONTEXT_BRANCH="claude/context-issue-${ISSUE_NUM}"
+          IMPL_BRANCH="quick-note/issue-${ISSUE_NUM}"
 
-          echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
+          # Check if a context branch (from issue-context-generator) already exists
+          if git ls-remote --exit-code origin "refs/heads/${CONTEXT_BRANCH}" 2>/dev/null; then
+            echo "Reusing existing context branch: $CONTEXT_BRANCH"
+            git fetch origin "$CONTEXT_BRANCH"
+            git checkout -b "$CONTEXT_BRANCH" "origin/$CONTEXT_BRANCH"
+            echo "branch=$CONTEXT_BRANCH" >> "$GITHUB_OUTPUT"
+          else
+            # Fall back to a fresh implementation branch
+            git push origin --delete "$IMPL_BRANCH" 2>/dev/null || true
+            git checkout -b "$IMPL_BRANCH"
+            echo "branch=$IMPL_BRANCH" >> "$GITHUB_OUTPUT"
+          fi
 
       # ── 8. Implement features with Claude ──────────────────────────────────
       - name: Implement features (Claude agentic loop)
@@ -340,21 +354,35 @@ jobs:
           PRBODY
           )"
 
-          PR_URL=$(gh pr create \
+          # Check for an existing draft PR on this branch (created by issue-context-generator)
+          EXISTING_PR=$(gh pr list \
             --repo "$REPO" \
-            --title "feat: implement quick-note issue #$ISSUE_NUM" \
-            --body "$PR_BODY" \
-            --base master \
-            --head "$BRANCH" 2>&1) || {
-            # gh pr create may fail if a PR already exists for this branch; recover it
-            echo "WARN: gh pr create failed ($PR_URL) — checking for existing PR on branch"
-            PR_URL=$(gh pr list \
+            --head "$BRANCH" \
+            --state open \
+            --json url,number,isDraft \
+            --jq '.[0]' 2>/dev/null || echo "")
+
+          if [ -n "$EXISTING_PR" ] && [ "$EXISTING_PR" != "null" ]; then
+            echo "Found existing PR on branch $BRANCH — reusing it"
+            PR_URL=$(echo "$EXISTING_PR" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d['url'])")
+          else
+            # Create a new DRAFT PR — draft prevents CodeRabbit/Copilot reviews until ready
+            PR_URL=$(gh pr create \
               --repo "$REPO" \
+              --title "feat: implement quick-note issue #$ISSUE_NUM" \
+              --body "$PR_BODY" \
+              --base master \
               --head "$BRANCH" \
-              --state open \
-              --json url \
-              --jq '.[0].url' 2>/dev/null || echo "")
-          }
+              --draft 2>&1) || {
+              echo "WARN: gh pr create failed ($PR_URL) — checking for existing PR"
+              PR_URL=$(gh pr list \
+                --repo "$REPO" \
+                --head "$BRANCH" \
+                --state open \
+                --json url \
+                --jq '.[0].url' 2>/dev/null || echo "")
+            }
+          fi
 
           PR_NUM=$(echo "$PR_URL" | grep -oE '[0-9]+$')
           echo "pr_number=$PR_NUM" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/security-gate.yml
+++ b/.github/workflows/security-gate.yml
@@ -3,6 +3,7 @@ name: Security Gate
 on:
   pull_request:
     branches: [master]
+    paths-ignore: ["docs/context/**"]
 
 permissions:
   security-events: write
@@ -17,6 +18,8 @@ jobs:
   security-gate:
     name: Security Gate — No New Alerts
     runs-on: ubuntu-latest
+    # Skip on draft PRs (e.g. auto-generated context plans).
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -3,8 +3,10 @@ name: "Security Scan"
 on:
   push:
     branches: [master]
+    paths-ignore: ["docs/context/**"]
   pull_request:
     branches: [master]
+    paths-ignore: ["docs/context/**"]
   schedule:
     - cron: '30 2 * * 1'   # Weekly on Monday at 02:30 UTC
   workflow_dispatch:

--- a/README.md
+++ b/README.md
@@ -274,6 +274,66 @@ Drop a task from anywhere — no laptop needed.
 
 ---
 
+## Issue → Context → Draft PR automation
+
+Every GitHub issue is automatically turned into an actionable, codebase-aware
+implementation plan — no manual triage required.
+
+```text
+issue opened (or `quick-note` label added)
+        ↓
+  [issue-context-generator workflow]
+        ↓
+  fetch linked URL (multi-strategy)  ──►  NVIDIA NIM (free models)
+        ↓                                 fallback: Claude Opus
+  generate: implementation prompt + prioritised TODO list
+            + relevant files + risk flags, grounded in CLAUDE.md
+            and the graphify codebase graph
+        ↓
+  commit docs/context/issue-N.md  ──►  open DRAFT PR  ──►  close issue
+```
+
+**Why draft PRs?** Draft status suppresses CodeRabbit / Copilot auto-reviews,
+so the plan lands cleanly without burning review cycles. When you (or the
+*Process Quick Note* workflow) implement against the plan, mark the PR ready
+for review.
+
+### The workflows
+
+| Workflow | Trigger | What it does |
+|----------|---------|--------------|
+| **`issue-context-generator.yml`** | Any issue `opened`, or `quick-note` label added | Fetches the linked URL, generates a grounded prompt + TODO plan, commits `docs/context/issue-N.md`, opens a **draft PR**, closes the issue. |
+| **`bulk-issue-context.yml`** | Manual (`workflow_dispatch`) | Backfills **all** open issues in one run. Supports `dry_run`, label exclusions, explicit `issue_numbers` targeting, and `regenerate` mode (updates an existing draft PR in place — preserves the PR number). |
+| **`process-quick-note.yml`** | Schedule / manual | Picks up a context branch and implements the plan — runs the agentic loop, tests, applies review feedback, and opens its PR as a **draft**. Reuses an existing `claude/context-issue-N` branch so implementation commits land on the pre-built draft PR. |
+
+### Free-first model routing
+
+Context generation runs on **free NVIDIA NIM models** by preference —
+`qwen/qwen3-coder-480b-a35b-instruct` → `nvidia/llama-3.3-nemotron-super-49b-v1`
+→ `meta/llama-3.3-70b-instruct` → `qwen/qwen2.5-coder-32b-instruct`, with
+Claude Opus as a final fallback only if every NVIDIA model is unavailable.
+
+### Backfilling existing issues
+
+```bash
+# Dry run — list what would be processed, change nothing
+gh workflow run bulk-issue-context.yml -f dry_run=true
+
+# Process all open issues (skips exhausted / agency-escalation by default)
+gh workflow run bulk-issue-context.yml
+
+# Target specific issues; regenerate updates existing draft PRs in place
+gh workflow run bulk-issue-context.yml \
+  -f issue_numbers="416,398,364" -f regenerate=true
+```
+
+> **Note:** the `issues`-event auto-trigger only fires once these workflows are
+> on the **default branch (master)** — GitHub runs event-triggered workflows
+> from master only. Before merge, use `workflow_dispatch` (the `bulk-issue-context`
+> commands above) to process issues from any branch.
+
+---
+
 ## Privacy, security, and cost
 
 ### Your data never leaves your server

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -28,8 +28,17 @@
 
 ## [Unreleased]
 
+### Added
+- **Issue → Context → Draft PR automation.** Three workflows turn every GitHub issue into a codebase-aware implementation plan: `issue-context-generator.yml` (triggers on any issue opened / `quick-note` label — fetches the linked URL, calls free NVIDIA NIM models with Claude Opus fallback, generates an implementation prompt + prioritised TODO list grounded in CLAUDE.md and the graphify graph, commits `docs/context/issue-N.md`, opens a **draft PR**, closes the issue); `bulk-issue-context.yml` (`workflow_dispatch` to backfill all open issues, with `dry_run`, label exclusions, explicit `issue_numbers` targeting, and `regenerate` mode that updates existing draft PRs in place); and `.github/scripts/generate_context.py` (the LLM engine — 4-model NVIDIA fallback chain, URL grounding via the shared `fetch_url.py`, structured JSON output). Replaces the old static-template `enrich-quick-note-context.yml` which added no LLM reasoning and never created PRs.
+- **README — "Issue → Context → Draft PR automation" section** documenting the pipeline, free-first NVIDIA model routing, backfill commands, and the master-branch auto-trigger caveat.
+
+### Changed
+- **`process-quick-note.yml`** — PR creation now uses `--draft` (suppresses CodeRabbit/Copilot auto-reviews on implementation PRs). Branch creation detects and reuses an existing `claude/context-issue-N` branch so implementation commits land on the pre-built draft PR instead of opening a duplicate.
+- **CI no longer runs on draft PRs or docs-only context commits.** `paths-ignore: ["docs/context/**"]` added to the push/pull_request triggers of `ci.yml`, `e2e.yml`, `browser-e2e.yml`, `security-gate.yml`, `changelog-check.yml`, `security-scan.yml`, plus `if: github.event.pull_request.draft == false` job guards on `ci.yml`, `e2e.yml`, `browser-e2e.yml`, `security-gate.yml`, `changelog-check.yml`. Draft status only stops review bots, not GitHub Actions — these guards stop auto-generated context draft PRs from triggering the full CI suite.
+- **Context PR titles use a `docs:` prefix** so the `changelog-check` gate exempts them (context PRs only add `docs/context/*.md`).
+
 ### Fixed
-^- **All 20 V5 screens audited for swallowed errors; approve/retry now show inline error banners.** `handleRetry` previously had a bare `catch (_) {}` swallowing all errors silently; now shows a yellow click-to-dismiss actionError banner. `handleApprove` filters out expected 404/400 (optimistic: no checkpoint to approve) but surfaces real failures.
+- **All 20 V5 screens audited for swallowed errors; approve/retry now show inline error banners.** `handleRetry` previously had a bare `catch (_) {}` swallowing all errors silently; now shows a yellow click-to-dismiss actionError banner. `handleApprove` filters out expected 404/400 (optimistic: no checkpoint to approve) but surfaces real failures.
 
 - **Browser E2E now covers 20 pages (was 13).** Added 7 missing V5 routes: `/intelligence`, `/company`, `/github`, `/skills`, `/doctor`, `/onboarding`, `/admin`.
 


### PR DESCRIPTION
## What this is

The **implemented automation** extracted from the roadmap PR #406 into a focused, reviewable PR, so it can land on `master` and actually take effect. (The roadmap doc + killer TODO backlog stay in #406 for separate review — nothing is lost.)

**Why extract?** GitHub reads `pull_request` workflow config from the **base branch (master)**. The CI guards and the issue→context auto-trigger only activate once they're on master — they can't take effect while sitting in a feature PR.

## What's included

### Issue → Context → Draft PR pipeline
- **`.github/workflows/issue-context-generator.yml`** — on any issue opened (or `quick-note` label added): fetches the linked URL, calls free **NVIDIA NIM** models (Qwen3-Coder 480B → Nemotron → Llama 3.3, Claude Opus fallback), generates a codebase-aware implementation **prompt + prioritised TODO list** grounded in `CLAUDE.md` and the graphify graph, commits `docs/context/issue-N.md`, opens a **draft PR**, and closes the issue.
- **`.github/workflows/bulk-issue-context.yml`** — `workflow_dispatch` to backfill all open issues. Supports `dry_run`, label exclusions, explicit `issue_numbers` targeting (any state), and `regenerate` (updates existing draft PRs in place, preserving PR numbers).
- **`.github/scripts/generate_context.py`** — the LLM engine: 4-model NVIDIA fallback chain, URL grounding via the shared `fetch_url.py`, structured JSON output (PR description, todos, relevant files, risk flags). Bandit-clean.

### CI hygiene (the resource-waste fix)
- `paths-ignore: ["docs/context/**"]` on the push/PR triggers of `ci.yml`, `e2e.yml`, `browser-e2e.yml`, `security-gate.yml`, `changelog-check.yml`, `security-scan.yml`.
- `if: github.event.pull_request.draft == false` job guards on `ci.yml`, `e2e.yml`, `browser-e2e.yml`, `security-gate.yml`, `changelog-check.yml`.
- **Draft status only stops review bots, not GitHub Actions** — these guards stop the auto-generated context draft PRs from triggering the full CI suite.
- `process-quick-note.yml` now opens **draft** PRs and reuses `claude/context-issue-N` branches.
- Context PR titles use a `docs:` prefix so `changelog-check` exempts them (they only add `docs/context/*.md`).

## After merge
- New issues auto-generate a context plan + draft PR (no manual dispatch needed).
- Draft PRs and docs-only context commits stop triggering CI.
- `changelog-check` stops failing on context PRs.

Extracted from #406. Roadmap / killer-TODO backlog remains in #406.

https://claude.ai/code/session_01MhS39wpGuP3KsQNMAXZ82Z

---
_Generated by [Claude Code](https://claude.ai/code/session_01MhS39wpGuP3KsQNMAXZ82Z)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automated issue-to-draft-PR workflow that converts GitHub issues into codebase-aware implementation plans with generated context documents.

* **Bug Fixes**
  * V5 screens now display inline dismissible error banners instead of silently suppressing errors.

* **Chores**
  * Optimized CI workflows to skip draft pull requests and documentation-only commits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->