### PR TITLE
fix(scheduler): wire on_fire callback + Cloudflare cron keepalive

### DIFF
--- a/backend/server.py
+++ b/backend/server.py
@@ -122,13 +122,18 @@ _ensure_error_log_capture()
 
 def _scheduler_on_fire(job) -> None:
     """Called by APScheduler when a cron fires. Dispatches to the orchestrator."""
-    import asyncio, threading
-    from services.workflow_orchestrator import get_workflow_orchestrator
+    import asyncio
+    from services.workflow_orchestrator import get_workflow_orchestrator, ExecutionRequest
     async def _dispatch():
         try:
             orch = get_workflow_orchestrator()
-            run = await orch.execute(request=job.instruction, auto_approve=True)
-            log.info("Scheduler fired job %s → run %s", job.job_id, run.get("run_id"))
+            req = ExecutionRequest(
+                request=job.instruction,
+                auto_approve=True,
+                user_id="scheduler",
+            )
+            run = await orch.execute(req)
+            log.info("Scheduler fired job %s → run %s", job.job_id, run.run_id)
         except Exception as exc:
             log.error("Scheduler on_fire failed for %s: %s", job.job_id, exc)
     try:
@@ -5651,19 +5656,26 @@ async def health():
 
 
 @app.post("/api/scheduler/tick")
-async def scheduler_tick():
-    """Called by Cloudflare Cron every minute to keep APScheduler alive on Render
-    and tick any overdue jobs. Safe to call from outside — no auth required since
-    it only triggers already-configured scheduled jobs."""
+async def scheduler_tick(request: Request):
+    """Called by Cloudflare Cron every minute. Protected by CRON_SECRET header."""
+    cron_secret = os.environ.get("CRON_SECRET", "")
+    incoming = request.headers.get("x-cron-secret", "")
+    if cron_secret and incoming != cron_secret:
+        from fastapi import HTTPException
+        raise HTTPException(status_code=403, detail="Invalid cron secret")
     scheduler = get_scheduler()
     fired = []
     try:
         jobs = scheduler.list()
-        import datetime
-        now = datetime.datetime.utcnow()
+        from datetime import datetime, timezone
+        now = datetime.now(timezone.utc)
         for job in jobs:
-            next_run = job.next_run_time if hasattr(job, "next_run_time") else None
-            if next_run and next_run <= now:
+            next_run = getattr(job, "next_run_time", None)
+            if next_run is None:
+                continue
+            if next_run.tzinfo is None:
+                next_run = next_run.replace(tzinfo=timezone.utc)
+            if next_run <= now:
                 try:
                     scheduler.trigger(job.job_id)
                     fired.append(job.job_id)

--- a/backend/server.py
+++ b/backend/server.py
@@ -120,7 +120,27 @@ def clear_error_log_buffer() -> None:
 
 _ensure_error_log_capture()
 
-SCHEDULER = AgentScheduler()
+def _scheduler_on_fire(job) -> None:
+    """Called by APScheduler when a cron fires. Dispatches to the orchestrator."""
+    import asyncio, threading
+    from services.workflow_orchestrator import get_workflow_orchestrator
+    async def _dispatch():
+        try:
+            orch = get_workflow_orchestrator()
+            run = await orch.execute(request=job.instruction, auto_approve=True)
+            log.info("Scheduler fired job %s → run %s", job.job_id, run.get("run_id"))
+        except Exception as exc:
+            log.error("Scheduler on_fire failed for %s: %s", job.job_id, exc)
+    try:
+        loop = asyncio.get_event_loop()
+        if loop.is_running():
+            asyncio.ensure_future(_dispatch())
+        else:
+            loop.run_until_complete(_dispatch())
+    except Exception as exc:
+        log.error("Scheduler on_fire loop error: %s", exc)
+
+SCHEDULER = AgentScheduler(on_fire=_scheduler_on_fire)
 set_scheduler(SCHEDULER)
 
 MONGO_URL = os.environ.get("MONGO_URL", "mongodb://localhost:27017")
@@ -5627,6 +5647,30 @@ async def health():
         mongo_ok = True
     except Exception:
         mongo_ok = False
+
+
+@app.post("/api/scheduler/tick")
+async def scheduler_tick():
+    """Called by Cloudflare Cron every minute to keep APScheduler alive on Render
+    and tick any overdue jobs. Safe to call from outside — no auth required since
+    it only triggers already-configured scheduled jobs."""
+    scheduler = get_scheduler()
+    fired = []
+    try:
+        jobs = scheduler.list()
+        import datetime
+        now = datetime.datetime.utcnow()
+        for job in jobs:
+            next_run = job.next_run_time if hasattr(job, "next_run_time") else None
+            if next_run and next_run <= now:
+                try:
+                    scheduler.trigger(job.job_id)
+                    fired.append(job.job_id)
+                except Exception as exc:
+                    log.warning("tick: failed to trigger %s: %s", job.job_id, exc)
+    except Exception as exc:
+        log.error("scheduler_tick error: %s", exc)
+    return {"ok": True, "fired": fired, "total_jobs": len(scheduler.list())}
 
     active = await get_active_provider()
     active_type = str((active or {}).get("type", "ollama")).lower()

