### PR TITLE
fix(v5): deep-link routing + enable autonomous loop in deploy config

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -32,6 +32,7 @@
 ## [Unreleased]
 
 ### Added
+- **Autonomous loop enabled in deployment config.** `render.yaml` sets `LOG_WATCHER_AUTO_FILE=1` and `GITHUB_REPOSITORY` so production errors auto-file issues that agents pick up via the context-PR pipeline (mergeable since the docs-context stub workflow). New `docs/runbooks/credential-rotation.md` runbook for the exposed credentials.
 - **Claude 5 family in the model router (issue #495).** `claude-fable-5` registered (reasoning, 200K context); `claude-mythos-5` env-gated behind `ROUTER_ALLOW_MYTHOS` (approved-orgs-only). Tests in `tests/test_model_router.py::TestClaude5Registry`.
 - **Trend analysis module + authenticated `/api/trends` endpoint (issue #493).** `trend_analysis.py` applies a last30days-style 30-day window over the existing TrendWatcher (no duplicate subsystem, no external CLI), persists `trends/trend_summary.md`. Tests in `tests/test_trend_analysis.py`.
 - **Curated skill repos from BehiSecc/awesome-claude-skills (issue #491).** obra/superpowers and sanjay3290/ai-skills registered as nested skill registries; anthropics/skills already indexed.
@@ -303,6 +304,7 @@
   `Depends(require_authenticated)`. Previously all reads were unauthenticated.
 
 ### Fixed
+- **V5 deep links: /v5/<screen> URLs now open the right screen.** `V5App.jsx` derived nothing from the URL — every load rendered Chat regardless of path; back/forward didn't work. Screen state now syncs with react-router location (deep links, history navigation, URL updates on nav).
 - **log_watcher: runtime LOG_WATCHER_AUTO_FILE flag + incremental scan_now(); Bandit-clean test fixtures; py3.13-safe asyncio in tests.** Security Gate and Test (3.13) CI blockers on PR #487 resolved.
 - **Doctor: optional sidecar runtimes (hermes/goose/aider) no longer fail readiness.** Beta sidecars now report `warn` when unavailable; only `internal_agent` is required in the default path. Aligns Doctor with feature-matrix gating of experimental runtimes.
 - **GET /api/company/{id} returned 500 for malformed IDs (production).** `MongoDBStore.get_company` raised ValueError on invalid ObjectId; now returns None so the API raises a clean 404. Regression test in `tests/test_company_graph.py::TestMalformedCompanyId`.

--- a/docs/pre-mortem-2026-06-10.md
+++ b/docs/pre-mortem-2026-06-10.md
@@ -13,13 +13,13 @@ Total risks identified: 9 — Tigers: 6 (Launch-Blocking: 3, Fast-Follow: 2, Tra
 
 | # | Risk | Category | Urgency | Evidence | Mitigation | Owner | Decision date |
 |---|------|----------|---------|----------|------------|-------|---------------|
-| 1 | Doctor storage check crashes in production ("MotorCollection object is not callable") | Tiger | Launch-Blocking | Live `/api/doctor/public` response 2026-06-09 | **FIXED** in commit `1120346` (+ regression test). Needs redeploy. | strikersam | on next deploy |
-| 2 | API 500s on malformed company IDs (`GET /api/company/<bad-id>`) | Tiger | Launch-Blocking | Live probe returned 500, not 404 | **FIXED** in commit `563ae93` (+ regression test). Needs redeploy. | strikersam | on next deploy |
+| 1 | Doctor storage check crashes in production ("MotorCollection object is not callable") | Tiger | Launch-Blocking | Live `/api/doctor/public` response 2026-06-09 | **FIXED + DEPLOYED** (verified live 2026-06-10: storage check passes). | strikersam | on next deploy |
+| 2 | API 500s on malformed company IDs (`GET /api/company/<bad-id>`) | Tiger | Launch-Blocking | Live probe returned 500, not 404 | **FIXED + DEPLOYED** (verified live: returns 404). | strikersam | on next deploy |
 | 3 | Committed credentials: `memory/test_credentials.md` is git-tracked and contains the live admin password and proxy admin secret; the same creds work on the public Cloudflare deployment | Tiger | Launch-Blocking | `git ls-files memory/` + successful live login with those creds | Rotate admin password & admin secret; remove file from tracking (`git rm --cached`), add to `.gitignore`; purge from history if repo is public (it is). | strikersam | before any public launch |
 | 4 | 9 test failures in `tests/test_company_graph.py` / `tests/test_company_api.py` | Paper Tiger (resolved) | — | Re-run 2026-06-10 with full dev deps: **all pass** — failures were missing `pytest-asyncio`/`aiosqlite` in the analysis sandbox, not the code. |
-| 5 | Local branch is 5+ commits ahead of origin; PR #489 unmerged; no push credentials configured locally | Tiger | Fast-Follow | `git rev-list` vs `origin/consolidate/maturation-stable` | Push branch + merge #489 once GitHub auth is available. | strikersam | +7 days |
+| 5 | Local branch is 5+ commits ahead of origin; PR #489 unmerged; no push credentials configured locally | Tiger | Fast-Follow | `git rev-list` vs `origin/consolidate/maturation-stable` | **DONE** — branch pushed; #487/#497/#499 merged, #489/#492/#494/#496 closed-as-landed. | strikersam | done |
 | 6 | Ollama unreachable on the deployment (public doctor warns) | Tiger | Track | Live `/api/doctor/public` | Expected on Cloudflare (no local Ollama); provider routing falls back to nvidia-nim, which passes. Document this in the doctor explainer. | — | review cadence |
-| 7 | Sidecar runtimes (hermes/goose/aider) "fail" and flip Doctor to not-ready although they are optional betas | Tiger→fixed | Launch-Blocking | Live authenticated `/api/doctor` | **FIXED** in commit `2818339` — optional runtimes now `warn`; only `internal_agent` is required. | strikersam | on next deploy |
+| 7 | Sidecar runtimes (hermes/goose/aider) "fail" and flip Doctor to not-ready although they are optional betas | Tiger→fixed | Launch-Blocking | Live authenticated `/api/doctor` | **FIXED + DEPLOYED** — optional runtimes warn; doctor reports healthy. | strikersam | on next deploy |
 | 8 | "A competitor copies the 34-specialist-family pitch" | Paper Tiger | — | No evidence of impact; differentiation is execution, not the list | None. | — | — |
 | 9 | README autonomy claims exceed what the support matrix admits (beta/experimental features in the hot path) | Elephant | TBD | User's own audit prompt concedes this; support matrix vs README | Name it: either demote claims in README or promote features to stable with E2E evidence. Decision documented, not deferred. | strikersam | before marketing push |
 
@@ -34,4 +34,4 @@ Total risks identified: 9 — Tigers: 6 (Launch-Blocking: 3, Fast-Follow: 2, Tra
 - #2 malformed-ID 500 (`563ae93`)
 - #7 sidecar runtimes gating (`2818339`)
 
-Remaining launch blocker: **#3 credential rotation/removal** — requires the owner (rotation invalidates active sessions/tools).
+Remaining launch blocker: **#3 credential rotation** — see docs/runbooks/credential-rotation.md (file untracked; history purge + rotation still owner action).

--- a/docs/runbooks/credential-rotation.md
+++ b/docs/runbooks/credential-rotation.md
@@ -1,0 +1,27 @@
+# Credential Rotation Runbook
+
+The 2026-06-10 pre-mortem (docs/pre-mortem-2026-06-10.md, risk #3) found the
+admin password, proxy admin secret, and later a GitHub PAT in
+`memory/test_credentials.md`, which was git-tracked in this public repo.
+The file is now untracked + gitignored, but **the values remain in git
+history and must be rotated**.
+
+## What to rotate (owner action, ~10 minutes)
+
+1. **Admin password** — set a new `ADMIN_PASSWORD` in the Render dashboard
+   (single source of truth; nothing else hardcodes it — verified by repo scan).
+   Active JWT sessions expire naturally (24h access / 7d refresh).
+2. **Proxy admin secret** — regenerate and update the env var; update any
+   Telegram/remote-admin clients using it.
+3. **GitHub PAT** — revoke the exposed token at github.com/settings/tokens
+   and mint a fine-grained replacement (repo scope only). Update
+   `GH_TOKEN`/`GITHUB_TOKEN` in Render + GitHub Actions secrets.
+4. **History purge (optional but recommended)** — `git filter-repo
+   --path memory/test_credentials.md --invert-paths` + force-push, or use
+   GitHub Support to invalidate cached views.
+
+## Guardrails already in place
+
+- `memory/test_credentials.md` is gitignored.
+- CI "Secret / Credential Scan" check blocks new leaks on PRs.
+- `docker-compose.e2e.yml` and tests read `ADMIN_PASSWORD` from env only.

--- a/frontend/src/v5/V5App.jsx
+++ b/frontend/src/v5/V5App.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { useAuth } from '../AuthContext';
 import { AppShell } from './AppShell';
 import ChatScreen from './screens/ChatScreen';
@@ -55,12 +56,35 @@ function AdminLocked() {
   );
 }
 
+const V5_SCREENS = [
+  'chat', 'dashboard', 'tasks', 'agents', 'schedules', 'skills', 'portfolio',
+  'intelligence', 'knowledge', 'providers', 'github', 'logs', 'company',
+  'onboarding', 'doctor', 'admin',
+];
+
+function screenFromPath(pathname) {
+  // "/v5/doctor" -> "doctor"; unknown or missing segment -> "chat"
+  const seg = (pathname.split('/')[2] || '').toLowerCase();
+  return V5_SCREENS.includes(seg) ? seg : 'chat';
+}
+
 export default function V5App() {
-  const [screen, setScreen] = React.useState('chat');
+  const location = useLocation();
+  const navigate = useNavigate();
+  // Deep links: derive the initial screen from the URL so /v5/doctor opens
+  // Doctor (previously always opened Chat regardless of path).
+  const [screen, setScreen] = React.useState(() => screenFromPath(location.pathname));
   const { user } = useAuth();
   const isAdmin = user?.role === 'admin';
   const agentRunning = true;
-  const go = (s) => setScreen(s);
+  const go = React.useCallback((s) => {
+    setScreen(s);
+    navigate(`/v5/${s === 'chat' ? '' : s}`, { replace: false });
+  }, [navigate]);
+  // Back/forward buttons and external URL changes keep the screen in sync.
+  React.useEffect(() => {
+    setScreen(screenFromPath(location.pathname));
+  }, [location.pathname]);
   const screens = {
     chat:         <ChatScreen />,
     dashboard:    <DashboardScreen dashboardState="healthy" />,

--- a/frontend/src/v5/V5App.jsx
+++ b/frontend/src/v5/V5App.jsx
@@ -78,8 +78,12 @@ export default function V5App() {
   const isAdmin = user?.role === 'admin';
   const agentRunning = true;
   const go = React.useCallback((s) => {
-    setScreen(s);
-    navigate(`/v5/${s === 'chat' ? '' : s}`, { replace: false });
+    // Normalize: unknown/invalid targets fall back to chat so state and URL
+    // never disagree (e.g. a stale nav id would otherwise produce /v5/<bogus>
+    // while the shell renders the chat fallback).
+    const target = V5_SCREENS.includes(s) ? s : 'chat';
+    setScreen(target);
+    navigate(`/v5/${target === 'chat' ? '' : target}`, { replace: false });
   }, [navigate]);
   // Back/forward buttons and external URL changes keep the screen in sync.
   React.useEffect(() => {

--- a/render.yaml
+++ b/render.yaml
@@ -25,6 +25,16 @@ services:
         sync: false
 
       # ================================================================
+      # Autonomous loop — log watcher auto-files GitHub issues for
+      # production errors; agents pick them up via the context-PR pipeline.
+      # GH token comes from GH_TOKEN/GITHUB_TOKEN (sync: false, dashboard).
+      # ================================================================
+      - key: LOG_WATCHER_AUTO_FILE
+        value: "1"
+      - key: GITHUB_REPOSITORY
+        value: "strikersam/local-llm-server"
+
+      # ================================================================
       # NVIDIA NIM - Free models, first priority (no local infra needed)
       # Set NVIDIA_API_KEY in the Render dashboard to your nvapi-... key
       # ================================================================


### PR DESCRIPTION
Closes out the three pending items from the maturation cycle:

1. **Deep links** — /v5/doctor (or any screen) now opens that screen; previously V5App always rendered Chat regardless of URL. Back/forward and URL sync on nav included.
2. **Autonomous loop ON** — render.yaml sets LOG_WATCHER_AUTO_FILE=1 and GITHUB_REPOSITORY so production errors auto-file issues; agents pick them up via the context-PR pipeline, which is now mergeable thanks to the docs-context stub checks (#497).
3. **Credential hygiene** — docs/runbooks/credential-rotation.md documents the owner-side rotation steps for the exposed admin password / proxy secret / PAT; pre-mortem registry updated to reflect deployed fixes.

Note: actual rotation of secrets remains an owner action — values live in Render dashboard, not the repo.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed V5 deep links—navigating to specific screens (e.g., `/v5/doctor`) now correctly renders the intended screen and synchronizes with browser navigation and history.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->