### PR TITLE
feat(agent): durable agent checkpointing for crash-recovery

### DIFF
--- a/agent/checkpoint.py
+++ b/agent/checkpoint.py
@@ -2,12 +2,16 @@
 
 Provides serialisable snapshots of AgentRunner state so long-running
 sessions can survive process restarts and resume from the last checkpoint.
+
+Feature-gated by ``AGENT_CHECKPOINT_ENABLED`` (default: true).
 """
 
 from __future__ import annotations
 
 import json
 import logging
+import os
+import re
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
@@ -15,6 +19,10 @@ from typing import Any
 log = logging.getLogger("qwen-proxy")
 
 DEFAULT_CHECKPOINT_DIR = ".data/checkpoints"
+
+# Session IDs must be alphanumeric with hyphens/underscores only —
+# prevents path-traversal via "../" or other directory escape sequences.
+_SESSION_ID_RE = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9_\-]*$")
 
 
 @dataclass
@@ -75,7 +83,16 @@ class CheckpointStore:
         )
         self._base_dir.mkdir(parents=True, exist_ok=True)
 
+    @staticmethod
+    def _validate_session_id(session_id: str) -> None:
+        if not _SESSION_ID_RE.match(session_id):
+            raise ValueError(
+                f"Invalid session_id: {session_id!r}. "
+                "Must be alphanumeric with optional hyphens/underscores."
+            )
+
     def _session_dir(self, session_id: str) -> Path:
+        self._validate_session_id(session_id)
         d = self._base_dir / session_id
         d.mkdir(parents=True, exist_ok=True)
         return d
@@ -122,6 +139,7 @@ class CheckpointStore:
 
     def delete_session(self, session_id: str) -> None:
         """Remove all checkpoints for a session."""
+        self._validate_session_id(session_id)
         import shutil
 
         sd = self._base_dir / session_id
@@ -141,6 +159,13 @@ def _get_checkpoint_store() -> CheckpointStore:
     return _store
 
 
+def _checkpointing_enabled() -> bool:
+    """Check whether durable checkpointing is enabled via env var."""
+    return os.environ.get("AGENT_CHECKPOINT_ENABLED", "true").strip().lower() in (
+        "true", "1", "yes", "on"
+    )
+
+
 def checkpoint_agent_state(
     session_id: str,
     step_index: int,
@@ -155,7 +180,17 @@ def checkpoint_agent_state(
 
     Called at key lifecycle points (step boundaries, errors) so the session
     can be restored after a crash.
+
+    This function is intentionally synchronous — it is called from lifecycle
+    hooks that may run in either sync or async contexts.  Callers in async
+    contexts should wrap it with ``asyncio.to_thread`` if needed.
+
+    No-op when ``AGENT_CHECKPOINT_ENABLED`` is false.
     """
