### PR TITLE
fix(deploy): Worker secret upload honors wrangler.jsonc (unbreaks deploys)

### DIFF
--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -55,4 +55,8 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: deploy --config wrangler.jsonc
+          command: deploy --config wrangler.jsonc --var AGENT_LLM_BASE_URL:https://api.anthropic.com/v1 --var AGENT_LLM_MODEL:claude-sonnet-4-6
+          secrets: |
+            AGENT_LLM_API_KEY
+        env:
+          AGENT_LLM_API_KEY: ${{ secrets.AGENT_LLM_API_KEY }}

--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -56,7 +56,10 @@ jobs:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           command: deploy --config wrangler.jsonc --var AGENT_LLM_BASE_URL:https://api.anthropic.com/v1 --var AGENT_LLM_MODEL:claude-sonnet-4-6
-          secrets: |
-            AGENT_LLM_API_KEY
+
+      - name: Push brain API key as Worker secret
         env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           AGENT_LLM_API_KEY: ${{ secrets.AGENT_LLM_API_KEY }}
+        run: echo "$AGENT_LLM_API_KEY" | npx -y wrangler@4 secret put AGENT_LLM_API_KEY --config wrangler.jsonc

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -62,6 +62,9 @@
 
 ## [Unreleased]
 
+### Added
+- **Deploy pins the agent brain via env (immune to #537).** deploy-cloudflare.yml now passes AGENT_LLM_BASE_URL (Anthropic OpenAI-compat) and AGENT_LLM_MODEL=claude-sonnet-4-6 as Worker vars and uploads AGENT_LLM_API_KEY as a Worker secret from GitHub secrets on every deploy. The brain resolver checks env before provider records, so Claude stays the brain across restarts and instances; remove the vars to fall back to record-priority ordering (free models).
+
 ### Fixed
 - **Brain resolver no longer re-sorts provider records.** The orchestrator local sort treated non-numeric priorities as 0, silently undoing the strict priority ordering introduced in #535 and keeping the env NIM record on top (verified live: llm_provenance stayed nemotron despite anthropic-claude at -50 and paid policy disabled). The upstream sorted list is now the single source of truth.
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -62,6 +62,9 @@
 
 ## [Unreleased]
 
+### Fixed
+- **Deploys unfrozen: Worker secret upload now honors wrangler.jsonc.** Every deploy since the brain-pinning change failed with "Required Worker name missing" because the wrangler-action secrets input runs `secret put` without `--config`. Replaced with an explicit `npx -y wrangler@4 secret put AGENT_LLM_API_KEY --config wrangler.jsonc` step; the first green deploy activates the env-pinned Claude brain.
+
 ### Added
 - **Deploy pins the agent brain via env (immune to #537).** deploy-cloudflare.yml now passes AGENT_LLM_BASE_URL (Anthropic OpenAI-compat) and AGENT_LLM_MODEL=claude-sonnet-4-6 as Worker vars and uploads AGENT_LLM_API_KEY as a Worker secret from GitHub secrets on every deploy. The brain resolver checks env before provider records, so Claude stays the brain across restarts and instances; remove the vars to fall back to record-priority ordering (free models).
 


### PR DESCRIPTION
Deploys fail since #538: wrangler-action secrets input runs secret put without --config wrangler.jsonc → Required Worker name missing → Failed to upload secrets → every deploy red, worker frozen on last good build. Replaced with an explicit npx -y wrangler@4 secret put step honoring the config. First green deploy activates the env-pinned Claude brain.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated deployment workflow to consistently supply agent base URL, model selection, and to upload the agent API key as a secret during deploys.

* **Documentation**
  * Added changelog entries describing the deployment behavior: pinned agent configuration across deploys and the new secret upload to avoid deployment failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->