### PR TITLE
fix(skills): registry empty in production (GH_TOKEN fallback + CWD-relative local dir)

### DIFF
--- a/agent/skill_registry.py
+++ b/agent/skill_registry.py
@@ -304,7 +304,11 @@ class SkillRegistry:
                  github_token: str | None = None) -> None:
         self._skills: dict[str, RegistrySkill] = {}
         self._last_remote_fetch: float = 0.0
-        self._local_dir = Path(local_skills_dir or ".claude/skills")
+        # Resolve relative to the repo root, not the process CWD — in
+        # production the server may start from a different working directory,
+        # which made the local skill index come up empty (0 skills loaded).
+        _default_dir = Path(__file__).resolve().parent.parent / ".claude" / "skills"
+        self._local_dir = Path(local_skills_dir) if local_skills_dir else _default_dir
         self._github_token = github_token
         self._semaphore = asyncio.Semaphore(self._MAX_CONCURRENT)
         self._etags: dict[str, str] = {}  # URL → ETag for conditional requests

--- a/backend/server.py
+++ b/backend/server.py
@@ -4772,7 +4772,12 @@ async def delete_model(model_name: str, user: dict = Depends(get_current_user)):
 try:
     from agent.skill_registry import SkillRegistry as _SkillRegistry, set_skill_registry
     _SKILL_REGISTRY = _SkillRegistry(
-        github_token=os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_PAT") or os.environ.get("GITHUB_ACCESS_TOKEN")
+        github_token=(
+            os.environ.get("GH_TOKEN")  # render.yaml / preflight use GH_TOKEN
+            or os.environ.get("GITHUB_TOKEN")
+            or os.environ.get("GH_PAT")
+            or os.environ.get("GITHUB_ACCESS_TOKEN")
+        )
     )
     set_skill_registry(_SKILL_REGISTRY)
 except Exception as _sr_err:

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -304,6 +304,7 @@
   `Depends(require_authenticated)`. Previously all reads were unauthenticated.
 
 ### Fixed
+- **Skill registry empty in production (Doctor: '0 skills loaded / repos configured but none fetched').** Two root causes found via browser E2E + pre-mortem probe: (1) the registry token fallback chain omitted `GH_TOKEN` (the var render.yaml and preflight actually use), so remote fetches ran unauthenticated and hit the 60/h GitHub rate limit; (2) the default local skills dir was CWD-relative, indexing 0 skills when the server starts outside the repo root. Token chain now includes GH_TOKEN; local dir resolves relative to the repo. Regression test added.
 - **V5 deep links: /v5/<screen> URLs now open the right screen.** `V5App.jsx` derived nothing from the URL — every load rendered Chat regardless of path; back/forward didn't work. Screen state now syncs with react-router location (deep links, history navigation, URL updates on nav).
 - **log_watcher: runtime LOG_WATCHER_AUTO_FILE flag + incremental scan_now(); Bandit-clean test fixtures; py3.13-safe asyncio in tests.** Security Gate and Test (3.13) CI blockers on PR #487 resolved.
 - **Doctor: optional sidecar runtimes (hermes/goose/aider) no longer fail readiness.** Beta sidecars now report `warn` when unavailable; only `internal_agent` is required in the default path. Aligns Doctor with feature-matrix gating of experimental runtimes.

--- a/tests/test_skill_registry.py
+++ b/tests/test_skill_registry.py
@@ -350,3 +350,14 @@ def test_nested_registry_indexes_deeply_nested_skills():
     # frontmatter stripped; description from prose, categories become tags
     assert "name: pre-mortem" not in pm.description
     assert "project-management" in pm.tags
+
+
+def test_local_skills_dir_defaults_to_repo_root_not_cwd(tmp_path, monkeypatch):
+    """Production regression: server started from a non-repo CWD indexed
+    0 local skills because the default path was CWD-relative."""
+    from agent.skill_registry import SkillRegistry
+    monkeypatch.chdir(tmp_path)  # simulate foreign working directory
+    sr = SkillRegistry()
+    assert len(sr.list(source="local")) > 0, (
+        "expected repo .claude/skills to be indexed regardless of CWD"
+    )

--- a/tests/test_skill_registry.py
+++ b/tests/test_skill_registry.py
@@ -352,7 +352,7 @@ def test_nested_registry_indexes_deeply_nested_skills():
     assert "project-management" in pm.tags
 
 
-def test_local_skills_dir_defaults_to_repo_root_not_cwd(tmp_path, monkeypatch):
+def test_local_skills_dir_defaults_to_repo_root_not_cwd(tmp_path, monkeypatch) -> None:
     """Production regression: server started from a non-repo CWD indexed
     0 local skills because the default path was CWD-relative."""
     from agent.skill_registry import SkillRegistry


### PR DESCRIPTION
Found via browser E2E + pre-mortem probe of the live deployment: Doctor reported 0 skills loaded and 5 remote repos configured but never fetched.

Root causes:
1. Skill registry token fallback chain read GITHUB_TOKEN/GH_PAT/GITHUB_ACCESS_TOKEN but not GH_TOKEN — the variable render.yaml and the workflow preflight actually set — so remote registry fetches ran unauthenticated and died on the 60 req/h GitHub rate limit.
2. Default local skills dir was CWD-relative (.claude/skills); in production the process CWD differs from the repo root, so 0 local skills were indexed.

Fixes: GH_TOKEN added first in the chain; local dir resolves relative to the repo root via __file__. Regression test: tests/test_skill_registry.py::test_local_skills_dir_defaults_to_repo_root_not_cwd.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed critical issue where Skill Registry failed to load any local skills when the server was launched from directories outside the repository root
  * Improved GitHub token authentication by prioritizing `GH_TOKEN` environment variable with fallback support for additional token sources

* **Tests**
  * Added regression test to prevent future regressions in local skills directory resolution

<!-- end of auto-generated comment: release notes by coderabbit.ai -->