### PR TITLE
fix: seed anthropic-claude at priority -50 + expose next_run from APScheduler

### DIFF
--- a/backend/server.py
+++ b/backend/server.py
@@ -2354,6 +2354,17 @@ async def seed_default_providers():
     )
     defaults = [
         {
+            "provider_id": "anthropic-claude",
+            "name": "Claude (Sonnet 4.6)",
+            "type": "anthropic",
+            "base_url": "https://api.anthropic.com/v1",
+            "api_key": ANTHROPIC_API_KEY,
+            "default_model": "claude-sonnet-4-6",
+            "is_default": False,
+            "priority": -50,
+            "status": "configured" if ANTHROPIC_API_KEY else "unconfigured",
+        },
+        {
             "provider_id": "nvidia-nim",
             "name": "Nvidia NIM (Free)",
             "type": "openai-compatible",

--- a/schedules/api.py
+++ b/schedules/api.py
@@ -49,9 +49,25 @@ class ScheduleToggleRequest(BaseModel):
 
 @schedules_router.get("/")
 async def list_schedules(request: Request) -> dict:
-    """List all scheduled jobs."""
+    """List all scheduled jobs, enriched with APScheduler next_run_time."""
     sched = get_scheduler()
-    return {"schedules": [j.as_dict() for j in sched.list()]}
+    jobs = sched.list()
+    # Build next_run lookup from APScheduler if available
+    next_run_map: dict[str, str] = {}
+    try:
+        if sched._aps:
+            for aps_job in sched._aps.get_jobs():
+                nrt = getattr(aps_job, "next_run_time", None)
+                if nrt:
+                    next_run_map[aps_job.id] = nrt.isoformat()
+    except Exception:
+        pass
+    result = []
+    for j in jobs:
+        d = j.as_dict()
+        d["next_run"] = next_run_map.get(j.job_id)
+        result.append(d)
+    return {"schedules": result}
 
 
 @schedules_router.post("/")


### PR DESCRIPTION
Permanent fix for brain reverting to nemotron on every deploy: anthropic-claude was missing from seed_default_providers so every startup left it with priority=None, losing to nvidia-nim. Also exposes APScheduler next_run_time in the schedules list so UI shows real fire times.