### PR TITLE
fix(auth): repair broken GitHub and Google social login

### DIFF
--- a/.claude/state/active-tasks.md
+++ b/.claude/state/active-tasks.md
@@ -26,6 +26,7 @@
 | 2 | Dynamic Session Planning Workflow (this task) | `IN_PROGRESS` | [#406](https://github.com/strikersam/local-llm-server/pull/406) | hooks + tracker + AGENTS.md update | 2026-06-05 |
 | 3 | Agentic Portfolio Management (WSJF) + v5 Portfolio screen | `DONE` | #423, #426 | portfolio.py, agile health/retro, v5 board | 2026-06-06 |
 | 4 | Autonomous Portfolio Intelligence (signals → initiatives, 6h cron) | `IN_PROGRESS` | claude/portfolio-autonomous | portfolio_intelligence.py + refresh workflow + UI provenance | 2026-06-06 |
+| 5 | Fix social login (Google & GitHub OAuth) | `DONE` | `claude/social-login-google-github-BBGoT` | 3 bugs fixed in backend/server.py — see bug log #4-6 | 2026-06-06 |
 
 ---
 
@@ -36,6 +37,9 @@
 | 1 | NVIDIA NIM double `/v1` URL in `agent/loop.py` line 911 | 2026-06-03 | 2026-06-03 | #397 | `BUG_FIXED` |
 | 2 | ProviderManager vs ProviderRouter type mismatch in `direct_chat.py` | 2026-06-03 | 2026-06-03 | #399 | `BUG_FIXED` |
 | 3 | TaskBoardScreen create-task modal silently swallowed API errors | 2026-06-05 | 2026-06-05 | #406 parent | `BUG_FIXED` |
+| 4 | GitHub+Google share `session["oauth_state"]` — CSRF check always fails on multi-tab/provider-switch | 2026-06-06 | 2026-06-06 | `claude/social-login-google-github-BBGoT` | `BUG_FIXED` |
+| 5 | Google redirect_uri via `url_for` breaks behind proxy — token exchange rejected by Google | 2026-06-06 | 2026-06-06 | `claude/social-login-google-github-BBGoT` | `BUG_FIXED` |
+| 6 | GitHub OAuth URL missing `redirect_uri`; no timeout on httpx clients in login flows | 2026-06-06 | 2026-06-06 | `claude/social-login-google-github-BBGoT` | `BUG_FIXED` |
 
 ---
 

--- a/.env.example
+++ b/.env.example
@@ -129,6 +129,11 @@ ADMIN_PASSWORD=changeme        # SET THIS before exposing the server
 # GH_TOKEN=                    # Alternate env name
 # GITHUB_CLIENT_ID=            # OAuth App client ID (optional)
 # GITHUB_CLIENT_SECRET=        # OAuth App client secret (optional)
+# GOOGLE_CLIENT_ID=            # Google OAuth 2.0 client ID (optional)
+# GOOGLE_CLIENT_SECRET=        # Google OAuth 2.0 client secret (optional)
+# OAUTH_REDIRECT_BASE=         # Public base URL of this server, e.g. https://myserver.com
+#                              # Must match the callback URL registered in GitHub/Google OAuth Apps.
+#                              # Leave unset for local dev (http://localhost:8001 auto-detected).
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # Website Scanner

--- a/backend/server.py
+++ b/backend/server.py
@@ -1144,6 +1144,10 @@ GITHUB_CLIENT_SECRET = os.environ.get("GITHUB_CLIENT_SECRET", "")
 GOOGLE_CLIENT_ID = os.environ.get("GOOGLE_CLIENT_ID", "")
 GOOGLE_CLIENT_SECRET = os.environ.get("GOOGLE_CLIENT_SECRET", "")
 SESSION_SECRET = os.environ.get("SESSION_SECRET", JWT_SECRET)
+# Base URL of this server — used for OAuth callback URIs.
+# Must match exactly what is registered in GitHub/Google OAuth App settings.
+# Example: https://myserver.com  (no trailing slash)
+OAUTH_REDIRECT_BASE = os.environ.get("OAUTH_REDIRECT_BASE", "").rstrip("/")
 
 # ─── Auth Helpers ───────────────────────────────────────────────────────────────
 
@@ -1307,10 +1311,16 @@ async def github_login(request: Request):
     if not GITHUB_CLIENT_ID:
         raise HTTPException(status_code=503, detail="GitHub login not configured")
     state = secrets.token_urlsafe(32)
-    request.session["oauth_state"] = state
+    request.session["github_oauth_state"] = state
+    redirect_uri = (
+        f"{OAUTH_REDIRECT_BASE}/api/auth/github/callback"
+        if OAUTH_REDIRECT_BASE
+        else str(request.url_for("github_callback"))
+    )
     url = (
         f"https://github.com/login/oauth/authorize"
         f"?client_id={GITHUB_CLIENT_ID}&state={state}&scope=user:email"
+        f"&redirect_uri={redirect_uri}"
     )
     return RedirectResponse(url)
 
@@ -1398,105 +1408,112 @@ async def github_callback(request: Request, code: str = None, state: str = None)
         return _oauth_popup_html(True, login=login)
 
     # Login flow: state was stored in the session by /api/auth/github/login
-    if state != request.session.pop("oauth_state", None):
+    if state != request.session.pop("github_oauth_state", None):
         raise HTTPException(status_code=400, detail="Invalid OAuth state")
 
-    async with httpx.AsyncClient() as client:
-        # 1. Exchange code for token
-        resp = await client.post(
-            "https://github.com/login/oauth/access_token",
-            data={
-                "client_id": GITHUB_CLIENT_ID,
-                "client_secret": GITHUB_CLIENT_SECRET,
-                "code": code,
-            },
-            headers={"Accept": "application/json"},
-        )
-        resp.raise_for_status()
-        token_data = resp.json()
-        access_token = token_data.get("access_token")
-        if not access_token:
-            raise HTTPException(status_code=400, detail="GitHub token exchange failed")
+    try:
+        async with httpx.AsyncClient(timeout=15) as client:
+            # 1. Exchange code for token
+            resp = await client.post(
+                "https://github.com/login/oauth/access_token",
+                data={
+                    "client_id": GITHUB_CLIENT_ID,
+                    "client_secret": GITHUB_CLIENT_SECRET,
+                    "code": code,
+                },
+                headers={"Accept": "application/json"},
+            )
+            resp.raise_for_status()
+            token_data = resp.json()
+            access_token = token_data.get("access_token")
+            if not access_token:
+                err = token_data.get("error_description") or token_data.get("error") or "No token returned"
+                raise HTTPException(status_code=400, detail=f"GitHub token exchange failed: {err}")
 
-        # 2. Get user info
-        user_resp = await client.get(
-            "https://api.github.com/user",
-            headers={"Authorization": f"token {access_token}"},
-        )
-        user_resp.raise_for_status()
-        gh_user = user_resp.json()
-
-        # 3. Get email (GitHub might not return it in the main user object)
-        email = gh_user.get("email")
-        if not email:
-            email_resp = await client.get(
-                "https://api.github.com/user/emails",
+            # 2. Get user info
+            user_resp = await client.get(
+                "https://api.github.com/user",
                 headers={"Authorization": f"token {access_token}"},
             )
-            email_resp.raise_for_status()
-            emails = email_resp.json()
-            # Find primary verified email
-            primary = next(
-                (e for e in emails if e.get("primary") and e.get("verified")), None
-            )
-            email = (
-                primary.get("email")
-                if primary
-                else (emails[0].get("email") if emails else None)
-            )
+            user_resp.raise_for_status()
+            gh_user = user_resp.json()
 
-        if not email:
-            raise HTTPException(
-                status_code=400, detail="Could not retrieve email from GitHub"
-            )
+            # 3. Get email (GitHub might not return it in the main user object)
+            email = gh_user.get("email")
+            if not email:
+                email_resp = await client.get(
+                    "https://api.github.com/user/emails",
+                    headers={"Authorization": f"token {access_token}"},
+                )
+                email_resp.raise_for_status()
+                emails = email_resp.json()
+                # Find primary verified email
+                primary = next(
+                    (e for e in emails if e.get("primary") and e.get("verified")), None
+                )
+                email = (
+                    primary.get("email")
+                    if primary
+                    else (emails[0].get("email") if emails else None)
+                )
+    except HTTPException:
+        raise
+    except Exception as exc:
+        log.error("GitHub OAuth login error: %s", exc)
+        raise HTTPException(status_code=502, detail="GitHub OAuth request failed")
 
-        # 4. Find or create user
-        user = await get_db().users.find_one({"email": email.lower()})
-        uid_str = str(gh_user["id"])
-        now = datetime.now(timezone.utc).isoformat()
-
-        if not user:
-            # Automatic registration
-            new_user = {
-                "email": email.lower(),
-                "name": gh_user.get("name") or gh_user.get("login"),
-                "avatar_url": gh_user.get("avatar_url"),
-                "provider": "github",
-                "provider_user_id": uid_str,
-                "role": "user",
-                "created_at": now,
-                "last_login": now,
-            }
-            result = await get_db().users.insert_one(new_user)
-            user_id = str(result.inserted_id)
-            await log_activity(
-                "auth", f"New user {email} registered via GitHub", user_id=user_id
-            )
-        else:
-            # Update existing user with social info if missing or just update last_login
-            user_id = str(user["_id"])
-            await get_db().users.update_one(
-                {"_id": user["_id"]},
-                {
-                    "$set": {
-                        "last_login": now,
-                        "provider": user.get("provider", "github"),
-                        "provider_user_id": user.get("provider_user_id", uid_str),
-                        "avatar_url": user.get("avatar_url")
-                        or gh_user.get("avatar_url"),
-                    }
-                },
-            )
-            await log_activity(
-                "auth", f"User {email} logged in via GitHub", user_id=user_id
-            )
-
-        # 5. Generate tokens and redirect to frontend
-        access = create_access_token(user_id, email)
-        refresh = create_refresh_token(user_id)
-        return RedirectResponse(
-            f"{frontend_url}/auth/callback?access_token={access}&refresh_token={refresh}"
+    if not email:
+        raise HTTPException(
+            status_code=400, detail="Could not retrieve email from GitHub"
         )
+
+    # 4. Find or create user
+    user = await get_db().users.find_one({"email": email.lower()})
+    uid_str = str(gh_user["id"])
+    now = datetime.now(timezone.utc).isoformat()
+
+    if not user:
+        # Automatic registration
+        new_user = {
+            "email": email.lower(),
+            "name": gh_user.get("name") or gh_user.get("login"),
+            "avatar_url": gh_user.get("avatar_url"),
+            "provider": "github",
+            "provider_user_id": uid_str,
+            "role": "user",
+            "created_at": now,
+            "last_login": now,
+        }
+        result = await get_db().users.insert_one(new_user)
+        user_id = str(result.inserted_id)
+        await log_activity(
+            "auth", f"New user {email} registered via GitHub", user_id=user_id
+        )
+    else:
+        # Update existing user with social info if missing or just update last_login
+        user_id = str(user["_id"])
+        await get_db().users.update_one(
+            {"_id": user["_id"]},
+            {
+                "$set": {
+                    "last_login": now,
+                    "provider": user.get("provider", "github"),
+                    "provider_user_id": user.get("provider_user_id", uid_str),
+                    "avatar_url": user.get("avatar_url")
+                    or gh_user.get("avatar_url"),
+                }
+            },
+        )
+        await log_activity(
+            "auth", f"User {email} logged in via GitHub", user_id=user_id
+        )
+
+    # 5. Generate tokens and redirect to frontend
+    access = create_access_token(user_id, email)
+    refresh = create_refresh_token(user_id)
+    return RedirectResponse(
+        f"{frontend_url}/auth/callback?access_token={access}&refresh_token={refresh}"
+    )
 
 
 @app.get("/api/auth/github/repo-access")
@@ -1678,11 +1695,14 @@ async def google_login(request: Request):
     if not GOOGLE_CLIENT_ID:
         raise HTTPException(status_code=503, detail="Google login not configured")
     state = secrets.token_urlsafe(32)
-    request.session["oauth_state"] = state
-    # Simplified redirect URI - in production this must match exactly what is in Google Console
-    redirect_uri = f"{request.url_for('google_callback')}"
-    # Ensure it's using the correct scheme (handled by middleware usually, but explicit is safer for some proxies)
-    # However, for simplicity we rely on FastAPI's url_for.
+    request.session["google_oauth_state"] = state
+    # Use OAUTH_REDIRECT_BASE so the redirect_uri matches what is registered in Google Console.
+    # Falls back to url_for only in local dev where no proxy is involved.
+    redirect_uri = (
+        f"{OAUTH_REDIRECT_BASE}/api/auth/google/callback"
+        if OAUTH_REDIRECT_BASE
+        else str(request.url_for("google_callback"))
+    )
     url = (
         f"https://accounts.google.com/o/oauth2/v2/auth"
         f"?client_id={GOOGLE_CLIENT_ID}&response_type=code&scope=openid%20email%20profile"
@@ -1695,92 +1715,98 @@ async def google_login(request: Request):
 async def google_callback(request: Request, code: str = None, state: str = None):
     if not code or not state:
         raise HTTPException(status_code=400, detail="Missing code or state")
-    if state != request.session.pop("oauth_state", None):
+    if state != request.session.pop("google_oauth_state", None):
         raise HTTPException(status_code=400, detail="Invalid OAuth state")
 
-    async with httpx.AsyncClient() as client:
-        # 1. Exchange code for token
-        redirect_uri = f"{request.url_for('google_callback')}"
-        resp = await client.post(
-            "https://oauth2.googleapis.com/token",
-            data={
-                "client_id": GOOGLE_CLIENT_ID,
-                "client_secret": GOOGLE_CLIENT_SECRET,
-                "code": code,
-                "grant_type": "authorization_code",
-                "redirect_uri": redirect_uri,
-            },
-        )
-        resp.raise_for_status()
-        token_data = resp.json()
-        access_token = token_data.get("access_token")
-        if not access_token:
-            raise HTTPException(status_code=400, detail="Google token exchange failed")
+    # redirect_uri must be identical to the one used in /api/auth/google/login
+    redirect_uri = (
+        f"{OAUTH_REDIRECT_BASE}/api/auth/google/callback"
+        if OAUTH_REDIRECT_BASE
+        else str(request.url_for("google_callback"))
+    )
 
-        # 2. Get user info
-        user_resp = await client.get(
-            "https://www.googleapis.com/oauth2/v3/userinfo",
-            headers={"Authorization": f"Bearer {access_token}"},
-        )
-        user_resp.raise_for_status()
-        g_user = user_resp.json()
-
-        email = g_user.get("email")
-        if not email:
-            raise HTTPException(
-                status_code=400, detail="Could not retrieve email from Google"
-            )
-
-        # 3. Find or create user
-        user = await get_db().users.find_one({"email": email.lower()})
-        uid_str = str(g_user.get("sub"))
-        now = datetime.now(timezone.utc).isoformat()
-
-        if not user:
-            new_user = {
-                "email": email.lower(),
-                "name": g_user.get("name"),
-                "avatar_url": g_user.get("picture"),
-                "provider": "google",
-                "provider_user_id": uid_str,
-                "role": "user",
-                "created_at": now,
-                "last_login": now,
-            }
-            result = await get_db().users.insert_one(new_user)
-            user_id = str(result.inserted_id)
-            try:
-                await log_activity(
-                    "auth", f"New user {email} registered via Google", user_id=user_id
-                )
-            except NameError:
-                pass
-        else:
-            user_id = str(user["_id"])
-            await get_db().users.update_one(
-                {"_id": user["_id"]},
-                {
-                    "$set": {
-                        "last_login": now,
-                        "provider": user.get("provider", "google"),
-                        "provider_user_id": user.get("provider_user_id", uid_str),
-                        "avatar_url": user.get("avatar_url") or g_user.get("picture"),
-                    }
+    try:
+        async with httpx.AsyncClient(timeout=15) as client:
+            # 1. Exchange code for token
+            resp = await client.post(
+                "https://oauth2.googleapis.com/token",
+                data={
+                    "client_id": GOOGLE_CLIENT_ID,
+                    "client_secret": GOOGLE_CLIENT_SECRET,
+                    "code": code,
+                    "grant_type": "authorization_code",
+                    "redirect_uri": redirect_uri,
                 },
             )
-            try:
-                await log_activity(
-                    "auth", f"User {email} logged in via Google", user_id=user_id
-                )
-            except NameError:
-                pass
+            resp.raise_for_status()
+            token_data = resp.json()
+            access_token = token_data.get("access_token")
+            if not access_token:
+                raise HTTPException(status_code=400, detail="Google token exchange failed")
 
-        # 4. Generate tokens and redirect to frontend
-        access = create_access_token(user_id, email)
-        refresh = create_refresh_token(user_id)
-        return RedirectResponse(
-            f"{frontend_url}/auth/callback?access_token={access}&refresh_token={refresh}"
+            # 2. Get user info
+            user_resp = await client.get(
+                "https://www.googleapis.com/oauth2/v3/userinfo",
+                headers={"Authorization": f"Bearer {access_token}"},
+            )
+            user_resp.raise_for_status()
+            g_user = user_resp.json()
+    except HTTPException:
+        raise
+    except Exception as exc:
+        log.error("Google OAuth login error: %s", exc)
+        raise HTTPException(status_code=502, detail="Google OAuth request failed")
+
+    email = g_user.get("email")
+    if not email:
+        raise HTTPException(
+            status_code=400, detail="Could not retrieve email from Google"
         )
+
+    # 3. Find or create user
+    user = await get_db().users.find_one({"email": email.lower()})
+    uid_str = str(g_user.get("sub"))
+    now = datetime.now(timezone.utc).isoformat()
+
+    if not user:
+        new_user = {
+            "email": email.lower(),
+            "name": g_user.get("name"),
+            "avatar_url": g_user.get("picture"),
+            "provider": "google",
+            "provider_user_id": uid_str,
+            "role": "user",
+            "created_at": now,
+            "last_login": now,
+        }
+        result = await get_db().users.insert_one(new_user)
+        user_id = str(result.inserted_id)
+        await log_activity(
+            "auth", f"New user {email} registered via Google", user_id=user_id
+        )
+    else:
+        user_id = str(user["_id"])
+        await get_db().users.update_one(
+            {"_id": user["_id"]},
+            {
+                "$set": {
+                    "last_login": now,
+                    "provider": user.get("provider", "google"),
+                    "provider_user_id": user.get("provider_user_id", uid_str),
+                    "avatar_url": user.get("avatar_url") or g_user.get("picture"),
+                }
+            },
+        )
+        await log_activity(
+            "auth", f"User {email} logged in via Google", user_id=user_id
+        )
+
+    # 4. Generate tokens and redirect to frontend
+    access = create_access_token(user_id, email)
+    refresh = create_refresh_token(user_id)
+    return RedirectResponse(
+        f"{frontend_url}/auth/callback?access_token={access}&refresh_token={refresh}"
+    )
 
 
 app.add_middleware(

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -43,6 +43,12 @@
 - **Context PR titles use a `docs:` prefix** so the `changelog-check` gate exempts them (context PRs only add `docs/context/*.md`).
 
 ### Fixed
+- **Social login (GitHub & Google OAuth) broken by three bugs in `backend/server.py`.**
+  1. *Session key collision*: Both `github_login` and `google_login` wrote to the same `session["oauth_state"]` key; starting one flow after the other (or in a multi-tab scenario) silently overwrote the state, causing the callback's CSRF check to always fail with "Invalid OAuth state". Fixed by using provider-specific keys: `github_oauth_state` and `google_oauth_state`.
+  2. *Google redirect_uri mismatch*: The callback used `request.url_for("google_callback")` which generates the wrong scheme/host behind a reverse proxy, causing Google's token exchange to reject the request. Fixed: both `/api/auth/google/login` and `/api/auth/google/callback` now derive `redirect_uri` from the new `OAUTH_REDIRECT_BASE` env var (with a local-dev fallback to `url_for`).
+  3. *Missing redirect_uri for GitHub*: GitHub OAuth authorize URL was missing `redirect_uri`, relying on the default registered callback. Now explicitly passed from `OAUTH_REDIRECT_BASE`.
+  Additional: added `timeout=15` on all social-login `httpx.AsyncClient` calls; wrapped HTTP exchanges in `try/except` for clean 502 errors instead of unhandled exceptions.
+
 - **All 20 V5 screens audited for swallowed errors; approve/retry now show inline error banners.** `handleRetry` previously had a bare `catch (_) {}` swallowing all errors silently; now shows a yellow click-to-dismiss actionError banner. `handleApprove` filters out expected 404/400 (optimistic: no checkpoint to approve) but surfaces real failures.
 
 - **Browser E2E now covers 20 pages (was 13).** Added 7 missing V5 routes: `/intelligence`, `/company`, `/github`, `/skills`, `/doctor`, `/onboarding`, `/admin`.


### PR DESCRIPTION
## Summary

Three bugs in `backend/server.py` were preventing both GitHub and Google OAuth from working.

- **Session key collision** — both `github_login` and `google_login` wrote to `session["oauth_state"]`; switching providers or opening a second tab silently overwrote the state, causing every callback CSRF check to fail with "Invalid OAuth state". Fixed by using provider-specific keys: `github_oauth_state` / `google_oauth_state`.

- **Google `redirect_uri` mismatch** — `google_login` used `request.url_for("google_callback")` which generates the wrong scheme/host behind a reverse proxy (Render, Cloudflare, Nginx). Google's token exchange rejects any mismatch. Both endpoints now derive `redirect_uri` from the new `OAUTH_REDIRECT_BASE` env var, with a local-dev fallback to `url_for`.

- **Missing `redirect_uri` for GitHub** — the GitHub authorize URL omitted `redirect_uri` entirely; now explicitly passed from `OAUTH_REDIRECT_BASE`.

Additional hardening: `timeout=15` added to all social-login `httpx.AsyncClient` calls (was no timeout — could hang); HTTP exchanges wrapped in `try/except` for clean 502 errors instead of unhandled exceptions; stale `try/except NameError` guards on `log_activity` removed.

## Environment variable to set on Render

```
OAUTH_REDIRECT_BASE=https://local-llm-server.onrender.com
```

This must match the callback URLs registered in the GitHub OAuth App and Google Cloud Console exactly. Your existing registrations (`…onrender.com/api/auth/github/callback` and `…onrender.com/api/auth/google/callback`) are already correct — just add this env var.

`FRONTEND_URL` and `CORS_ORIGINS` are already pointing at the Cloudflare Pages deployment — no change needed there.

## Test plan

- [ ] Set `OAUTH_REDIRECT_BASE=https://local-llm-server.onrender.com` on Render
- [ ] Click **GitHub** on the login page → consent screen → redirected back → JWT stored → dashboard loads
- [ ] Click **Google** on the login page → consent screen → redirected back → JWT stored → dashboard loads
- [ ] Open two tabs, start GitHub login in one and Google login in the other — both complete independently without interfering
- [ ] Existing email/password login still works
- [ ] CI green

https://claude.ai/code/session_01SqCXBK9KHVAaPpgXkkhQXZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01SqCXBK9KHVAaPpgXkkhQXZ)_