+    if not _checkpointing_enabled():
+        log.debug("Checkpointing disabled — skipping save for session %s", session_id)
+        return Checkpoint(session_id=session_id, step_index=step_index, goal=goal)
+
     store = _get_checkpoint_store()
     cp = Checkpoint(
         session_id=session_id,
@@ -175,8 +210,12 @@ async def restore_agent_state(session_id: str) -> dict[str, Any] | None:
     """Restore the latest checkpoint for a session.
 
     Returns a dict with the checkpointed state suitable for resuming an
-    AgentRunner session, or None if no checkpoint exists.
+    AgentRunner session, or None if no checkpoint exists or checkpointing
+    is disabled.
     """
+    if not _checkpointing_enabled():
+        return None
+
     import asyncio
     store = _get_checkpoint_store()
     cp = await asyncio.to_thread(store.load_latest, session_id)
@@ -196,7 +235,13 @@ async def restore_agent_state(session_id: str) -> dict[str, Any] | None:
 
 
 async def cleanup_checkpoints(session_id: str) -> None:
-    """Remove all checkpoints for a session (called on successful completion)."""
+    """Remove all checkpoints for a session (called on successful completion).
+
+    No-op when checkpointing is disabled.
+    """
+    if not _checkpointing_enabled():
+        return
+
     import asyncio
     store = _get_checkpoint_store()
     await asyncio.to_thread(store.delete_session, session_id)

--- a/agent/checkpoint.py
+++ b/agent/checkpoint.py
@@ -1,0 +1,202 @@
+"""Durable agent checkpointing for crash-recovery and resumption.
+
+Provides serialisable snapshots of AgentRunner state so long-running
+sessions can survive process restarts and resume from the last checkpoint.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+log = logging.getLogger("qwen-proxy")
+
+DEFAULT_CHECKPOINT_DIR = ".data/checkpoints"
+
+
+@dataclass
+class Checkpoint:
+    """Serialisable snapshot of agent execution state."""
+
+    session_id: str
+    step_index: int
+    goal: str
+    plan_steps: list[dict[str, Any]] = field(default_factory=list)
+    completed_steps: list[int] = field(default_factory=list)
+    tool_call_history: list[dict[str, Any]] = field(default_factory=list)
+    scratchpad_raw: str = ""
+    error_info: str | None = None
+    created_at: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "session_id": self.session_id,
+            "step_index": self.step_index,
+            "goal": self.goal,
+            "plan_steps": self.plan_steps,
+            "completed_steps": self.completed_steps,
+            "tool_call_history": self.tool_call_history,
+            "scratchpad_raw": self.scratchpad_raw[:8000],
+            "error_info": self.error_info,
+            "created_at": self.created_at,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> Checkpoint:
+        return cls(
+            session_id=data["session_id"],
+            step_index=data.get("step_index", 0),
+            goal=data.get("goal", ""),
+            plan_steps=data.get("plan_steps", []),
+            completed_steps=data.get("completed_steps", []),
+            tool_call_history=data.get("tool_call_history", []),
+            scratchpad_raw=data.get("scratchpad_raw", ""),
+            error_info=data.get("error_info"),
+            created_at=data.get("created_at", ""),
+        )
+
+
+class CheckpointStore:
+    """File-backed checkpoint persistence.
+
+    Each session gets a directory under ``_base_dir`` and checkpoints are
+    written as numbered JSON files.  On restore the store returns the
+    highest-numbered checkpoint for a session.
+    """
+
+    def __init__(self, base_dir: str | Path | None = None) -> None:
+        import os
+
+        self._base_dir = Path(
+            base_dir or os.environ.get("AGENT_CHECKPOINT_DIR") or DEFAULT_CHECKPOINT_DIR
+        )
+        self._base_dir.mkdir(parents=True, exist_ok=True)
+
+    def _session_dir(self, session_id: str) -> Path:
+        d = self._base_dir / session_id
+        d.mkdir(parents=True, exist_ok=True)
+        return d
+
+    def save(self, checkpoint: Checkpoint) -> Path:
+        """Persist a checkpoint to disk.  Returns the file path."""
+        import time
+
+        checkpoint.created_at = time.strftime(
+            "%Y-%m-%dT%H:%M:%SZ", time.gmtime()
+        )
+        sd = self._session_dir(checkpoint.session_id)
+        path = sd / f"checkpoint_{checkpoint.step_index:04d}.json"
+        with open(path, "w") as f:
+            json.dump(checkpoint.to_dict(), f, indent=2)
+        log.debug(
+            "CheckpointStore: saved checkpoint at step %d for session %s",
+            checkpoint.step_index,
+            checkpoint.session_id,
+        )
+        return path
+
+    def load_latest(self, session_id: str) -> Checkpoint | None:
+        """Return the latest checkpoint for a session, or None."""
+        sd = self._session_dir(session_id)
+        files = sorted(sd.glob("checkpoint_*.json"))
+        if not files:
+            return None
+        latest = files[-1]
+        try:
+            with open(latest) as f:
+                data = json.load(f)
+            return Checkpoint.from_dict(data)
+        except (json.JSONDecodeError, KeyError) as exc:
+            log.warning(
+                "CheckpointStore: corrupt checkpoint %s — %s", latest, exc
+            )
+            return None
+
+    def list_checkpoints(self, session_id: str) -> list[Path]:
+        """Return all checkpoint files for a session, sorted by step index."""
+        sd = self._session_dir(session_id)
+        return sorted(sd.glob("checkpoint_*.json"))
+
+    def delete_session(self, session_id: str) -> None:
+        """Remove all checkpoints for a session."""
+        import shutil
+
+        sd = self._base_dir / session_id
+        if sd.exists():
+            shutil.rmtree(sd)
+            log.debug(
+                "CheckpointStore: deleted checkpoints for session %s",
+                session_id,
+            )
+
+
+def _get_checkpoint_store() -> CheckpointStore:
+    """Return the process-wide singleton CheckpointStore."""
+    global _store
+    if "_store" not in globals():
+        _store = CheckpointStore()
+    return _store
+
+
+def checkpoint_agent_state(
+    session_id: str,
+    step_index: int,
+    goal: str,
+    plan_steps: list[dict[str, Any]],
+    completed_steps: list[int],
+    tool_call_history: list[dict[str, Any]],
+    scratchpad_raw: str = "",
+    error_info: str | None = None,
+) -> Checkpoint:
+    """Save the current agent state as a durable checkpoint.
+
+    Called at key lifecycle points (step boundaries, errors) so the session
+    can be restored after a crash.
+    """
+    store = _get_checkpoint_store()
+    cp = Checkpoint(
+        session_id=session_id,
+        step_index=step_index,
+        goal=goal,
+        plan_steps=plan_steps,
+        completed_steps=completed_steps,
+        tool_call_history=tool_call_history,
+        scratchpad_raw=scratchpad_raw,
+        error_info=error_info,
+    )
+    store.save(cp)
+    return cp
+
+
+async def restore_agent_state(session_id: str) -> dict[str, Any] | None:
+    """Restore the latest checkpoint for a session.
+
+    Returns a dict with the checkpointed state suitable for resuming an
+    AgentRunner session, or None if no checkpoint exists.
+    """
+    import asyncio
+    store = _get_checkpoint_store()
+    cp = await asyncio.to_thread(store.load_latest, session_id)
+    if cp is None:
+        return None
+    return {
+        "session_id": cp.session_id,
+        "resume_step": cp.step_index + 1,
+        "goal": cp.goal,
+        "plan_steps": cp.plan_steps,
+        "completed_steps": cp.completed_steps,
+        "tool_call_history": cp.tool_call_history,
+        "scratchpad_raw": cp.scratchpad_raw,
+        "had_error": cp.error_info is not None,
+        "error_info": cp.error_info,
+    }
+
+
+async def cleanup_checkpoints(session_id: str) -> None:
+    """Remove all checkpoints for a session (called on successful completion)."""
+    import asyncio
+    store = _get_checkpoint_store()
+    await asyncio.to_thread(store.delete_session, session_id)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,7 @@
 - **Onboarding UX, logs, chat, admin fixes.** *Onboarding:* clickable breadcrumbs, restart button, Done back button. *Logs:* expandable messages (click to expand). *Chat:* ModelPicker two-step provider→model, mutual dropdown exclusion, repo URL input for code tasks. *Admin:* Companies tab with delete cleanup. *Backend:* DELETE /api/company/{id} endpoint.
 
 - **Agency Core v5 hardening — Phases 1-4 (SkillBindings, WorkflowOrchestrator, Doctor route split, Dashboard resilience).**
+- **Durable agent checkpointing (`agent/checkpoint.py`).** New `CheckpointStore` with save/restore/list/delete operations for crash-recovery. `checkpoint_agent_state()` snapshots AgentRunner state (goal, plan steps, tool call history, scratchpad) at key lifecycle points. `restore_agent_state()` returns structured resume data. File-backed persistence under `.data/checkpoints/`. 13 tests in `tests/test_checkpoint.py`.
 
   *Phase 1 — Skill Wiring:* `services/skill_bindings.py` with 28 typed runtime skills (7 production, 19 gated);
   `models/company_graph.py` now stores `bound_skills` on Specialist; specialist auto-binding + `get_bound_skills()`;

--- a/tests/test_checkpoint.py
+++ b/tests/test_checkpoint.py
@@ -1,0 +1,181 @@
+"""Tests for durable agent checkpointing (PR #412)."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from agent.checkpoint import (
+    Checkpoint,
+    CheckpointStore,
+    cleanup_checkpoints,
+    checkpoint_agent_state,
+    restore_agent_state,
+)
+
+
+class TestCheckpointModel:
+    def test_to_dict_roundtrip(self) -> None:
+        cp = Checkpoint(
+            session_id="sess_abc",
+            step_index=3,
+            goal="Fix production bug",
+            plan_steps=[{"id": 1, "description": "Read log"}],
+            completed_steps=[0, 1],
+            tool_call_history=[{"tool": "read_file", "args": {"path": "x.py"}}],
+            scratchpad_raw="need to check auth module",
+        )
+        d = cp.to_dict()
+        assert d["session_id"] == "sess_abc"
+        assert d["step_index"] == 3
+        assert len(d["tool_call_history"]) == 1
+        assert d["scratchpad_raw"] == "need to check auth module"
+
+    def test_from_dict(self) -> None:
+        data = {
+            "session_id": "sess_xyz",
+            "step_index": 5,
+            "goal": "Refactor module",
+            "plan_steps": [],
+            "completed_steps": [0, 1, 2, 3],
+            "tool_call_history": [],
+            "scratchpad_raw": "",
+            "error_info": "timeout",
+        }
+        cp = Checkpoint.from_dict(data)
+        assert cp.session_id == "sess_xyz"
+        assert cp.step_index == 5
+        assert cp.error_info == "timeout"
+
+    def test_scratchpad_truncated(self) -> None:
+        cp = Checkpoint(
+            session_id="s",
+            step_index=1,
+            goal="g",
+            scratchpad_raw="x" * 10000,
+        )
+        d = cp.to_dict()
+        assert len(d["scratchpad_raw"]) <= 8000
+
+
+class TestCheckpointStore:
+    def test_save_and_load(self, tmp_path: Path) -> None:
+        store = CheckpointStore(base_dir=tmp_path)
+        cp = Checkpoint(session_id="sess_1", step_index=2, goal="Test")
+        store.save(cp)
+
+        restored = store.load_latest("sess_1")
+        assert restored is not None
+        assert restored.session_id == "sess_1"
+        assert restored.step_index == 2
+        assert restored.goal == "Test"
+
+    def test_load_latest_returns_highest_step(self, tmp_path: Path) -> None:
+        store = CheckpointStore(base_dir=tmp_path)
+        for i in range(5):
+            store.save(Checkpoint(session_id="sess", step_index=i, goal=f"step_{i}"))
+
+        latest = store.load_latest("sess")
+        assert latest is not None
+        assert latest.step_index == 4
+
+    def test_load_latest_nonexistent_session(self, tmp_path: Path) -> None:
+        store = CheckpointStore(base_dir=tmp_path)
+        assert store.load_latest("no_session") is None
+
+    def test_list_checkpoints(self, tmp_path: Path) -> None:
+        store = CheckpointStore(base_dir=tmp_path)
+        store.save(Checkpoint(session_id="s", step_index=0, goal="g"))
+        store.save(Checkpoint(session_id="s", step_index=1, goal="g"))
+
+        files = store.list_checkpoints("s")
+        assert len(files) == 2
+
+    def test_delete_session(self, tmp_path: Path) -> None:
+        store = CheckpointStore(base_dir=tmp_path)
+        store.save(Checkpoint(session_id="sess_del", step_index=0, goal="g"))
+        assert store.load_latest("sess_del") is not None
+
+        store.delete_session("sess_del")
+        assert store.load_latest("sess_del") is None
+
+    def test_corrupt_checkpoint_handled(self, tmp_path: Path) -> None:
+        store = CheckpointStore(base_dir=tmp_path)
+        sd = store._session_dir("sess_bad")
+        sd.mkdir(parents=True, exist_ok=True)
+        with open(sd / "checkpoint_0000.json", "w") as f:
+            f.write("{not valid json")
+
+        assert store.load_latest("sess_bad") is None
+
+
+class TestAsyncCheckpointAPI:
+    @pytest.mark.asyncio
+    async def test_checkpoint_and_restore(self, tmp_path: Path) -> None:
+        import agent.checkpoint as ckpt
+
+        ckpt._store = CheckpointStore(base_dir=tmp_path)
+
+        checkpoint_agent_state(
+            session_id="test_sess",
+            step_index=4,
+            goal="Implement feature",
+            plan_steps=[{"id": 1, "description": "Write code"}],
+            completed_steps=[0, 1, 2],
+            tool_call_history=[{"tool": "write_file", "args": {}}],
+            scratchpad_raw="Done with step 4",
+        )
+
+        restored = await restore_agent_state("test_sess")
+        assert restored is not None
+        assert restored["session_id"] == "test_sess"
+        assert restored["resume_step"] == 5
+        assert restored["goal"] == "Implement feature"
+        assert len(restored["tool_call_history"]) == 1
+
+    @pytest.mark.asyncio
+    async def test_restore_nonexistent(self, tmp_path: Path) -> None:
+        import agent.checkpoint as ckpt
+
+        ckpt._store = CheckpointStore(base_dir=tmp_path)
+        assert await restore_agent_state("nonexistent") is None
+
+    @pytest.mark.asyncio
+    async def test_checkpoint_with_error(self, tmp_path: Path) -> None:
+        import agent.checkpoint as ckpt
+
+        ckpt._store = CheckpointStore(base_dir=tmp_path)
+
+        checkpoint_agent_state(
+            session_id="err_sess",
+            step_index=2,
+            goal="Bug fix",
+            plan_steps=[],
+            completed_steps=[0],
+            tool_call_history=[],
+            error_info="Ollama connection timeout",
+        )
+
+        restored = await restore_agent_state("err_sess")
+        assert restored is not None
+        assert restored["had_error"] is True
+        assert "timeout" in str(restored["error_info"])
+
+    @pytest.mark.asyncio
+    async def test_cleanup_checkpoints(self, tmp_path: Path) -> None:
+        import agent.checkpoint as ckpt
+
+        ckpt._store = CheckpointStore(base_dir=tmp_path)
+
+        checkpoint_agent_state(
+            session_id="cleanup_sess",
+            step_index=0,
+            goal="Test cleanup",
+            plan_steps=[],
+            completed_steps=[],
+            tool_call_history=[],
+        )
+        assert await restore_agent_state("cleanup_sess") is not None
+
+        await cleanup_checkpoints("cleanup_sess")
+        assert await restore_agent_state("cleanup_sess") is None

--- a/tests/test_checkpoint.py
+++ b/tests/test_checkpoint.py
@@ -108,6 +108,28 @@ class TestCheckpointStore:
 
         assert store.load_latest("sess_bad") is None
 
+    def test_rejects_path_traversal_session_id(self, tmp_path: Path) -> None:
+        store = CheckpointStore(base_dir=tmp_path)
+        with pytest.raises(ValueError, match="Invalid session_id"):
+            store._validate_session_id("../etc/passwd")
+        with pytest.raises(ValueError, match="Invalid session_id"):
+            store._validate_session_id("sess/../../malicious")
+        with pytest.raises(ValueError, match="Invalid session_id"):
+            store._validate_session_id("/absolute/path")
+
+    def test_accepts_valid_session_ids(self, tmp_path: Path) -> None:
+        store = CheckpointStore(base_dir=tmp_path)
+        # These should not raise
+        store._validate_session_id("sess_abc_123")
+        store._validate_session_id("my-session")
+        store._validate_session_id("abc")
+        store._validate_session_id("A1_b2-C3")
+
+    def test_rejects_empty_session_id(self, tmp_path: Path) -> None:
+        store = CheckpointStore(base_dir=tmp_path)
+        with pytest.raises(ValueError, match="Invalid session_id"):
+            store._validate_session_id("")
+
 
 class TestAsyncCheckpointAPI:
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Implements durable agent checkpointing so long-running AgentRunner sessions survive process restarts and resume from the last checkpoint.

## Changes

- **`agent/checkpoint.py`** — New module: `Checkpoint` dataclass, `CheckpointStore` with save/load/latest/list/delete, `checkpoint_agent_state()` + `restore_agent_state()` + `cleanup_checkpoints()` functions
- **`tests/test_checkpoint.py`** — 13 tests covering model round-trip, store persistence, async API surface, corrupt file handling, and cleanup

Closes #412.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatic agent session checkpointing saves progress to disk for crash recovery
  * Sessions can now resume from the last saved checkpoint after interruption

* **Tests**
  * Added comprehensive test coverage for checkpoint operations and recovery workflows

* **Documentation**
  * Changelog updated with checkpointing feature details

<!-- end of auto-generated comment: release notes by coderabbit.ai -->