### PR TITLE
feat(deploy): pin agent brain to Claude via Worker env vars + secret

### DIFF
--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -55,4 +55,8 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: deploy --config wrangler.jsonc
+          command: deploy --config wrangler.jsonc --var AGENT_LLM_BASE_URL:https://api.anthropic.com/v1 --var AGENT_LLM_MODEL:claude-sonnet-4-6
+          secrets: |
+            AGENT_LLM_API_KEY
+        env:
+          AGENT_LLM_API_KEY: ${{ secrets.AGENT_LLM_API_KEY }}

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -62,6 +62,9 @@
 
 ## [Unreleased]
 
+### Added
+- **Deploy pins the agent brain via env (immune to #537).** deploy-cloudflare.yml now passes AGENT_LLM_BASE_URL (Anthropic OpenAI-compat) and AGENT_LLM_MODEL=claude-sonnet-4-6 as Worker vars and uploads AGENT_LLM_API_KEY as a Worker secret from GitHub secrets on every deploy. The brain resolver checks env before provider records, so Claude stays the brain across restarts and instances; remove the vars to fall back to record-priority ordering (free models).
+
 ### Fixed
 - **Brain resolver no longer re-sorts provider records.** The orchestrator local sort treated non-numeric priorities as 0, silently undoing the strict priority ordering introduced in #535 and keeping the env NIM record on top (verified live: llm_provenance stayed nemotron despite anthropic-claude at -50 and paid policy disabled). The upstream sorted list is now the single source of truth.
 


### PR DESCRIPTION
Per request: sets the brain to claude-sonnet-4-6 in a way that survives restarts, instances, and deploys — env beats records in the resolver, sidestepping #537. AGENT_LLM_API_KEY was added as an encrypted GitHub Actions secret (never plaintext in the repo) and is uploaded as a Worker secret on each deploy. Switch back to free models later by removing the two --var flags. Changelog included.