### PR TITLE
ci: fix Cloudflare deploy — remove --no-bundle flag

### DIFF
--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -55,4 +55,4 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: deploy --no-bundle
+          command: deploy


### PR DESCRIPTION
## Bug

The Cloudflare deploy workflow failed on every run with:

```
✘ [ERROR] Missing entry-point: The entry-point should be specified via the command line or the main config field.
```

## Root cause
The `--no-bundle` flag skips bundling entirely, preventing wrangler from reading `wrangler.jsonc` which defines `main: worker/index.js`.

## Fix
Removed `--no-bundle` — the `wrangler.jsonc` already has the full config (build command, assets, main entry point). Using `command: deploy` without extra flags lets wrangler use its config file normally.