### PR TITLE
ci: use wrangler-action v3 with explicit --config wrangler.jsonc

### DIFF
--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -51,7 +51,8 @@ jobs:
         run: rm -f frontend/build/_redirects
 
       - name: Deploy to Cloudflare Workers
-        env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-        run: npx wrangler deploy
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: deploy --config wrangler.jsonc


### PR DESCRIPTION
## Fix

Hybrid approach combining the best of both previous attempts:
- Uses `cloudflare/wrangler-action@v3` for reliable token handling (`apiToken` / `accountId` inputs)
- Explicitly specifies `--config wrangler.jsonc` so wrangler finds the entry-point (`main: worker/index.js`)

This resolves both the auth issue (action handles token) and the config discovery issue (explicit path).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment configuration to streamline the release process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->