### PR TITLE
fix(deploy): Worker secret upload honors wrangler.jsonc (unbreaks deploys, supersedes #539)

### DIFF
--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -56,7 +56,10 @@ jobs:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           command: deploy --config wrangler.jsonc --var AGENT_LLM_BASE_URL:https://api.anthropic.com/v1 --var AGENT_LLM_MODEL:claude-sonnet-4-6
-          secrets: |
-            AGENT_LLM_API_KEY
+
+      - name: Push brain API key as Worker secret
         env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           AGENT_LLM_API_KEY: ${{ secrets.AGENT_LLM_API_KEY }}
+        run: echo "$AGENT_LLM_API_KEY" | npx -y wrangler@4 secret put AGENT_LLM_API_KEY --config wrangler.jsonc

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -62,6 +62,9 @@
 
 ## [Unreleased]
 
+### Fixed
+- **Deploys unfrozen: Worker secret upload honors wrangler.jsonc.** Deploys failed with "Required Worker name missing" because the wrangler-action secrets input runs secret put without --config. Replaced with an explicit npx -y wrangler@4 secret put step; the first green deploy activates the env-pinned Claude brain.
+
 ### Added
 - **Deploy pins the agent brain via env (immune to #537).** deploy-cloudflare.yml now passes AGENT_LLM_BASE_URL (Anthropic OpenAI-compat) and AGENT_LLM_MODEL=claude-sonnet-4-6 as Worker vars and uploads AGENT_LLM_API_KEY as a Worker secret from GitHub secrets on every deploy. The brain resolver checks env before provider records, so Claude stays the brain across restarts and instances; remove the vars to fall back to record-priority ordering (free models).
 


### PR DESCRIPTION
Clean rebuild of #539 (which got tangled in conflicts). Single commit off current master: explicit npx -y wrangler@4 secret put AGENT_LLM_API_KEY --config wrangler.jsonc step replaces the wrangler-action secrets input that ran without --config and failed every deploy with Required Worker name missing. Changelog included. First green deploy activates the env-pinned Claude brain.