### PR TITLE
fix(cloudflare): bind AGENT_LLM env vars to Worker so brain resolver sees them

### DIFF
--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -55,11 +55,11 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: deploy --config wrangler.jsonc --var AGENT_LLM_BASE_URL:https://api.anthropic.com/v1 --var AGENT_LLM_MODEL:claude-sonnet-4-6
+          command: deploy --config wrangler.jsonc --env production
 
       - name: Push brain API key as Worker secret
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           AGENT_LLM_API_KEY: ${{ secrets.AGENT_LLM_API_KEY }}
-        run: echo "$AGENT_LLM_API_KEY" | npx -y wrangler@4 secret put AGENT_LLM_API_KEY --config wrangler.jsonc
+        run: echo "$AGENT_LLM_API_KEY" | npx -y wrangler@4 secret put AGENT_LLM_API_KEY --config wrangler.jsonc --env production

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -63,6 +63,9 @@
 ## [Unreleased]
 
 ### Fixed
+- **Agent brain now visible to FastAPI in Cloudflare Worker.** Env vars set via `--var` on deploy do not auto-populate process.env in Node.js; added `[env.production]` to wrangler.jsonc binding AGENT_LLM_BASE_URL, AGENT_LLM_MODEL, and AGENT_LLM_API_KEY so the orchestrator resolver can read them. Deploy now uses `--env production` and the secret upload targets the same environment.
+
+### Fixed
 - **Deploys unfrozen: Worker secret upload honors wrangler.jsonc.** Deploys failed with "Required Worker name missing" because the wrangler-action secrets input runs secret put without --config. Replaced with an explicit npx -y wrangler@4 secret put step; the first green deploy activates the env-pinned Claude brain.
 
 ### Added

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -9,6 +9,15 @@
   "observability": {
     "enabled": true
   },
+  "env": {
+    "production": {
+      "vars": {
+        "AGENT_LLM_BASE_URL": "https://api.anthropic.com/v1",
+        "AGENT_LLM_MODEL": "claude-sonnet-4-6"
+      },
+      "secrets": ["AGENT_LLM_API_KEY"]
+    }
+  },
   // The React SPA is built by the CI/CD workflow (GitHub Actions) before wrangler runs.
   // No build.command here — the workflow handles: npm install + npm run build + _redirects cleanup.
   "assets": {


### PR DESCRIPTION
Live evidence: deploy succeeded but Claude brain didn't activate because Cloudflare Worker vars set via `--var` flags don't become process.env in Node.js. Wrangler requires explicit [env] binding in wrangler.jsonc. Added production environment with AGENT_LLM_* vars and secrets, deploy now targets --env production. First green deploy activates Claude brain globally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed production environment variable handling for LLM agent configuration to ensure settings properly populate at deploy time.

* **Chores**
  * Updated deployment workflow to use environment-scoped configuration management.
  * Updated production environment configuration for LLM agent runtime values.

* **Documentation**
  * Clarified changelog entry regarding environment variable behavior in production deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->