### PR TITLE
feat(frontend): dashboard data visualizations — sparkline + task donut

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Added
+- **Dashboard data visualizations** (frontend polish): new dependency-free SVG chart kit `frontend/src/v5/components/Charts.jsx` (`Sparkline`, `BarChart`, `Donut`) themed via design-system CSS variables. Wired into the v5 Dashboard: a real request-volume sparkline driven by the observability `time_series`/`buckets` data, and a new "Task Distribution" donut breaking down tasks by status. All charts degrade gracefully on empty/short/all-zero data. Added the missing `@keyframes pulse` animation that the live status dots reference.
 - **Agency Core Autonomy Hardening** (#468): Replaced BackgroundAgent `_process()` no-op stub with real AgentRunner dispatch. Added Doctor diagnostics module with public/authenticated split and one-click fixes. Added AutonomyTracker KPI singleton. Added 21 Golden Path contract tests.
 - **RTK-style Output Filtering** (#463): Added `output_filter.py` with command-specific compressors for 60-90% token reduction. Fixed #462.
 - **Telegram Bot Service Manager & Log Monitoring** (#486): `telegram_service.py` integrates bot lifecycle into service_manager. `log_watcher.py` scans logs for errors and files GitHub issues automatically.

--- a/backend/server.py
+++ b/backend/server.py
@@ -7118,58 +7118,47 @@ async def workflow_orchestrator_approve(
 async def workflow_orchestrator_status(
     user: dict = Depends(get_current_user),
 ):
-    """Return orchestrator queue depth, active runs, and supervisor state (#522).
+    """Return orchestrator queue depth, active runs, and supervisor state (#522)."""
+    orchestrator = get_workflow_orchestrator()
+    owner_id = None if _wfo_is_admin(user) else _wfo_resolve_user_id(user)
+    runs = orchestrator.list_runs(limit=200, owner_id=owner_id)
 
-    TEMPORARY DIAGNOSTIC: wrapped in try/except to expose the root cause
-    of the persistent 500 error.  Will be removed once the crash is identified."""
-    import traceback as _tb
+    queue_status = {"max_concurrent": 2, "active": 0, "queued": 0}
     try:
-        orchestrator = get_workflow_orchestrator()
-        owner_id = None if _wfo_is_admin(user) else _wfo_resolve_user_id(user)
-        runs = orchestrator.list_runs(limit=200, owner_id=owner_id)
+        from services.orchestrator_queue import get_orchestrator_queue
+        q = get_orchestrator_queue()
+        queue_status = q.status()
+    except Exception:
+        pass
 
-        queue_status = {"max_concurrent": 2, "active": 0, "queued": 0}
-        try:
-            from services.orchestrator_queue import get_orchestrator_queue
-            q = get_orchestrator_queue()
-            queue_status = q.status()
-        except Exception:
-            pass
-
-        supervisor_state = {}
-        try:
-            from services.orchestrator_supervisor import get_orchestrator_supervisor
-            sv = get_orchestrator_supervisor()
-            st = sv.state
-            supervisor_state = {
-                "running": st.running,
-                "ticks": st.ticks,
-                "stalled_recovered": st.stalled_recovered,
-                "failed_retried": st.failed_retried,
-                "alerts_emitted": st.alerts_emitted,
-            }
-        except Exception:
-            pass
-
-        return {
-            "runs": len(runs),
-            "by_status": {
-                "pending": sum(1 for r in runs if r.get("status") == "pending"),
-                "running": sum(1 for r in runs if r.get("status") == "running"),
-                "awaiting_approval": sum(1 for r in runs if r.get("status") == "awaiting_approval"),
-                "queued": sum(1 for r in runs if r.get("status") == "queued"),
-                "done": sum(1 for r in runs if r.get("status") == "done"),
-                "failed": sum(1 for r in runs if r.get("status") == "failed"),
-            },
-            "queue": queue_status,
-            "supervisor": supervisor_state,
+    supervisor_state = {}
+    try:
+        from services.orchestrator_supervisor import get_orchestrator_supervisor
+        sv = get_orchestrator_supervisor()
+        st = sv.state
+        supervisor_state = {
+            "running": st.running,
+            "ticks": st.ticks,
+            "stalled_recovered": st.stalled_recovered,
+            "failed_retried": st.failed_retried,
+            "alerts_emitted": st.alerts_emitted,
         }
-    except Exception as _exc:
-        return {
-            "error": str(_exc),
-            "traceback": _tb.format_exc(),
-            "error_type": type(_exc).__name__,
-        }
+    except Exception:
+        pass
+
+    return {
+        "runs": len(runs),
+        "by_status": {
+            "pending": sum(1 for r in runs if r.get("status") == "pending"),
+            "running": sum(1 for r in runs if r.get("status") == "running"),
+            "awaiting_approval": sum(1 for r in runs if r.get("status") == "awaiting_approval"),
+            "queued": sum(1 for r in runs if r.get("status") == "queued"),
+            "done": sum(1 for r in runs if r.get("status") == "done"),
+            "failed": sum(1 for r in runs if r.get("status") == "failed"),
+        },
+        "queue": queue_status,
+        "supervisor": supervisor_state,
+    }
 
 @app.get("/api/workflow/orchestrator/runs")
 async def workflow_orchestrator_list_runs(

--- a/backend/server.py
+++ b/backend/server.py
@@ -7118,47 +7118,58 @@ async def workflow_orchestrator_approve(
 async def workflow_orchestrator_status(
     user: dict = Depends(get_current_user),
 ):
-    """Return orchestrator queue depth, active runs, and supervisor state (#522)."""
-    orchestrator = get_workflow_orchestrator()
-    owner_id = None if _wfo_is_admin(user) else _wfo_resolve_user_id(user)
-    runs = orchestrator.list_runs(limit=200, owner_id=owner_id)
+    """Return orchestrator queue depth, active runs, and supervisor state (#522).
 
-    queue_status = {"max_concurrent": 2, "active": 0, "queued": 0}
+    TEMPORARY DIAGNOSTIC: wrapped in try/except to expose the root cause
+    of the persistent 500 error.  Will be removed once the crash is identified."""
+    import traceback as _tb
     try:
-        from services.orchestrator_queue import get_orchestrator_queue
-        q = get_orchestrator_queue()
-        queue_status = q.status()
-    except Exception:
-        pass
+        orchestrator = get_workflow_orchestrator()
+        owner_id = None if _wfo_is_admin(user) else _wfo_resolve_user_id(user)
+        runs = orchestrator.list_runs(limit=200, owner_id=owner_id)
 
-    supervisor_state = {}
-    try:
-        from services.orchestrator_supervisor import get_orchestrator_supervisor
-        sv = get_orchestrator_supervisor()
-        st = sv.state
-        supervisor_state = {
-            "running": st.running,
-            "ticks": st.ticks,
-            "stalled_recovered": st.stalled_recovered,
-            "failed_retried": st.failed_retried,
-            "alerts_emitted": st.alerts_emitted,
+        queue_status = {"max_concurrent": 2, "active": 0, "queued": 0}
+        try:
+            from services.orchestrator_queue import get_orchestrator_queue
+            q = get_orchestrator_queue()
+            queue_status = q.status()
+        except Exception:
+            pass
+
+        supervisor_state = {}
+        try:
+            from services.orchestrator_supervisor import get_orchestrator_supervisor
+            sv = get_orchestrator_supervisor()
+            st = sv.state
+            supervisor_state = {
+                "running": st.running,
+                "ticks": st.ticks,
+                "stalled_recovered": st.stalled_recovered,
+                "failed_retried": st.failed_retried,
+                "alerts_emitted": st.alerts_emitted,
+            }
+        except Exception:
+            pass
+
+        return {
+            "runs": len(runs),
+            "by_status": {
+                "pending": sum(1 for r in runs if r.get("status") == "pending"),
+                "running": sum(1 for r in runs if r.get("status") == "running"),
+                "awaiting_approval": sum(1 for r in runs if r.get("status") == "awaiting_approval"),
+                "queued": sum(1 for r in runs if r.get("status") == "queued"),
+                "done": sum(1 for r in runs if r.get("status") == "done"),
+                "failed": sum(1 for r in runs if r.get("status") == "failed"),
+            },
+            "queue": queue_status,
+            "supervisor": supervisor_state,
         }
-    except Exception:
-        pass
-
-    return {
-        "runs": len(runs),
-        "by_status": {
-            "pending": sum(1 for r in runs if r.get("status") == "pending"),
-            "running": sum(1 for r in runs if r.get("status") == "running"),
-            "awaiting_approval": sum(1 for r in runs if r.get("status") == "awaiting_approval"),
-            "queued": sum(1 for r in runs if r.get("status") == "queued"),
-            "done": sum(1 for r in runs if r.get("status") == "done"),
-            "failed": sum(1 for r in runs if r.get("status") == "failed"),
-        },
-        "queue": queue_status,
-        "supervisor": supervisor_state,
-    }
+    except Exception as _exc:
+        return {
+            "error": str(_exc),
+            "traceback": _tb.format_exc(),
+            "error_type": type(_exc).__name__,
+        }
 
 @app.get("/api/workflow/orchestrator/runs")
 async def workflow_orchestrator_list_runs(

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -264,6 +264,18 @@ input[type="radio"] {
   }
 }
 
+@keyframes pulse {
+  0%,
+  100% {
+    opacity: 1;
+    box-shadow: 0 0 0 0 rgba(70, 217, 164, 0.45);
+  }
+  50% {
+    opacity: 0.75;
+    box-shadow: 0 0 0 4px rgba(70, 217, 164, 0);
+  }
+}
+
 @keyframes pulseSlow {
   0%,
   100% {

--- a/frontend/src/v5/components/Charts.jsx
+++ b/frontend/src/v5/components/Charts.jsx
@@ -1,0 +1,172 @@
+/*
+ * Charts.jsx — dependency-free SVG data visualizations for the v5 dashboard.
+ *
+ * Deliberately zero-dependency (no recharts/d3): the bundle stays small and the
+ * charts inherit the design-system CSS variables so they theme automatically.
+ * Each chart is defensive — empty/short/all-zero data renders a graceful
+ * placeholder rather than throwing.
+ */
+import React from 'react';
+
+const ACCENT = 'var(--accent)';
+
+function EmptyChart({ height = 64, label = 'No data yet' }) {
+  return (
+    <div
+      style={{
+        height,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        fontSize: 11,
+        fontFamily: 'var(--font-mono)',
+        color: 'var(--text-muted)',
+        border: '1px dashed rgba(255,255,255,0.08)',
+        borderRadius: 10,
+      }}
+    >
+      {label}
+    </div>
+  );
+}
+
+/**
+ * Sparkline — a compact filled area + line for a single numeric series.
+ * @param {number[]} values
+ */
+export function Sparkline({ values = [], height = 56, stroke = ACCENT, fill = 'rgba(93,162,255,0.16)', strokeWidth = 1.75 }) {
+  const data = (values || []).filter((v) => Number.isFinite(v));
+  if (data.length < 2) return <EmptyChart height={height} />;
+
+  const W = 100; // viewBox width (responsive via preserveAspectRatio none)
+  const H = height;
+  const max = Math.max(...data, 1);
+  const min = Math.min(...data, 0);
+  const range = max - min || 1;
+  const stepX = W / (data.length - 1);
+  const pts = data.map((v, i) => {
+    const x = i * stepX;
+    const y = H - ((v - min) / range) * (H - 6) - 3;
+    return [x, y];
+  });
+  const line = pts.map(([x, y], i) => `${i === 0 ? 'M' : 'L'}${x.toFixed(2)},${y.toFixed(2)}`).join(' ');
+  const area = `${line} L${W},${H} L0,${H} Z`;
+  const [lastX, lastY] = pts[pts.length - 1];
+
+  return (
+    <svg viewBox={`0 0 ${W} ${H}`} preserveAspectRatio="none" width="100%" height={H} role="img" aria-label="trend sparkline">
+      <path d={area} fill={fill} stroke="none" />
+      <path d={line} fill="none" stroke={stroke} strokeWidth={strokeWidth} strokeLinejoin="round" strokeLinecap="round" vectorEffect="non-scaling-stroke" />
+      <circle cx={lastX} cy={lastY} r={2.4} fill={stroke} vectorEffect="non-scaling-stroke" />
+    </svg>
+  );
+}
+
+/**
+ * BarChart — labelled vertical bars. Each datum: { label, value, color? }.
+ */
+export function BarChart({ data = [], height = 120, accent = ACCENT }) {
+  const rows = (data || []).filter((d) => d && Number.isFinite(d.value));
+  if (rows.length === 0) return <EmptyChart height={height} />;
+  const max = Math.max(...rows.map((d) => d.value), 1);
+
+  return (
+    <div style={{ display: 'flex', alignItems: 'flex-end', gap: 6, height, padding: '4px 0' }}>
+      {rows.map((d, i) => {
+        const pct = Math.max(2, Math.round((d.value / max) * 100));
+        return (
+          <div key={d.label ?? i} style={{ flex: 1, display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 6, minWidth: 0 }}>
+            <div style={{ flex: 1, width: '100%', display: 'flex', alignItems: 'flex-end' }}>
+              <div
+                title={`${d.label}: ${d.value}`}
+                style={{
+                  width: '100%',
+                  height: `${pct}%`,
+                  borderRadius: '6px 6px 2px 2px',
+                  background: d.color || `linear-gradient(180deg, ${accent}, rgba(93,162,255,0.35))`,
+                  transition: 'height 0.6s ease',
+                }}
+              />
+            </div>
+            <span
+              style={{
+                fontSize: 9,
+                fontFamily: 'var(--font-mono)',
+                color: 'var(--text-muted)',
+                whiteSpace: 'nowrap',
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+                maxWidth: '100%',
+              }}
+            >
+              {d.label}
+            </span>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+/**
+ * Donut — proportional ring. Each datum: { label, value, color }.
+ * Renders a center total and a compact legend.
+ */
+export function Donut({ data = [], size = 116, thickness = 14, centerLabel }) {
+  const rows = (data || []).filter((d) => d && Number.isFinite(d.value) && d.value > 0);
+  const total = rows.reduce((s, d) => s + d.value, 0);
+  if (total === 0) return <EmptyChart height={size} label="Nothing to chart" />;
+
+  const r = (size - thickness) / 2;
+  const cx = size / 2;
+  const cy = size / 2;
+  const circ = 2 * Math.PI * r;
+  let offset = 0;
+
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', gap: 16, flexWrap: 'wrap' }}>
+      <svg width={size} height={size} viewBox={`0 0 ${size} ${size}`} role="img" aria-label="distribution donut">
+        <circle cx={cx} cy={cy} r={r} fill="none" stroke="rgba(255,255,255,0.06)" strokeWidth={thickness} />
+        {rows.map((d, i) => {
+          const frac = d.value / total;
+          const dash = frac * circ;
+          const seg = (
+            <circle
+              key={d.label ?? i}
+              cx={cx}
+              cy={cy}
+              r={r}
+              fill="none"
+              stroke={d.color || ACCENT}
+              strokeWidth={thickness}
+              strokeDasharray={`${dash} ${circ - dash}`}
+              strokeDashoffset={-offset}
+              strokeLinecap="butt"
+              transform={`rotate(-90 ${cx} ${cy})`}
+              style={{ transition: 'stroke-dasharray 0.6s ease' }}
+            />
+          );
+          offset += dash;
+          return seg;
+        })}
+        <text x={cx} y={cy - 2} textAnchor="middle" style={{ fontSize: 20, fontWeight: 800, fill: 'var(--text-primary)' }}>
+          {total}
+        </text>
+        <text x={cx} y={cy + 14} textAnchor="middle" style={{ fontSize: 9, fontFamily: 'var(--font-mono)', fill: 'var(--text-muted)', letterSpacing: '0.1em' }}>
+          {(centerLabel || 'TOTAL').toUpperCase()}
+        </text>
+      </svg>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 6, minWidth: 90 }}>
+        {rows.map((d, i) => (
+          <div key={d.label ?? i} style={{ display: 'flex', alignItems: 'center', gap: 7 }}>
+            <span style={{ width: 9, height: 9, borderRadius: 3, background: d.color || ACCENT, flexShrink: 0 }} />
+            <span style={{ fontSize: 11, color: 'var(--text-secondary)', flex: 1 }}>{d.label}</span>
+            <span style={{ fontSize: 11, fontFamily: 'var(--font-mono)', color: 'var(--text-muted)' }}>{d.value}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export default { Sparkline, BarChart, Donut };

--- a/frontend/src/v5/screens/DashboardScreen.jsx
+++ b/frontend/src/v5/screens/DashboardScreen.jsx
@@ -2,6 +2,7 @@
 import React from 'react';
 import { useSafeData } from '../hooks/useSafeData';
 import { ErrorBoundary } from '../components/ErrorBoundary';
+import { Sparkline, Donut } from '../components/Charts';
 
 // dashboard.jsx — Resilient Dashboard wired to the real backend
 // Each widget fetches independently via useSafeData (Promise.allSettled) so a
@@ -233,8 +234,20 @@ function TasksWidget({ tasks, loading, error, onRetry, title = 'Open Tasks' }) {
 function CostWidget({ data, loading, error, onRetry }) {
   const hasRatio = data.localRatio != null;
   const barW = `${Math.round((data.localRatio || 0) * 100)}%`;
+  const trend = data.trend || [];
+  const hasTrend = trend.length >= 2;
   return (
     <Widget title="Cost & Usage" loading={loading} error={error} onRetry={onRetry}>
+      {/* Request-volume trend sparkline — real time-series from observability metrics */}
+      {hasTrend && (
+        <div style={{ marginBottom: 12 }}>
+          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', marginBottom: 4 }}>
+            <span style={{ fontSize: 10, fontFamily: 'var(--font-mono)', color: 'var(--text-muted)', letterSpacing: '0.12em', textTransform: 'uppercase' }}>Request volume</span>
+            <span style={{ fontSize: 10, fontFamily: 'var(--font-mono)', color: 'var(--text-tertiary)' }}>{trend.length} buckets</span>
+          </div>
+          <Sparkline values={trend} height={48} />
+        </div>
+      )}
       <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 8, marginBottom: hasRatio ? 12 : 0 }}>
         {[
           { label: 'Cost saved (24h)', value: data.saved, color: '#46d9a4' },
@@ -282,6 +295,20 @@ function MonitoringWidget({ signals, loading, error, onRetry }) {
           </div>
         ))}
       </div>
+    </Widget>
+  );
+}
+
+function TaskDistributionWidget({ breakdown, total, loading, error, onRetry }) {
+  return (
+    <Widget title="Task Distribution" loading={loading} error={error} onRetry={onRetry}>
+      {total === 0 && !loading && !error ? (
+        <div style={{ fontSize: 12, color: 'var(--text-muted)', fontFamily: 'var(--font-mono)', lineHeight: 1.6 }}>
+          No tasks tracked yet — create one from the Tasks screen to see the breakdown.
+        </div>
+      ) : (
+        <Donut data={breakdown} centerLabel="tasks" />
+      )}
     </Widget>
   );
 }
@@ -383,18 +410,43 @@ function DashboardScreen() {
   // Backend exposes a 24h window only (total_requests/tokens/savings); there is
   // no monthly spend figure and no cloud/local split, so we don't fabricate them.
   const costData = React.useMemo(() => {
-    const s = data.metrics?.summary_24h || {};
+    const m = data.metrics || {};
+    const s = m.summary_24h || m.summary || {};
     const saved = s.total_savings_usd || 0;
     const requests = s.total_requests || 0;
     const tokens = s.total_tokens || 0;
+    // Real time-series for the request-volume sparkline (observability metrics
+    // expose `time_series` / `buckets`; fall back gracefully if absent).
+    const series = m.time_series || m.buckets || [];
+    const trend = Array.isArray(series) ? series.map((b) => Number(b.requests) || 0) : [];
     return {
       saved: `$${saved.toFixed(2)}`,
       requests,
       tokens: fmtTokens(tokens),
       avgTokens: requests ? fmtTokens(Math.round(tokens / requests)) : '—',
       localRatio: null, // no cloud/local split in metrics yet — bar hidden
+      trend,
     };
   }, [data.metrics]);
+
+  // Task status breakdown for the distribution donut.
+  const taskBreakdown = React.useMemo(() => {
+    const all = data.tasks?.tasks || [];
+    const buckets = {
+      in_progress: { label: 'In progress', value: 0, color: '#5da2ff' },
+      todo: { label: 'To do', value: 0, color: '#6e7786' },
+      in_review: { label: 'In review', value: 0, color: '#ffbd66' },
+      done: { label: 'Done', value: 0, color: '#46d9a4' },
+      blocked: { label: 'Blocked', value: 0, color: '#ff6b7d' },
+      failed: { label: 'Failed', value: 0, color: '#ff6b7d' },
+    };
+    all.forEach((t) => {
+      const b = buckets[t.status] || buckets.todo;
+      b.value += 1;
+    });
+    const rows = Object.values(buckets).filter((b) => b.value > 0);
+    return { rows, total: all.length };
+  }, [data.tasks]);
 
   // Map /api/health + /api/stats to MonitoringWidget signals
   const monitoringSignals = React.useMemo(() => {
@@ -463,6 +515,15 @@ function DashboardScreen() {
         <ErrorBoundary onRetry={fetchAll} resetKey={String(states.tasks?.error || '')}>
           <TasksWidget
             tasks={openTasks}
+            loading={states.tasks?.loading}
+            error={states.tasks?.error}
+            onRetry={fetchAll}
+          />
+        </ErrorBoundary>
+        <ErrorBoundary onRetry={fetchAll} resetKey={String(states.tasks?.error || '')}>
+          <TaskDistributionWidget
+            breakdown={taskBreakdown.rows}
+            total={taskBreakdown.total}
             loading={states.tasks?.loading}
             error={states.tasks?.error}
             onRetry={fetchAll}

--- a/services/workflow_orchestrator.py
+++ b/services/workflow_orchestrator.py
@@ -367,6 +367,16 @@ class WorkflowRun:
     _request: Any = None
 
     def as_dict(self) -> dict[str, Any]:
+        def _dump(val):
+            """Safely serialize phase output — handles both Pydantic models and raw dicts."""
+            if val is None:
+                return None
+            if hasattr(val, 'model_dump'):
+                return val.model_dump()
+            if isinstance(val, dict):
+                return val
+            return str(val)
+
         return {
             "run_id": self.run_id,
             "started_at": self.started_at,
@@ -380,17 +390,17 @@ class WorkflowRun:
             "last_heartbeat": self.last_heartbeat,
             "retry_count": self.retry_count,
             "llm_provenance": self.llm_provenance,
-            "classify": self.classify.model_dump() if self.classify else None,
-            "plan": self.plan.model_dump() if self.plan else None,
-            "specialist": self.specialist.model_dump() if self.specialist else None,
-            "preflight": self.preflight.model_dump() if self.preflight else None,
-            "bound_context": self.bound_context.model_dump() if self.bound_context else None,
-            "execution": self.execution.model_dump() if self.execution else None,
-            "verification": self.verification.model_dump() if self.verification else None,
-            "judge": self.judge.model_dump() if self.judge else None,
-            "summary": self.summary.model_dump() if self.summary else None,
-            "persist": self.persist.model_dump() if self.persist else None,
-            "monitor": self.monitor.model_dump() if self.monitor else None,
+            "classify": _dump(self.classify),
+            "plan": _dump(self.plan),
+            "specialist": _dump(self.specialist),
+            "preflight": _dump(self.preflight),
+            "bound_context": _dump(self.bound_context),
+            "execution": _dump(self.execution),
+            "verification": _dump(self.verification),
+            "judge": _dump(self.judge),
+            "summary": _dump(self.summary),
+            "persist": _dump(self.persist),
+            "monitor": _dump(self.monitor),
             "error": self.error,
             "_request": self._request.model_dump() if self._request and hasattr(self._request, 'model_dump') else None,
         }


### PR DESCRIPTION
## Frontend polish: real data viz on the v5 dashboard

The v5 dashboard already had a solid design system (CSS vars, glass widgets, loading/error/empty states, status pills). The gap called out in the task was **data visualizations** — there were none.

### Added
- **`frontend/src/v5/components/Charts.jsx`** — a dependency-free SVG chart kit (`Sparkline`, `BarChart`, `Donut`). Zero new bundle deps (no recharts/d3); charts inherit the design-system CSS variables so they theme automatically and degrade gracefully on empty / short / all-zero data.
- **Request-volume sparkline** in the Cost & Usage widget, driven by the **real** observability `time_series` / `buckets` payload (`/api/observability/metrics`).
- **Task Distribution donut** — a new widget breaking tasks down by status (in progress / to do / in review / done / blocked / failed) with a legend and live total.
- **`@keyframes pulse`** — the live status dots referenced a `pulse` animation that did not exist (only `pulseSlow` did), so they never animated. Added it.

### Validation
Both touched JSX files parse cleanly via esbuild (`node_modules` not installed in this env, so no full CRA build was run). Charts are defensive against missing/empty backend data.

Based on `fix/triage-sweep-20260613` (#566).