### PR TITLE
fix(telegram): strip ALL whitespace from TELEGRAM_BOT_TOKEN not just leading/trailing

### DIFF
--- a/telegram_bot.py
+++ b/telegram_bot.py
@@ -65,6 +65,9 @@ logging.basicConfig(
 # ─── Configuration ─────────────────────────────────────────────────────────────
 
 TELEGRAM_BOT_TOKEN: str = os.environ.get("TELEGRAM_BOT_TOKEN", "").strip()
+# Telegram tokens MUST not contain any whitespace — a common copy-paste error
+# from BotFather. Strip all whitespace (not just leading/trailing) defensively.
+TELEGRAM_BOT_TOKEN = "".join(TELEGRAM_BOT_TOKEN.split())
 PROXY_BASE_URL: str = os.environ.get("PROXY_BASE_URL", "http://localhost:8000").rstrip("/")
 PROXY_ADMIN_SECRET: str = os.environ.get("ADMIN_SECRET", "").strip()
 PROXY_API_KEY: str = os.environ.get("TELEGRAM_PROXY_API_KEY", "").strip()
@@ -700,6 +703,15 @@ async def run_bot() -> None:
     if not TELEGRAM_BOT_TOKEN:
         log.error("TELEGRAM_BOT_TOKEN is not set. Set it in the environment and restart.")
         return
+    # Defensively strip any internal whitespace from the token (common copy-paste error).
+    safe_token = "".join(TELEGRAM_BOT_TOKEN.split())
+    if safe_token != TELEGRAM_BOT_TOKEN:
+        TELEGRAM_BOT_TOKEN = safe_token  # allow the global to be reassigned
+        log.warning(
+            "TELEGRAM_BOT_TOKEN contained whitespace — stripped to %d chars. "
+            "Fix the env var to avoid this warning.",
+            len(TELEGRAM_BOT_TOKEN),
+        )
     if not ALLOWED_USER_IDS:
         raw = os.environ.get("TELEGRAM_ALLOWED_USER_IDS", "")
         log.error(


### PR DESCRIPTION
## Problem

Render log showed a 404 error from Telegram's getMe API. The root cause: `TELEGRAM_BOT_TOKEN` had internal spaces from a copy-paste error (`8661289550: AAFIxeig IMMrEt7LWgeM2NEX9KEUeBuikVY`). The code only used `.strip()` which removes leading/trailing whitespace but not internal spaces.

## Fix

1. Module-level: After `.strip()`, also remove ALL internal whitespace with `"".join(token.split())`
2. run_bot(): Same defensive stripping at startup, with a warning log if whitespace was found
3. Render env var already fixed to the clean token

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Implemented automatic whitespace removal from bot tokens during initialization to prevent startup failures with malformed credentials
  * Added warning messages during bot startup when token sanitization occurs, providing better diagnostic information for configuration issues

<!-- end of auto-generated comment: release notes by coderabbit.ai -->