### PR TITLE
fix(orchestrator): brain resolves LLM from provider setup + truthful run status

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -31,6 +31,10 @@
 
 ## [Unreleased]
 
+### Fixed
+- **Orchestrator execution brain now resolves its LLM endpoint from the provider setup.** `services/workflow_orchestrator.py` no longer hardwires `AgentRunner` to `OLLAMA_BASE`/localhost (root cause of every cloud run dying at planning with "All connection attempts failed"). New `_resolve_brain_provider()` picks the highest-priority configured provider record (the same store the Providers screen manages), passing its base URL, auth header, and default model to the runner; optional `AGENT_LLM_BASE_URL`/`AGENT_LLM_API_KEY`/`AGENT_LLM_MODEL` env override; local Ollama remains the last-resort fallback. Provider switching is now a priority change in the dashboard, no redeploy.
+- **Truthful run status.** A run whose verification fails can no longer end `done`: it is marked `failed` with the verification issues in `run.error`. Live evidence: five approved runs on 2026-06-10 reported `done` with zero changed files and `verification.passed=false`.
+
 ### Added
 - **Autonomous loop enabled in deployment config.** `render.yaml` sets `LOG_WATCHER_AUTO_FILE=1` and `GITHUB_REPOSITORY` so production errors auto-file issues that agents pick up via the context-PR pipeline (mergeable since the docs-context stub workflow). New `docs/runbooks/credential-rotation.md` runbook for the exposed credentials.
 - **Claude 5 family in the model router (issue #495).** `claude-fable-5` registered (reasoning, 200K context); `claude-mythos-5` env-gated behind `ROUTER_ALLOW_MYTHOS` (approved-orgs-only). Tests in `tests/test_model_router.py::TestClaude5Registry`.

--- a/services/workflow_orchestrator.py
+++ b/services/workflow_orchestrator.py
@@ -444,6 +444,16 @@ class WorkflowOrchestrator:
                 run.error = f"{type(exc).__name__}: {exc}"
                 return run
 
+        if run.verification is not None and not run.verification.passed:
+            run.status = "failed"
+            run.error = run.error or "; ".join(
+                run.verification.issues or ["Verification failed"]
+            )
+            log.info(
+                "WorkflowOrchestrator: run=%s FAILED — verification did not pass", run.run_id
+            )
+            return run
+
         run.status = "done"
         log.info("WorkflowOrchestrator: run=%s DONE", run.run_id)
         return run
@@ -816,6 +826,51 @@ class WorkflowOrchestrator:
         if plan.goal and plan.goal.strip() and plan.goal[:200] != req.request[:200]:
             instruction = f"Goal: {plan.goal}\n\nFull request:\n{req.request}"
 
+        async def _resolve_brain_provider():
+            """Resolve the LLM endpoint for agent execution from the provider setup.
+
+            Order: AGENT_LLM_* env override -> highest-priority configured provider
+            record (the same store the Providers screen manages) -> local Ollama.
+            Returns (openai_compatible_base_url, auth_headers_or_None, model_or_None).
+            """
+            import os as _os2
+            env_base = (_os2.environ.get("AGENT_LLM_BASE_URL") or "").strip()
+            if env_base:
+                key = (_os2.environ.get("AGENT_LLM_API_KEY") or "").strip()
+                headers = {"Authorization": f"Bearer {key}"} if key else None
+                return env_base.rstrip("/"), headers, (_os2.environ.get("AGENT_LLM_MODEL") or None)
+            try:
+                # Lazy import to avoid a circular import at module load time.
+                from backend.server import _list_configured_provider_records
+                records = await _list_configured_provider_records()
+                records.sort(
+                    key=lambda r: r.get("priority") if isinstance(r.get("priority"), (int, float)) else 0
+                )
+                for rec in records:
+                    base = str(rec.get("base_url") or "").strip().rstrip("/")
+                    if not base:
+                        continue
+                    rtype = str(rec.get("type") or "").lower()
+                    key = str(rec.get("api_key") or "").strip()
+                    if rtype != "ollama" and not key:
+                        continue
+                    if not base.endswith("/v1"):
+                        base = f"{base}/v1"
+                    headers = {"Authorization": f"Bearer {key}"} if key else None
+                    model = str(rec.get("default_model") or "").strip() or None
+                    log.info(
+                        "Brain provider resolved from provider setup: %s base=%s model=%s",
+                        rec.get("provider_id"), base, model,
+                    )
+                    return base, headers, model
+            except Exception:
+                log.exception("Brain provider resolution failed — falling back to local Ollama")
+            return (
+                _os2.environ.get("OLLAMA_BASE", "http://localhost:11434").rstrip("/"),
+                None,
+                None,
+            )
+
         # Try AgentRunner for actual execution (bypass deprecation via flag)
         try:
             from agent.loop import AgentRunner
@@ -833,8 +888,10 @@ class WorkflowOrchestrator:
                 gh_token = req.github_token
                 if gh_token is None and req.user_id is None:
                     gh_token = _os.environ.get("GH_TOKEN") or _os.environ.get("GH_PAT") or _os.environ.get("GITHUB_TOKEN")
+                brain_base, brain_headers, brain_model = await _resolve_brain_provider()
                 runner = AgentRunner(
-                    ollama_base=_os.environ.get("OLLAMA_BASE", "http://localhost:11434"),
+                    ollama_base=brain_base,
+                    provider_headers=brain_headers,
                     workspace_root=_os.getcwd(),
                     github_token=gh_token,
                     email=req.user_id,
@@ -842,7 +899,7 @@ class WorkflowOrchestrator:
                 result = await runner.run(
                     instruction=instruction,
                     history=[],
-                    requested_model=None,
+                    requested_model=brain_model,
                     auto_commit=False,
                     max_steps=req.max_steps,
                     user_id=req.user_id,

--- a/services/workflow_orchestrator.py
+++ b/services/workflow_orchestrator.py
@@ -833,12 +833,11 @@ class WorkflowOrchestrator:
             record (the same store the Providers screen manages) -> local Ollama.
             Returns (openai_compatible_base_url, auth_headers_or_None, model_or_None).
             """
-            import os as _os2
-            env_base = (_os2.environ.get("AGENT_LLM_BASE_URL") or "").strip()
+            env_base = (os.environ.get("AGENT_LLM_BASE_URL") or "").strip()
             if env_base:
-                key = (_os2.environ.get("AGENT_LLM_API_KEY") or "").strip()
+                key = (os.environ.get("AGENT_LLM_API_KEY") or "").strip()
                 headers = {"Authorization": f"Bearer {key}"} if key else None
-                return env_base.rstrip("/"), headers, (_os2.environ.get("AGENT_LLM_MODEL") or None)
+                return env_base.rstrip("/"), headers, (os.environ.get("AGENT_LLM_MODEL") or None)
             try:
                 # Lazy import to avoid a circular import at module load time.
                 from backend.server import _list_configured_provider_records
@@ -866,7 +865,7 @@ class WorkflowOrchestrator:
             except Exception:
                 log.exception("Brain provider resolution failed — falling back to local Ollama")
             return (
-                _os2.environ.get("OLLAMA_BASE", "http://localhost:11434").rstrip("/"),
+                os.environ.get("OLLAMA_BASE", "http://localhost:11434").rstrip("/"),
                 None,
                 None,
             )


### PR DESCRIPTION
Bootstrap fix so the agency can repair itself.

**Root cause fixed:** `workflow_orchestrator.py` hardwired `AgentRunner` to `OLLAMA_BASE`/localhost, so every cloud run died at planning (`All connection attempts failed`) yet reported `done`.

**Changes**
- `_resolve_brain_provider()`: providers are tried in ascending priority order (lower number = higher priority, matching ProviderRouter). Non-Ollama records require an API key; **Ollama records are intentionally selectable without an API key**, consistent with `_list_configured_provider_records()`. `AGENT_LLM_BASE_URL/API_KEY/MODEL` env override supported; local Ollama remains the last-resort fallback.
- Truthful status: failed verification now ends the run `failed` with issues in `run.error`.
- Changelog entry under Unreleased.

After merge + deploy, the 5 previously hollow fix runs will be re-filed for agents to execute for real.