### PR TITLE
fix(orchestrator): correct Anthropic auth headers — x-api-key not Bearer

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -87,6 +87,9 @@
 ## [Unreleased]
 
 ### Fixed
+- **Anthropic brain calls now authenticated correctly.** The brain resolver used `Authorization: Bearer` for all provider types including `type=anthropic`, which requires `x-api-key` + `anthropic-version` headers. This caused silent 401s that appeared as stalled runs. Fixed with a type check in the resolver.
+
+### Fixed
 - **Anthropic API calls no longer 404.** Seed records for `anthropic-claude` had `base_url` ending in `/v1`; the orchestrator resolver then appended `/v1/messages`, producing `https://api.anthropic.com/v1/v1/messages`. Changed both seed records to `https://api.anthropic.com` to match the env default.
 
 ### Fixed

--- a/services/workflow_orchestrator.py
+++ b/services/workflow_orchestrator.py
@@ -1071,7 +1071,9 @@ class WorkflowOrchestrator:
                     key = str(rec.get("api_key") or "").strip()
                     if rtype != "ollama" and not key:
                         continue
-                    if not base.endswith("/v1"):
+                    # Native Anthropic: agent/loop.py appends /v1/messages itself.
+                    # All others: normalise to end in /v1 so the agent loop finds the right path.
+                    if rtype != "anthropic" and not base.endswith("/v1"):
                         base = f"{base}/v1"
                     # Anthropic native API uses x-api-key, not Bearer token.
                     if rtype == "anthropic":

--- a/services/workflow_orchestrator.py
+++ b/services/workflow_orchestrator.py
@@ -1073,7 +1073,11 @@ class WorkflowOrchestrator:
                         continue
                     if not base.endswith("/v1"):
                         base = f"{base}/v1"
-                    headers = {"Authorization": f"Bearer {key}"} if key else None
+                    # Anthropic native API uses x-api-key, not Bearer token.
+                    if rtype == "anthropic":
+                        headers = {"x-api-key": key, "anthropic-version": "2023-06-01"} if key else None
+                    else:
+                        headers = {"Authorization": f"Bearer {key}"} if key else None
                     model = str(rec.get("default_model") or "").strip() or None
                     log.info(
                         "Brain provider resolved from provider setup: %s base=%s model=%s",


### PR DESCRIPTION
Every Claude execution stalled silently because the resolver sent Authorization: Bearer which Anthropic rejects with 401. Added type check: anthropic providers get x-api-key + anthropic-version, others keep Bearer.