### PR TITLE
ci: use npx wrangler deploy directly (fix entry-point discovery)

### DIFF
--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -51,8 +51,7 @@ jobs:
         run: rm -f frontend/build/_redirects
 
       - name: Deploy to Cloudflare Workers
-        uses: cloudflare/wrangler-action@v3
-        with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: deploy
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: npx wrangler deploy


### PR DESCRIPTION
## Bug

The `cloudflare/wrangler-action@v3` action can't find the entry-point defined in `wrangler.jsonc` (`main: worker/index.js`), causing every deploy to fail with:

```
✘ [ERROR] Missing entry-point: The entry-point should be specified via the command line or the main config field.
```

## Fix
Replaced the action with direct `npx wrangler deploy` which reads `wrangler.jsonc` correctly. This is exactly equivalent to running `git pull origin master && wrangler deploy` locally.

- Removed `cloudflare/wrangler-action@v3` action
- Uses `npx wrangler deploy` with `CLOUDFLARE_API_TOKEN` / `CLOUDFLARE_ACCOUNT_ID` env vars
- Wrangler reads `wrangler.jsonc` which defines `main`, `build.command`, and `assets`