### PR TITLE
feat(scheduler): add GET /api/scheduler/tick/last monitoring endpoint

### DIFF
--- a/backend/server.py
+++ b/backend/server.py
@@ -5702,8 +5702,22 @@ async def scheduler_tick(request: Request):
     return {"ok": True, "fired": fired, "total_jobs": len(scheduler.list())}
 
 
-@app.get("/api/scheduler/tick/last")
-async def scheduler_tick_last() -> dict:
+
+class SchedulerTickLastResponse(BaseModel):
+    """Public keepalive-monitoring response for GET /api/scheduler/tick/last.
+
+    Intentionally public — no auth required.  Monitoring tools and the
+    Cloudflare Worker itself call this endpoint to confirm the cron
+    ``scheduled()`` handler is successfully reaching the Render backend.
+    """
+    last_tick_at: Optional[str] = Field(default=None, description="ISO 8601 timestamp of last tick, or null")
+    seconds_since_last_tick: Optional[float] = Field(default=None, description="Elapsed seconds since last tick, or null")
+    stale: bool = Field(default=True, description="True when >120s since last tick")
+    message: str = Field(default="No tick received yet since server start", description="Human-readable status")
+
+
+@app.get("/api/scheduler/tick/last", response_model=SchedulerTickLastResponse)
+async def scheduler_tick_last() -> SchedulerTickLastResponse:
     """Return the last Cloudflare Cron tick timestamp for keepalive monitoring.
 
     Public — no auth required. Monitoring tools and the Cloudflare Worker itself
@@ -5712,24 +5726,24 @@ async def scheduler_tick_last() -> dict:
     """
     tick_at = _last_cron_tick_at
     if tick_at is None:
-        return {
-            "last_tick_at": None,
-            "seconds_since_last_tick": None,
-            "stale": True,
-            "message": "No tick received yet since server start",
-        }
+        return SchedulerTickLastResponse(
+            last_tick_at=None,
+            seconds_since_last_tick=None,
+            stale=True,
+            message="No tick received yet since server start",
+        )
     now = datetime.now(timezone.utc)
     delta = (now - tick_at).total_seconds()
     stale = delta > 120
-    return {
-        "last_tick_at": tick_at.isoformat(),
-        "seconds_since_last_tick": round(delta, 1),
-        "stale": stale,
-        "message": (
+    return SchedulerTickLastResponse(
+        last_tick_at=tick_at.isoformat(),
+        seconds_since_last_tick=round(delta, 1),
+        stale=stale,
+        message=(
             "Keepalive is healthy" if not stale
             else f"No tick received in {round(delta)}s — keepalive may be down"
         ),
-    }
+    )
 
 
     active = await get_active_provider()

--- a/backend/server.py
+++ b/backend/server.py
@@ -5666,6 +5666,9 @@ async def health():
     return {"status": "ok" if mongo_ok else "degraded", "mongo": mongo_ok}
 
 
+_last_cron_tick_at: Optional[datetime] = None
+
+
 @app.post("/api/scheduler/tick")
 async def scheduler_tick(request: Request):
     """Called by Cloudflare Cron every minute. Protected by CRON_SECRET header."""
@@ -5674,6 +5677,8 @@ async def scheduler_tick(request: Request):
     if cron_secret and incoming != cron_secret:
         from fastapi import HTTPException
         raise HTTPException(status_code=403, detail="Invalid cron secret")
+    global _last_cron_tick_at
+    _last_cron_tick_at = datetime.now(timezone.utc)
     scheduler = get_scheduler()
     fired = []
     try:
@@ -5695,6 +5700,37 @@ async def scheduler_tick(request: Request):
     except Exception as exc:
         log.error("scheduler_tick error: %s", exc)
     return {"ok": True, "fired": fired, "total_jobs": len(scheduler.list())}
+
+
+@app.get("/api/scheduler/tick/last")
+async def scheduler_tick_last() -> dict:
+    """Return the last Cloudflare Cron tick timestamp for keepalive monitoring.
+
+    Public — no auth required. Monitoring tools and the Cloudflare Worker itself
+    can call this to confirm the cron is successfully reaching the backend.
+    Returns nulls when the server has just started and no tick has arrived yet.
+    """
+    tick_at = _last_cron_tick_at
+    if tick_at is None:
+        return {
+            "last_tick_at": None,
+            "seconds_since_last_tick": None,
+            "stale": True,
+            "message": "No tick received yet since server start",
+        }
+    now = datetime.now(timezone.utc)
+    delta = (now - tick_at).total_seconds()
+    stale = delta > 120
+    return {
+        "last_tick_at": tick_at.isoformat(),
+        "seconds_since_last_tick": round(delta, 1),
+        "stale": stale,
+        "message": (
+            "Keepalive is healthy" if not stale
+            else f"No tick received in {round(delta)}s — keepalive may be down"
+        ),
+    }
+
 
     active = await get_active_provider()
     active_type = str((active or {}).get("type", "ollama")).lower()

--- a/backend/server.py
+++ b/backend/server.py
@@ -5683,7 +5683,6 @@ async def scheduler_tick(request: Request):
     fired = []
     try:
         jobs = scheduler.list()
-        from datetime import datetime, timezone
         now = datetime.now(timezone.utc)
         for job in jobs:
             next_run = getattr(job, "next_run_time", None)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -86,6 +86,9 @@
 
 ## [Unreleased]
 
+### Added
+- **`GET /api/scheduler/tick/last` — Cloudflare cron keepalive monitoring endpoint.** Tracks `_last_cron_tick_at` (updated on each authenticated `POST /api/scheduler/tick` from the Cloudflare Worker). Public endpoint (no auth) returns last tick timestamp, seconds since last tick, staleness flag (>120s = stale), and human-readable message. Monitoring tools can poll this to confirm the Worker's `scheduled()` handler is successfully reaching Render.
+
 ### Fixed
 - **Anthropic brain calls now authenticated correctly.** The brain resolver used `Authorization: Bearer` for all provider types including `type=anthropic`, which requires `x-api-key` + `anthropic-version` headers. This caused silent 401s that appeared as stalled runs. Fixed with a type check in the resolver.
 


### PR DESCRIPTION
## Summary

Adds a public monitoring endpoint to confirm the Cloudflare Worker cron keepalive is successfully reaching the Render backend.

## Changes

- **`_last_cron_tick_at`** — module-level `Optional[datetime]` variable tracking the last cron tick timestamp
- **Updated `POST /api/scheduler/tick`** — records `datetime.now(timezone.utc)` on each authenticated tick
- **New `GET /api/scheduler/tick/last`** — public endpoint (no auth) returning:
  - `last_tick_at`: ISO 8601 timestamp of last tick (or null)
  - `seconds_since_last_tick`: elapsed seconds (or null)
  - `stale`: true if >120s since last tick
  - `message`: human-readable status

## Why

Monitoring tools and the Cloudflare Worker itself can call this endpoint to confirm the cron keepalive is functioning. Without it, there's no way to verify the Worker's `scheduled()` handler is actually firing and reaching Render.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a scheduler health monitoring endpoint. It reports the timestamp of the most recent scheduler tick, time elapsed since the last tick, and a staleness status flag. The endpoint detects unhealthy scheduler states by indicating when no tick has been received within 120 seconds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->