### PR TITLE
fix(orchestrator): trust upstream provider sort in brain resolver

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -63,6 +63,9 @@
 ## [Unreleased]
 
 ### Fixed
+- **Brain resolver no longer re-sorts provider records.** The orchestrator local sort treated non-numeric priorities as 0, silently undoing the strict priority ordering introduced in #535 and keeping the env NIM record on top (verified live: llm_provenance stayed nemotron despite anthropic-claude at -50 and paid policy disabled). The upstream sorted list is now the single source of truth.
+
+### Fixed
 - **Provider priority now governs ALL records, including env-injected Nvidia NIM.** `_list_configured_provider_records` previously prepended the env NIM record unconditionally, so a user-promoted provider (e.g. Anthropic at -50) could never outrank it — verified live via llm_provenance showing nemotron despite Claude on top. Records are now merged and sorted strictly by priority (#524). Note: commercial providers additionally require the runtime policy `never_use_paid_providers` to be disabled.
 
 

--- a/services/workflow_orchestrator.py
+++ b/services/workflow_orchestrator.py
@@ -1064,10 +1064,10 @@ class WorkflowOrchestrator:
             try:
                 # Lazy import to avoid a circular import at module load time.
                 from backend.server import _list_configured_provider_records
+                # Records arrive already sorted strictly by priority (#524/#535).
+                # Do NOT re-sort here: the previous local sort treated string
+                # priorities as 0 and silently undid the upstream ordering.
                 records = await _list_configured_provider_records()
-                records.sort(
-                    key=lambda r: r.get("priority") if isinstance(r.get("priority"), (int, float)) else 0
-                )
                 for rec in records:
                     base = str(rec.get("base_url") or "").strip().rstrip("/")
                     if not base:


### PR DESCRIPTION
Closes the last priority bug: the orchestrator brain resolver re-sorted records with a key that maps non-numeric priorities to 0, silently undoing #535 and keeping env NIM on top — verified live (provenance stayed nemotron with anthropic-claude at -50 and never_use_paid_providers=false). The upstream sorted list is now the single source of truth. Changelog included.