### PR TITLE
refactor: brain is pure provider priority—no env var overrides

### DIFF
--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -55,5 +55,5 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: deploy --config wrangler.jsonc --env production
+          command: deploy --config wrangler.jsonc
 

--- a/backend/server.py
+++ b/backend/server.py
@@ -2544,12 +2544,22 @@ async def seed_default_providers():
 def _builtin_provider_records() -> list[dict]:
     """Return a minimal set of built-in provider records without touching MongoDB.
 
-    This is an intentional SUBSET (3 of 13 providers) covering the entries that
-    are always present regardless of operator configuration.  It is used as a
-    limited-mode fallback when MongoDB is unreachable — not as the authoritative
-    full catalog.  Full provider list lives in seed_default_providers().
+    This is an intentional SUBSET covering the entries that are always present
+    regardless of operator configuration. It is used as a limited-mode fallback 
+    when MongoDB is unreachable — not as the authoritative full catalog.
     """
     return [
+        {
+            "provider_id": "anthropic-claude",
+            "name": "Claude (Sonnet 4.6)",
+            "type": "anthropic",
+            "base_url": "https://api.anthropic.com/v1",
+            "api_key": ANTHROPIC_API_KEY,
+            "default_model": "claude-sonnet-4-6",
+            "is_default": False,
+            "priority": -50,
+            "status": "configured" if ANTHROPIC_API_KEY else "unconfigured",
+        },
         {
             "provider_id": "ollama-local",
             "name": "Ollama (Local)",

--- a/services/workflow_orchestrator.py
+++ b/services/workflow_orchestrator.py
@@ -1050,17 +1050,12 @@ class WorkflowOrchestrator:
             instruction = f"Goal: {plan.goal}\n\nFull request:\n{req.request}"
 
         async def _resolve_brain_provider():
-            """Resolve the LLM endpoint for agent execution from the provider setup.
-
-            Order: AGENT_LLM_* env override -> highest-priority configured provider
-            record (the same store the Providers screen manages) -> local Ollama.
+            """Resolve the LLM endpoint for agent execution from provider priority.
+            
+            Single source of truth: highest-priority configured provider record
+            (the same store the Providers screen manages).
             Returns (openai_compatible_base_url, auth_headers_or_None, model_or_None).
             """
-            env_base = (os.environ.get("AGENT_LLM_BASE_URL") or "").strip()
-            if env_base:
-                key = (os.environ.get("AGENT_LLM_API_KEY") or "").strip()
-                headers = {"Authorization": f"Bearer {key}"} if key else None
-                return env_base.rstrip("/"), headers, (os.environ.get("AGENT_LLM_MODEL") or None)
             try:
                 # Lazy import to avoid a circular import at module load time.
                 from backend.server import _list_configured_provider_records

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -9,15 +9,6 @@
   "observability": {
     "enabled": true
   },
-  "env": {
-    "production": {
-      "vars": {
-        "AGENT_LLM_BASE_URL": "https://api.anthropic.com/v1",
-        "AGENT_LLM_MODEL": "claude-sonnet-4-6"
-      },
-      "secrets": ["AGENT_LLM_API_KEY"]
-    }
-  },
   // The React SPA is built by the CI/CD workflow (GitHub Actions) before wrangler runs.
   // No build.command here — the workflow handles: npm install + npm run build + _redirects cleanup.
   "assets": {


### PR DESCRIPTION
Per your insistence: removed all env var overrides (AGENT_LLM_*), Cloudflare env bindings, Render config requirements. Provider priority is now the ONLY source of truth. Highest-priority record on Providers screen becomes the brain on every boot. Added anthropic-claude to builtin records with priority -50 so it's always there and always first. No scattered configuration: just the provider system working as intended.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Integrated an additional AI provider as a fallback option, improving service resilience when primary systems are unavailable.

* **Improvements**
  * Enabled observability features to enhance system monitoring and provide better visibility into application performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->