### PR TITLE
ci(portfolio): reuse RENDER_BACKEND_URL secret for refresh cron

### DIFF
--- a/.claude/state/active-tasks.md
+++ b/.claude/state/active-tasks.md
@@ -25,7 +25,8 @@
 | 1 | Killer TODO Roadmap (docs only — 33-item backlog from 6 OSS repos) | `DONE` | [#406](https://github.com/strikersam/local-llm-server/pull/406) | Draft PR created, CI running | 2026-06-05 |
 | 2 | Dynamic Session Planning Workflow (this task) | `IN_PROGRESS` | [#406](https://github.com/strikersam/local-llm-server/pull/406) | hooks + tracker + AGENTS.md update | 2026-06-05 |
 | 3 | Agentic Portfolio Management (WSJF) + v5 Portfolio screen | `DONE` | #423, #426 | portfolio.py, agile health/retro, v5 board | 2026-06-06 |
-| 4 | Autonomous Portfolio Intelligence (signals → initiatives, 6h cron) | `IN_PROGRESS` | claude/portfolio-autonomous | portfolio_intelligence.py + refresh workflow + UI provenance | 2026-06-06 |
+| 4 | Autonomous Portfolio Intelligence (signals → initiatives, 6h cron) | `DONE` | [#427](https://github.com/strikersam/local-llm-server/pull/427) | portfolio_intelligence.py + refresh workflow + UI provenance | 2026-06-06 |
+| 5 | Portfolio refresh workflow → reuse RENDER_BACKEND_URL secret | `IN_PROGRESS` | claude/portfolio-refresh-backend-url | point cron ping at existing secret | 2026-06-06 |
 
 ---
 

--- a/.github/workflows/portfolio-refresh.yml
+++ b/.github/workflows/portfolio-refresh.yml
@@ -43,7 +43,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PORTFOLIO_REPO: ${{ github.repository }}
-          # Optional: set repo variable BACKEND_URL to refresh the deployed dashboard.
-          BACKEND_URL: ${{ vars.BACKEND_URL }}
+          # Backend origin to refresh — reuses the existing RENDER_BACKEND_URL secret.
+          BACKEND_URL: ${{ secrets.RENDER_BACKEND_URL }}
           PORTFOLIO_RESEARCH: ${{ github.event.inputs.research == 'true' && '1' || '0' }}
         run: python3 .github/scripts/portfolio_refresh.py

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -38,6 +38,7 @@
 - **README — "Issue → Context → Draft PR automation" section** documenting the pipeline, free-first NVIDIA model routing, backfill commands, and the master-branch auto-trigger caveat.
 
 ### Changed
+- **`portfolio-refresh.yml`** — the 6-hourly refresh cron now reads the backend origin from the existing `RENDER_BACKEND_URL` secret (was a new `BACKEND_URL` repo variable), so no extra config is needed to ping the deployed dashboard.
 - **`process-quick-note.yml`** — PR creation now uses `--draft` (suppresses CodeRabbit/Copilot auto-reviews on implementation PRs). Branch creation detects and reuses an existing `claude/context-issue-N` branch so implementation commits land on the pre-built draft PR instead of opening a duplicate.
 - **CI no longer runs on draft PRs or docs-only context commits.** `paths-ignore: ["docs/context/**"]` added to the push/pull_request triggers of `ci.yml`, `e2e.yml`, `browser-e2e.yml`, `security-gate.yml`, `changelog-check.yml`, `security-scan.yml`, plus `if: github.event.pull_request.draft == false` job guards on `ci.yml`, `e2e.yml`, `browser-e2e.yml`, `security-gate.yml`, `changelog-check.yml`. Draft status only stops review bots, not GitHub Actions — these guards stop auto-generated context draft PRs from triggering the full CI suite.
 - **Context PR titles use a `docs:` prefix** so the `changelog-check` gate exempts them (context PRs only add `docs/context/*.md`).

--- a/docs/context/agentic-portfolio.md
+++ b/docs/context/agentic-portfolio.md
@@ -99,9 +99,10 @@ Each `Initiative` carries `source` + `rationale` provenance, surfaced as badges 
 `portfolio_api.py` caches the built board for 30 min; `POST /api/portfolio/refresh` forces a
 re-sweep. The **`portfolio-refresh.yml`** Action (cron every 6h) runs the sweep in CI (with the
 Actions `GITHUB_TOKEN` for PR/issue access), publishes a WSJF digest, and pings
-`BACKEND_URL/api/portfolio/refresh` (set the `BACKEND_URL` repo variable) to refresh the live
-dashboard. Enable research signals via the workflow's `research=true` dispatch input or
-`PORTFOLIO_RESEARCH=1`.
+`<backend>/api/portfolio/refresh` (the backend origin is read from the existing
+`RENDER_BACKEND_URL` secret) to refresh the live dashboard. The deployed backend reads open
+PRs/bug issues from its own `GH_PAT`/`GITHUB_TOKEN` env. Enable research signals via the
+workflow's `research=true` dispatch input or `PORTFOLIO_RESEARCH=1`.
 
 ## Extension ideas (not yet built)
 


### PR DESCRIPTION
## Summary

Small config follow-up to #427. The portfolio-refresh cron now reads the backend origin from the **existing `RENDER_BACKEND_URL` secret** (already used by `deploy-frontend.yml`) instead of requiring a new `BACKEND_URL` repo variable — so no extra setup is needed to wire the 6-hourly live-dashboard refresh.

## Changes
- `.github/workflows/portfolio-refresh.yml` — `BACKEND_URL: ${{ secrets.RENDER_BACKEND_URL }}` (was `${{ vars.BACKEND_URL }}`).
- `docs/context/agentic-portfolio.md` — doc updated to match (and note the backend reads PRs/issues from its own `GH_PAT`/`GITHUB_TOKEN`, now set in Render).
- `.claude/state/active-tasks.md` — mark the autonomous-portfolio task **DONE** (#427), add this follow-up row.

No code/tests touched (`ci:`-prefixed, changelog-exempt). Once merged, the `Portfolio Refresh` workflow's 6h cron will ping `https://local-llm-server.onrender.com/api/portfolio/refresh` automatically.

https://claude.ai/code/session_012B1HKdxVqRbVmo7rnzRCmo

---
_Generated by [Claude Code](https://claude.ai/code/session_012B1HKdxVqRbVmo7rnzRCmo)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated changelog and portfolio automation documentation to reflect workflow configuration changes.

* **Chores**
  * Optimized portfolio refresh workflow configuration for improved secret management.
  * Updated sprint task tracking to reflect completed autonomous portfolio intelligence feature and ongoing refresh workflow improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->