--- a/backend/server.py
+++ b/backend/server.py
@@ -5647,6 +5647,7 @@ async def health():
         mongo_ok = True
     except Exception:
         mongo_ok = False
+    return {"status": "ok" if mongo_ok else "degraded", "mongo": mongo_ok}
 
 
 @app.post("/api/scheduler/tick")

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -86,6 +86,9 @@
 
 ## [Unreleased]
 
+### Fixed
+- **Scheduler now actually fires jobs.** Two root causes fixed: (1) AgentScheduler was created without an on_fire callback so cron events had nowhere to go; wired to orchestrator execute with auto_approve. (2) Render free tier spins down after inactivity killing APScheduler; added Cloudflare cron trigger (every minute) in wrangler.jsonc and a Worker scheduled handler that pings /api/scheduler/tick on the Render backend. APScheduler now stays alive and overdue jobs are dispatched on every tick.
+
 ### Added
 - **SEO audit: browser-fetch path (bot-protection bypass) + demoable UI + honest revenue model.**
   - *Browser-use fetch backend* (`services/seo_fetch.py`): pluggable page fetchers — default `HttpxFetcher`,

--- a/worker/index.js
+++ b/worker/index.js
@@ -27,11 +27,19 @@ export default {
       const target = BACKEND_ORIGIN + url.pathname + url.search;
       const proxied = new Request(target, request);
       proxied.headers.set("X-Forwarded-Host", url.host);
-      // redirect: "manual" so backend 3xx responses (e.g. OAuth login) are handed
-      // back to the browser instead of being followed server-side.
       return fetch(proxied, { redirect: "manual" });
     }
 
     return env.ASSETS.fetch(request);
+  },
+
+  async scheduled(event, env, ctx) {
+    // Cloudflare Cron fires every minute — pings the Render backend tick endpoint
+    // to keep APScheduler alive and fire overdue scheduled jobs.
+    ctx.waitUntil(
+      fetch(BACKEND_ORIGIN + "/api/scheduler/tick", { method: "POST" })
+        .then(r => r.ok ? console.log("tick ok") : console.warn("tick", r.status))
+        .catch(e => console.error("tick error", e))
+    );
   },
 };

--- a/worker/index.js
+++ b/worker/index.js
@@ -36,8 +36,12 @@ export default {
   async scheduled(event, env, ctx) {
     // Cloudflare Cron fires every minute — pings the Render backend tick endpoint
     // to keep APScheduler alive and fire overdue scheduled jobs.
+    const secret = env.CRON_SECRET || "";
     ctx.waitUntil(
-      fetch(BACKEND_ORIGIN + "/api/scheduler/tick", { method: "POST" })
+      fetch(BACKEND_ORIGIN + "/api/scheduler/tick", {
+        method: "POST",
+        headers: { "x-cron-secret": secret },
+      })
         .then(r => r.ok ? console.log("tick ok") : console.warn("tick", r.status))
         .catch(e => console.error("tick error", e))
     );

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -9,6 +9,9 @@
   "observability": {
     "enabled": true
   },
+  "triggers": {
+    "crons": ["* * * * *"]
+  },
   // The React SPA is built by the CI/CD workflow (GitHub Actions) before wrangler runs.
   // No build.command here — the workflow handles: npm install + npm run build + _redirects cleanup.
   "assets": {


### PR DESCRIPTION
Root cause of 0 runs / never-firing schedules:

1. `AgentScheduler()` created at line 123 with no `on_fire` — APScheduler fires the cron but the callback is None so nothing dispatches to the orchestrator.
2. Render free tier spins down after 15min inactivity, killing the APScheduler background thread silently.

Fixes:
- Wire `on_fire=_scheduler_on_fire` which calls `orchestrator.execute(auto_approve=True)`
- Cloudflare cron trigger every minute in wrangler.jsonc
- Worker `scheduled()` handler POSTs `/api/scheduler/tick` to Render, keeping the process alive and ticking overdue jobs
- Added `/api/scheduler/tick` POST endpoint on backend

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Scheduled jobs now execute as configured; resolved a critical issue where registered jobs were not being dispatched at their scheduled times.

* **New Features**
  * Implemented automatic scheduler maintenance that periodically checks for overdue jobs and triggers their execution, improving reliability of job dispatch on resource-constrained deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->