### PR TITLE
debug(orchestrator): add try/except to status endpoint to expose 500 crash

### DIFF
--- a/backend/server.py
+++ b/backend/server.py
@@ -7119,47 +7119,50 @@ async def workflow_orchestrator_status(
     user: dict = Depends(get_current_user),
 ):
     """Return orchestrator queue depth, active runs, and supervisor state (#522)."""
-    orchestrator = get_workflow_orchestrator()
-    owner_id = None if _wfo_is_admin(user) else _wfo_resolve_user_id(user)
-    runs = orchestrator.list_runs(limit=200, owner_id=owner_id)
-
-    queue_status = {"max_concurrent": 2, "active": 0, "queued": 0}
+    import traceback as _tb
     try:
-        from services.orchestrator_queue import get_orchestrator_queue
-        q = get_orchestrator_queue()
-        queue_status = q.status()
-    except Exception:
-        pass
+        orchestrator = get_workflow_orchestrator()
+        owner_id = None if _wfo_is_admin(user) else _wfo_resolve_user_id(user)
+        runs = orchestrator.list_runs(limit=200, owner_id=owner_id)
 
-    supervisor_state = {}
-    try:
-        from services.orchestrator_supervisor import get_orchestrator_supervisor
-        sv = get_orchestrator_supervisor()
-        st = sv.state
-        supervisor_state = {
-            "running": st.running,
-            "ticks": st.ticks,
-            "stalled_recovered": st.stalled_recovered,
-            "failed_retried": st.failed_retried,
-            "alerts_emitted": st.alerts_emitted,
+        queue_status = {"max_concurrent": 2, "active": 0, "queued": 0}
+        try:
+            from services.orchestrator_queue import get_orchestrator_queue
+            q = get_orchestrator_queue()
+            queue_status = q.status()
+        except Exception:
+            pass
+
+        supervisor_state = {}
+        try:
+            from services.orchestrator_supervisor import get_orchestrator_supervisor
+            sv = get_orchestrator_supervisor()
+            st = sv.state
+            supervisor_state = {
+                "running": st.running,
+                "ticks": st.ticks,
+                "stalled_recovered": st.stalled_recovered,
+                "failed_retried": st.failed_retried,
+                "alerts_emitted": st.alerts_emitted,
+            }
+        except Exception:
+            pass
+
+        return {
+            "runs": len(runs),
+            "by_status": {
+                "pending": sum(1 for r in runs if r.get("status") == "pending"),
+                "running": sum(1 for r in runs if r.get("status") == "running"),
+                "awaiting_approval": sum(1 for r in runs if r.get("status") == "awaiting_approval"),
+                "queued": sum(1 for r in runs if r.get("status") == "queued"),
+                "done": sum(1 for r in runs if r.get("status") == "done"),
+                "failed": sum(1 for r in runs if r.get("status") == "failed"),
+            },
+            "queue": queue_status,
+            "supervisor": supervisor_state,
         }
-    except Exception:
-        pass
-
-    return {
-        "runs": len(runs),
-        "by_status": {
-            "pending": sum(1 for r in runs if r.get("status") == "pending"),
-            "running": sum(1 for r in runs if r.get("status") == "running"),
-            "awaiting_approval": sum(1 for r in runs if r.get("status") == "awaiting_approval"),
-            "queued": sum(1 for r in runs if r.get("status") == "queued"),
-            "done": sum(1 for r in runs if r.get("status") == "done"),
-            "failed": sum(1 for r in runs if r.get("status") == "failed"),
-        },
-        "queue": queue_status,
-        "supervisor": supervisor_state,
-    }
-
+    except Exception as _exc:
+        return {"error": str(_exc), "traceback": _tb.format_exc()}
 @app.get("/api/workflow/orchestrator/runs")
 async def workflow_orchestrator_list_runs(
     limit: int = 50,


### PR DESCRIPTION
## Summary

Diagnostic change: wraps the orchestrator/status handler body in try/except that catches any exception and returns the error message + full Python traceback as JSON.

## Why

The endpoint is returning 500 on every authenticated call despite the dict key fix being deployed. The root cause is unclear from remote inspection. This wrapper will expose the actual exception on production.

## What changes

- Added `import traceback as _tb` at the top of the handler
- Wrapped the entire handler body in `try: ... except Exception as _exc: return {"error": ..., "traceback": ...}`
- No logic changes - all calls are identical, just now inside a try block
- On success, the response shape is unchanged

## Next steps

Once deployed, hitting `GET /api/workflow/orchestrator/status` with JWT auth will return the actual crash error. Use that to fix the root cause, then remove this diagnostic wrapper.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling for the orchestrator status endpoint. The API now returns comprehensive error details with complete traceback information when failures occur, improving debugging and troubleshooting capabilities. The successful response structure remains unchanged, ensuring full backward compatibility with existing integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->