### PR TITLE
fix: update NVIDIA model + add orchestrator heartbeat + bind_context timeout

### DIFF
--- a/.github/scripts/generate_context.py
+++ b/.github/scripts/generate_context.py
@@ -38,7 +38,7 @@ REPO_ROOT = Path(os.environ.get("REPO_ROOT", str(Path(__file__).parent.parent.pa
 # NVIDIA NIM models tried in order.
 # nvidia/llama-3.1-nemotron-ultra-253b-v1 removed — returns 404 on this account.
 NVIDIA_MODELS = [
-    "qwen/qwen3-coder-480b-a35b-instruct",
+    "nvidia/nemotron-3-super-120b-a12b",
     "nvidia/llama-3.3-nemotron-super-49b-v1",
     "meta/llama-3.3-70b-instruct",
     "qwen/qwen2.5-coder-32b-instruct",

--- a/backend/server.py
+++ b/backend/server.py
@@ -7123,7 +7123,7 @@ async def workflow_orchestrator_status(
     owner_id = None if _wfo_is_admin(user) else _wfo_resolve_user_id(user)
     runs = orchestrator.list_runs(limit=200, owner_id=owner_id)
 
-    queue_status = {max_concurrent: 2, active: 0, queued: 0}
+    queue_status = {"max_concurrent": 2, "active": 0, "queued": 0}
     try:
         from services.orchestrator_queue import get_orchestrator_queue
         q = get_orchestrator_queue()
@@ -7137,23 +7137,27 @@ async def workflow_orchestrator_status(
         sv = get_orchestrator_supervisor()
         st = sv.state
         supervisor_state = {
-            running: st.running,
-            ticks: st.ticks,
-            stalled_recovered: st.stalled_recovered,
-            failed_retried: st.failed_retried,
-            alerts_emitted: st.alerts_emitted,
+            "running": st.running,
+            "ticks": st.ticks,
+            "stalled_recovered": st.stalled_recovered,
+            "failed_retried": st.failed_retried,
+            "alerts_emitted": st.alerts_emitted,
         }
     except Exception:
         pass
 
     return {
-        runs: len(runs),
-        by_status: {
-            s: sum(1 for r in runs if r.get(status) == s)
-            for s in [pending, running, awaiting_approval, queued, done, failed]
+        "runs": len(runs),
+        "by_status": {
+            "pending": sum(1 for r in runs if r.get("status") == "pending"),
+            "running": sum(1 for r in runs if r.get("status") == "running"),
+            "awaiting_approval": sum(1 for r in runs if r.get("status") == "awaiting_approval"),
+            "queued": sum(1 for r in runs if r.get("status") == "queued"),
+            "done": sum(1 for r in runs if r.get("status") == "done"),
+            "failed": sum(1 for r in runs if r.get("status") == "failed"),
         },
-        queue: queue_status,
-        supervisor: supervisor_state,
+        "queue": queue_status,
+        "supervisor": supervisor_state,
     }
 
 @app.get("/api/workflow/orchestrator/runs")

--- a/services/workflow_orchestrator.py
+++ b/services/workflow_orchestrator.py
@@ -451,10 +451,24 @@ class WorkflowOrchestrator:
             run.phase_attempts[phase.value] = attempt + 1
             try:
                 started = time.time()
-                await asyncio.wait_for(
-                    handler(run, req),
-                    timeout=_PHASE_TIMEOUT_SEC,
-                )
+                # Periodic heartbeat — update last_heartbeat every 30s while the
+                # phase runs so the supervisor knows it is not stalled (#522).
+                async def _heartbeat():
+                    while True:
+                        await asyncio.sleep(30)
+                        run.last_heartbeat = time.time()
+                heartbeat_task = asyncio.create_task(_heartbeat())
+                try:
+                    await asyncio.wait_for(
+                        handler(run, req),
+                        timeout=_PHASE_TIMEOUT_SEC,
+                    )
+                finally:
+                    heartbeat_task.cancel()
+                    try:
+                        await heartbeat_task
+                    except asyncio.CancelledError:
+                        pass
                 elapsed = time.time() - started
                 run.last_heartbeat = time.time()
                 log.debug(
@@ -571,7 +585,7 @@ class WorkflowOrchestrator:
                 # LLM-bearing phases (PLAN, EXECUTE, VERIFY, JUDGE) get the full
                 # timeout/retry treatment; lightweight phases (CLASSIFY, PERSIST)
                 # run directly.
-                _LLM_PHASES = {Phase.PLAN, Phase.EXECUTE, Phase.VERIFY, Phase.JUDGE}
+                _LLM_PHASES = {Phase.PLAN, Phase.BIND_CONTEXT, Phase.EXECUTE, Phase.VERIFY, Phase.JUDGE}
                 if phase in _LLM_PHASES:
                     await self._run_phase_with_timeout(run, req, phase, handler)
                 else:


### PR DESCRIPTION
## Summary

Three fixes addressing CI failures and orchestrator stall timeouts.

## Changes

### 1. Fix issue-context-generator NVIDIA model (HTTP 410)
`.github/scripts/generate_context.py`: Replaced deprecated `qwen/qwen3-coder-480b-a35b-instruct` (returned HTTP 410 Gone) with `nvidia/nemotron-3-super-120b-a12b` — the free NVIDIA model already used throughout the codebase.

### 2. Add periodic heartbeat during phase execution (#522)
`services/workflow_orchestrator.py`: Each LLM-bearing phase now spawns a background `asyncio.create_task` that updates `run.last_heartbeat = time.time()` every 30s. Previously, heartbeat was only set AFTER phase completion — so the supervisor's 300s stall threshold was breached by any phase taking >300s (common with external API calls + retries). The heartbeat task is cancelled in a `finally` block with proper `CancelledError` handling.

### 3. Add BIND_CONTEXT to timeout-protected phases
`services/workflow_orchestrator.py`: `BIND_CONTEXT` was missing from `_LLM_PHASES`, so `_handle_bind_context` ran with no timeout at all. DB calls could hang indefinitely. Added to the set alongside PLAN/EXECUTE/VERIFY/JUDGE for 120s timeout + retry protection.

## Why

All 7 recent orchestrator runs were failing with "Stalled >300s after 3 retries" because:
- Phases took >300s (external Anthropic API calls with retries) with zero heartbeat updates
- BIND_CONTEXT had no timeout at all, so DB hangs permanently stalled runs
- The issue-context-generator workflow failed because the NVIDIA model endpoint was deprecated