### PR TITLE
debug(orchestrator): add try/except to status endpoint to expose 500 crash

### DIFF
--- a/backend/server.py
+++ b/backend/server.py
@@ -7118,47 +7118,58 @@ async def workflow_orchestrator_approve(
 async def workflow_orchestrator_status(
     user: dict = Depends(get_current_user),
 ):
-    """Return orchestrator queue depth, active runs, and supervisor state (#522)."""
-    orchestrator = get_workflow_orchestrator()
-    owner_id = None if _wfo_is_admin(user) else _wfo_resolve_user_id(user)
-    runs = orchestrator.list_runs(limit=200, owner_id=owner_id)
+    """Return orchestrator queue depth, active runs, and supervisor state (#522).
 
-    queue_status = {"max_concurrent": 2, "active": 0, "queued": 0}
+    TEMPORARY DIAGNOSTIC: wrapped in try/except to expose the root cause
+    of the persistent 500 error.  Will be removed once the crash is identified."""
+    import traceback as _tb
     try:
-        from services.orchestrator_queue import get_orchestrator_queue
-        q = get_orchestrator_queue()
-        queue_status = q.status()
-    except Exception:
-        pass
+        orchestrator = get_workflow_orchestrator()
+        owner_id = None if _wfo_is_admin(user) else _wfo_resolve_user_id(user)
+        runs = orchestrator.list_runs(limit=200, owner_id=owner_id)
 
-    supervisor_state = {}
-    try:
-        from services.orchestrator_supervisor import get_orchestrator_supervisor
-        sv = get_orchestrator_supervisor()
-        st = sv.state
-        supervisor_state = {
-            "running": st.running,
-            "ticks": st.ticks,
-            "stalled_recovered": st.stalled_recovered,
-            "failed_retried": st.failed_retried,
-            "alerts_emitted": st.alerts_emitted,
+        queue_status = {"max_concurrent": 2, "active": 0, "queued": 0}
+        try:
+            from services.orchestrator_queue import get_orchestrator_queue
+            q = get_orchestrator_queue()
+            queue_status = q.status()
+        except Exception:
+            pass
+
+        supervisor_state = {}
+        try:
+            from services.orchestrator_supervisor import get_orchestrator_supervisor
+            sv = get_orchestrator_supervisor()
+            st = sv.state
+            supervisor_state = {
+                "running": st.running,
+                "ticks": st.ticks,
+                "stalled_recovered": st.stalled_recovered,
+                "failed_retried": st.failed_retried,
+                "alerts_emitted": st.alerts_emitted,
+            }
+        except Exception:
+            pass
+
+        return {
+            "runs": len(runs),
+            "by_status": {
+                "pending": sum(1 for r in runs if r.get("status") == "pending"),
+                "running": sum(1 for r in runs if r.get("status") == "running"),
+                "awaiting_approval": sum(1 for r in runs if r.get("status") == "awaiting_approval"),
+                "queued": sum(1 for r in runs if r.get("status") == "queued"),
+                "done": sum(1 for r in runs if r.get("status") == "done"),
+                "failed": sum(1 for r in runs if r.get("status") == "failed"),
+            },
+            "queue": queue_status,
+            "supervisor": supervisor_state,
         }
-    except Exception:
-        pass
-
-    return {
-        "runs": len(runs),
-        "by_status": {
-            "pending": sum(1 for r in runs if r.get("status") == "pending"),
-            "running": sum(1 for r in runs if r.get("status") == "running"),
-            "awaiting_approval": sum(1 for r in runs if r.get("status") == "awaiting_approval"),
-            "queued": sum(1 for r in runs if r.get("status") == "queued"),
-            "done": sum(1 for r in runs if r.get("status") == "done"),
-            "failed": sum(1 for r in runs if r.get("status") == "failed"),
-        },
-        "queue": queue_status,
-        "supervisor": supervisor_state,
-    }
+    except Exception as _exc:
+        return {
+            "error": str(_exc),
+            "traceback": _tb.format_exc(),
+            "error_type": type(_exc).__name__,
+        }
 
 @app.get("/api/workflow/orchestrator/runs")
 async def workflow_orchestrator_list_runs(


### PR DESCRIPTION
## Summary

Temporary diagnostic change: wraps the orchestrator/status handler body in try/except that catches any exception and returns the error message + full Python traceback as JSON.

## Why

The endpoint is returning 500 on every authenticated call. The root cause is unclear from remote inspection. This wrapper will expose the actual exception.

## What changes

- Added `import traceback as _tb` at the top of the handler
- Wrapped the entire handler body in `try: ... except Exception as _exc: return {"error": ..., "traceback": ...}`
- No logic changes - all calls are identical, just now inside a try block
- Extended docstring to note this is temporary

After this is merged and deployed, hitting the endpoint will reveal the exact crash so we can apply the real fix and then remove this diagnostic wrapper.