### PR TITLE
fix(providers): priority governs all records including env NIM (#524)

### DIFF
--- a/backend/server.py
+++ b/backend/server.py
@@ -3350,10 +3350,18 @@ async def _list_configured_provider_records() -> list[dict]:
             continue
         if provider_type == "ollama" or status == "configured" or has_key:
             filtered.append(record)
-    # Always prepend Nvidia NIM from env when key is present — takes priority over DB records
+    # Nvidia NIM from env participates like any other record — priority governs.
+    # (Previously it was unconditionally prepended, which made UI ordering a lie:
+    # a user-promoted provider could never outrank it. See #524.)
     nim = _nvidia_nim_provider_record()
-    if nim:
-        filtered = [nim] + [r for r in filtered if r.get("provider_id") != "nvidia-nim"]
+    if nim and not any(r.get("provider_id") == "nvidia-nim" for r in filtered):
+        filtered.append(nim)
+    filtered.sort(
+        key=lambda r: (
+            int(r.get("priority")) if isinstance(r.get("priority"), (int, float)) else 100,
+            str(r.get("provider_id") or ""),
+        )
+    )
     return filtered or [_fallback_local_provider_record()]
 
 

--- a/backend/server.py
+++ b/backend/server.py
@@ -3356,11 +3356,14 @@ async def _list_configured_provider_records() -> list[dict]:
     nim = _nvidia_nim_provider_record()
     if nim and not any(r.get("provider_id") == "nvidia-nim" for r in filtered):
         filtered.append(nim)
+    def _record_priority(r: dict) -> int:
+        try:
+            return int(float(r.get("priority")))
+        except (TypeError, ValueError):
+            return 100
+
     filtered.sort(
-        key=lambda r: (
-            int(r.get("priority")) if isinstance(r.get("priority"), (int, float)) else 100,
-            str(r.get("provider_id") or ""),
-        )
+        key=lambda r: (_record_priority(r), str(r.get("provider_id") or ""))
     )
     return filtered or [_fallback_local_provider_record()]
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -62,6 +62,9 @@
 
 ## [Unreleased]
 
+### Fixed
+- **Provider priority now governs ALL records, including env-injected Nvidia NIM.** `_list_configured_provider_records` previously prepended the env NIM record unconditionally, so a user-promoted provider (e.g. Anthropic at -50) could never outrank it — verified live via llm_provenance showing nemotron despite Claude on top. Records are now merged and sorted strictly by priority (#524). Note: commercial providers additionally require the runtime policy `never_use_paid_providers` to be disabled.
+
 
 ### Added
 - **#522: Orchestrator reliability — async approve queue, per-phase timeouts, heartbeat watchdog, deterministic supervisor, step-level checkpointing.** New modules:  (FIFO queue with configurable concurrency semaphore via ),  (zero-LLM periodic coroutine that detects stalled runs by heartbeat and re-enqueues them; configurable via  /  / ),  (durable Mongo/SQLite checkpoint store; in-flight runs survive restarts).  now wraps LLM phases (PLAN, EXECUTE, VERIFY, JUDGE) in per-phase timeouts (, default 120s) with exponential-backoff retries (, default 2) and  tracking.  enqueues approved runs via the FIFO queue instead of blocking inline (API returns 202).  rehydrates + re-enqueues runs after a restart. New endpoints:  (queue depth, active runs, supervisor state), , , , . Startup hooks hydrate persisted schedules and restore in-flight runs.


### PR DESCRIPTION
Live evidence: with anthropic-claude at priority -50, llm_provenance still showed nemotron — the env NIM record was unconditionally prepended, making UI ordering meaningless. Now all records (DB + env NIM) merge and sort strictly by priority. Reminder for operators: commercial providers also require runtime policy never_use_paid_providers=false. Changelog included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed provider priority ordering to apply consistently across all configured providers. User-promoted providers can now correctly outrank others based on their configured priority, rather than being unconditionally subordinated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->