### PR TITLE
fix(telegram): show raw TELEGRAM_ALLOWED_USER_IDS in error log instead of literal '<redacted>'

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -978,3 +978,6 @@
 - ECC Harness Patterns (agents/harness_adapter.py, #237).
 - Quality Checker (agents/quality_checker.py, #237).
 - Temporal Context (services/temporal_context.py, #237).
+
+### Fixed
+- **Telegram bot error log showed literal `<redacted>` instead of the actual `TELEGRAM_ALLOWED_USER_IDS` value.** The CodeRabbit auto-fix on PR #438 replaced the raw env value with a hardcoded `<redacted>` string, making it impossible to see what value was configured. The error log now shows the actual raw value (Telegram user IDs are public identifiers, not secrets). `_parse_user_ids` also logs rejected tokens at DEBUG level for easier troubleshooting.

--- a/telegram_bot.py
+++ b/telegram_bot.py
@@ -88,11 +88,18 @@ def _parse_user_ids(raw: str) -> set[int]:
     tokens = _re.split(r'[,;\s]+', raw.strip())
     result = set()
     for token in tokens:
+        if not token:
+            continue
         # Strip surrounding quotes, brackets, parentheses
         cleaned = token.strip().strip('"\'[](){}')
         # Only accept tokens that are purely numeric (with optional leading minus)
         if _re.match(r'^-?\d+$', cleaned):
             result.add(int(cleaned))
+        elif cleaned:
+            log.debug(
+                "Rejected Telegram user ID token %r (cleaned as %r) — must be purely numeric.",
+                token, cleaned,
+            )
     return result
 
 
@@ -696,9 +703,10 @@ async def run_bot() -> None:
     if not ALLOWED_USER_IDS:
         raw = os.environ.get("TELEGRAM_ALLOWED_USER_IDS", "")
         log.error(
-            "TELEGRAM_ALLOWED_USER_IDS produced no numeric IDs (got <redacted>, length=%d). "
+            "TELEGRAM_ALLOWED_USER_IDS produced no numeric IDs (got %r, length=%d). "
             "Use the NUMERIC id from @userinfobot (e.g. 8120976), comma-separated — "
             "not your @username, and without quotes. No one can use the bot.",
+            raw,
             len(raw),
         )
         return


### PR DESCRIPTION
## Problem

The Render log showed:
```
2026-06-06 16:51:16,630 [ERROR] TELEGRAM_ALLOWED_USER_IDS produced no numeric IDs (got <redacted>, length=10). Use the NUMERIC id from @userinfobot (e.g. 8120976), comma-separated — not your @username, and without quotes. No one can use the bot.
```

The CodeRabbit auto-fix on PR #438 literally hardcoded `<redacted>` into the log message, making debugging impossible. Telegram user IDs are **public identifiers** (not secrets like API tokens), so redacting them only prevents operators from seeing what value is actually configured.

## Fix

1. **`run_bot()` error log**: Replaced the literal string `<redacted>` with `%r` formatting and passes `raw` so the actual env value appears in the log
2. **`_parse_user_ids()`**: Added debug-level logging for rejected non-empty tokens — operators can enable DEBUG logging to see exactly which tokens were dropped and why
3. Also skips empty tokens cleanly (from split producing empty strings on consecutive separators)

## After this fix

The Render log will show something like:
```
TELEGRAM_ALLOWED_USER_IDS produced no numeric IDs (got 'somevalue1234?', length=14). Use the NUMERIC id...
```
making it immediately obvious what value needs to be corrected.