### PR TITLE
feat: brand rename → Autonomous AI Agency + login screen refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ With Autonomous AI Agency:
 ## How it works — the 5-minute version
 
 1. **Paste your website URL.** `https://acme-store.com`
-2. **Agency Core scans it.** A BuiltWith-parity technology scanner detects your tech stack, business systems, and integrations (Shopify, Stripe, Google Analytics, GitHub, Intercom, Salesforce, …). It fuses four evidence sources — headless-browser HTML fingerprinting (Playwright, with `curl_cffi` Chrome impersonation to clear bot walls), DNS records (MX/NS/TXT/CNAME), TLS-certificate issuer + Subject Alternative Names, and high-signal response headers (CF-Ray, X-Served-By, X-Amz-Cf-Id, Server, X-Powered-By) — so it identifies CDN/host/cert providers even on sites whose HTML is bot-walled, with highest-confidence-wins merging.
+2. **Autonomous AI Agency scans it.** Playwright + HTTP fingerprinting detects your tech stack, business systems, and integrations (Shopify, Stripe, Google Analytics, GitHub, Intercom, Salesforce, …).
 3. **It asks you the right questions.** AI-generated onboarding questions based on what it found — not generic forms.
 4. **Specialists are auto-provisioned.** A fleet of agents is assembled from 34 specialist families — exactly the ones your business needs, with the right runtimes and skills bound.
 5. **Schedules activate.** Health scans, security audits, code quality checks, SEO monitoring, graph sync — all running on their own cadence without manual setup.

--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -1,2 +1,2 @@
-"""Backend package for the LLM Relay dashboard."""
+"""Backend package for the Autonomous AI Agency dashboard."""
 

--- a/backend/company_api.py
+++ b/backend/company_api.py
@@ -2,7 +2,7 @@
 Company Graph API Router
 
 Provides all endpoints for managing companies, their graphs, and related entities.
-This is the canonical API for the Agency Core v5 Company Graph.
+This is the canonical API for the Autonomous AI Agency Company Graph.
 """
 
 from __future__ import annotations

--- a/backend/server.py
+++ b/backend/server.py
@@ -1421,11 +1421,11 @@ async def lifespan(app_: "FastAPI"):
     bg: Optional[BackgroundServices] = None
     try:
         await ensure_bootstrap()
-        log.info("LLM Relay Platform started — provider=%s", LLM_PROVIDER)
+        log.info("Autonomous AI Agency started — provider=%s", LLM_PROVIDER)
     except Exception as exc:
         log.warning("MongoDB bootstrap deferred (no DB connection): %s", exc)
         log.info(
-            "LLM Relay Platform started in limited mode — set MONGO_URL to enable full features"
+            "Autonomous AI Agency started in limited mode — set MONGO_URL to enable full features"
         )
 
     if run_background_in_web():

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -87,10 +87,8 @@
 ## [Unreleased]
 
 ### Changed
-- **ECC skill enabled.** `ecc-harness-patterns` re-enabled in skill_bindings.py (was off since 2026-06-10). Cross-harness orchestration now available to engineering/devops/architecture runs.
-
-### Fixed
-- **Checkpoint restore now preserves phase outputs and _request.** On retry/restart, `restore_in_flight` only restored status/heartbeat — all phase outputs (classify, plan, execution, etc.) were None, so skip detection never fired and every resume re-ran all phases from scratch. Restored all phase attrs and `_request` from snapshot so retries resume from their last successful phase.
+- **Brand rename to "Autonomous AI Agency."** Replaced all user-visible occurrences of the legacy names *Agency Core*, *LLM Relay*, and *Local LLM Server* across the frontend (login screen, dashboard, control plane, onboarding, activation gate, setup wizard, nav), marketing/landing HTML (`index.html`, `docs/index.html`, GitHub Pages pages), admin templates, the web UI, README, launcher/daemon/tunnel CLI banners, and `version.py`/`version.js` brand constants. GitHub repo URLs, deployment URLs, env-var names, logger names, and package names were intentionally left unchanged. Updated `scripts/bump_version.py` and `tests/test_version_consistency.py` to track the new brand label.
+- **Login screen refresh.** New headline ("Autonomous AI Agency"), subheadline ("Your AI-powered workforce — plan, execute, and deliver across any codebase or workflow."), three value bullets (multi-agent execution with provider failover; technology intelligence across 1,000+ platforms; connect any repo, any team, any tool), and a "Sign in" CTA. Desktop split-panel continues to stack into a single centered column on mobile.
 
 ### Fixed
 - **Checkpoint restore now preserves phase outputs and _request.** On retry/restart, `restore_in_flight` only restored status/heartbeat — all phase outputs (classify, plan, execution, etc.) were None, so skip detection never fired and every resume re-ran all phases from scratch. Restored all phase attrs and `_request` from snapshot so retries resume from their last successful phase.

--- a/docs/index.html
+++ b/docs/index.html
@@ -3,14 +3,14 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Autonomous AI Agency v5 - Autonomous AI Platform | StrikerSam</title>
+    <title>Autonomous AI Agency v5 - Your AI-powered workforce | StrikerSam</title>
 
     <!-- Schema.org structured data for documentation -->
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",
       "@type": "TechArticle",
-      "headline": "Autonomous AI Agency v5 — Autonomous AI Agency Platform",
+      "headline": "Autonomous AI Agency v5 — Your AI-powered workforce",
       "description": "Documentation for the self-hosted, OpenAI-compatible AI proxy and multi-agent platform with Company Graph architecture and 11-phase workflow orchestration.",
       "url": "https://local-llm-server.strikersam.workers.dev",
       "author": {

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -4,18 +4,18 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <meta name="theme-color" content="#0F0F13" />
-  <meta name="description" content="Agency Core v5.0 — Autonomous AI Platform. Self-hosted, CEO-coordinated agents, internet-connected trend intelligence, and 8 runtimes on your own hardware." />
-  <title>Agency Core v5.0 — Autonomous AI Platform</title>
+  <meta name="description" content="Autonomous AI Agency v5.0 — Your AI-powered workforce. Self-hosted, CEO-coordinated agents, internet-connected trend intelligence, and 8 runtimes on your own hardware." />
+  <title>Autonomous AI Agency v5.0 — Your AI-powered workforce</title>
 
   <!-- Schema.org structured data for the SPA dashboard -->
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
     "@type": "WebApplication",
-    "name": "Agency Core v5 Dashboard",
+    "name": "Autonomous AI Agency v5 Dashboard",
     "url": "https://local-llm-server.strikersam.workers.dev",
     "applicationCategory": "BusinessApplication",
-    "description": "Admin dashboard for the Agency Core v5 autonomous AI platform — manage companies, specialists, tasks, agents, and monitor system health.",
+    "description": "Admin dashboard for the Autonomous AI Agency v5 platform — manage companies, specialists, tasks, agents, and monitor system health.",
     "browserRequirements": "Requires JavaScript",
     "author": {
       "@type": "Person",

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -64,12 +64,12 @@ function AppRoutes() {
       {/* Pre-auth setup wizard — configure backend URL before logging in */}
       <Route path="/bootstrap" element={<SetupWizardPage />} />
 
-      {/* V5.0 Agency Core — primary authenticated UI */}
+      {/* V5.0 Autonomous AI Agency — primary authenticated UI */}
       <Route
         path="/v5/*"
         element={
           <ProtectedRoute>
-            <Suspense fallback={<LoadingScreen message="Loading Agency Core" />}>
+            <Suspense fallback={<LoadingScreen message="Loading the Agency" />}>
               <V5App />
             </Suspense>
           </ProtectedRoute>
@@ -88,7 +88,7 @@ function AppRoutes() {
         }
       />
 
-      {/* Default: redirect authenticated users to Agency Core v5 */}
+      {/* Default: redirect authenticated users to the Agency v5 */}
       <Route
         path="/*"
         element={user ? <Navigate to="/v5" replace /> : <Navigate to="/login" replace />}

--- a/frontend/src/__tests__/controlPlanePage.test.js
+++ b/frontend/src/__tests__/controlPlanePage.test.js
@@ -188,7 +188,7 @@ test('renders company-style dashboard summary with NVIDIA priority surfaced', as
   renderPage();
 
   expect(await screen.findByRole('heading', { name: 'Dashboard' })).toBeInTheDocument();
-  expect(screen.getByText(/Agency Core v5\.0/i)).toBeInTheDocument();
+  expect(screen.getByText(/Autonomous AI Agency command center/i)).toBeInTheDocument();
 
   await waitFor(() => expect(getUsage).toHaveBeenCalled());
   expect(screen.getByText('$128.40')).toBeInTheDocument();

--- a/frontend/src/components/HeroSection.js
+++ b/frontend/src/components/HeroSection.js
@@ -3,9 +3,9 @@ export default function HeroSection() {
     <section className="auth-shell__hero flex min-h-[592px] w-full items-start justify-start px-4">
       <div className="auth-shell__brand flex items-center gap-2 mb-6">
         <img src="/logos/logo-only.svg" alt="" width="24" height="24" aria-hidden="true" />
-        <span className="auth-shell__brand-name text-xl font-semibold">Agency Core v5.0</span>
+        <span className="auth-shell__brand-name text-xl font-semibold">Autonomous AI Agency</span>
       </div>
-      <h1 className="text-3xl font-bold mb-4">Welcome to Agency Core v5.0.</h1>
+      <h1 className="text-3xl font-bold mb-4">Welcome to the Autonomous AI Agency.</h1>
       <p className="text-lg text-muted-foreground">
         Coordinate agents, tasks, chats, and execution environments from one operator workspace built for teams shipping real work with AI.
       </p>

--- a/frontend/src/components/PanelSection.js
+++ b/frontend/src/components/PanelSection.js
@@ -5,7 +5,7 @@ export default function PanelSection() {
         <div className="cl-card w-full min-w-0 p-6">
           <div className="cl-header mb-6">
             <div className="cl-internal-x0fvpz">
-              <h1 className="cl-headerTitle text-2xl font-bold">Sign in to Agency Core v5.0</h1>
+              <h1 className="cl-headerTitle text-2xl font-bold">Sign in to the Autonomous AI Agency</h1>
               <p className="cl-headerSubtitle text-muted-foreground mt-2">
                 Welcome back! Please sign in to continue
               </p>
@@ -87,7 +87,7 @@ export default function PanelSection() {
             <div className="cl-footer mt-6 flex flex-col items-center">
               <div className="cl-footerAction cl-footerAction__signIn flex items-center gap-2 text-sm text-muted-foreground">
                 <span className="cl-footerActionText">Don't have an account?</span>
-                <a className="cl-footerActionLink underline" href="https://strikersam.github.io/local-llm-server/">Open LLM Relay</a>
+                <a className="cl-footerActionLink underline" href="https://strikersam.github.io/local-llm-server/">Open the Agency</a>
               </div>
               <div className="cl-internal-1dauvpw flex flex-col items-center mt-4">
                 <div className="cl-internal-dt53uo flex items-center gap-2">

--- a/frontend/src/pages/AuthCallback.js
+++ b/frontend/src/pages/AuthCallback.js
@@ -1,5 +1,5 @@
 /**
- * AuthCallback.js — Social login callback handler for LLM Relay v4.0
+ * AuthCallback.js — Social login callback handler for the Autonomous AI Agency
  *
  * Handles two OAuth flows:
  *   1. Legacy flow: /auth/callback?access_token=...&refresh_token=...

--- a/frontend/src/pages/ControlPlanePage.js
+++ b/frontend/src/pages/ControlPlanePage.js
@@ -516,7 +516,7 @@ export default function ControlPlanePage() {
 
               <h1 className="mt-4 text-3xl font-semibold tracking-[-0.04em] text-white sm:text-4xl">Dashboard</h1>
               <p className="mt-3 max-w-2xl text-sm leading-relaxed sm:text-[15px]" style={{ color: C.secondary }}>
-                Agency Core v5.0 autonomous agency command center. Monitor agent work, keep NVIDIA-first routing visible, and move between tasks, chats, and infrastructure without leaving the root dashboard.
+                Autonomous AI Agency command center. Monitor agent work, keep NVIDIA-first routing visible, and move between tasks, chats, and infrastructure without leaving the root dashboard.
               </p>
 
               <div className="mt-4 flex flex-wrap items-center gap-2">
@@ -799,3 +799,4 @@ export default function ControlPlanePage() {
     </div>
   );
 }
+              

--- a/frontend/src/pages/DashboardHome.js
+++ b/frontend/src/pages/DashboardHome.js
@@ -168,7 +168,7 @@ export default function DashboardHome() {
         <div>
           <h1 className="text-[1.5rem] font-bold tracking-tight text-[var(--text-primary)]"
             style={{ fontFamily: 'var(--font-main)' }}>Dashboard</h1>
-          <p className="text-[0.9rem] text-[var(--text-tertiary)]">Overview of your LLM Relay system</p>
+          <p className="text-[0.9rem] text-[var(--text-tertiary)]">Overview of your Autonomous AI Agency</p>
         </div>
         <div className="flex items-center gap-3">
           <HealthBadge label="API" ok={Boolean(stats?.llm_provider)} />

--- a/frontend/src/pages/DashboardLayout.js
+++ b/frontend/src/pages/DashboardLayout.js
@@ -28,7 +28,7 @@ import KnowledgePage from './KnowledgePage';
 import LogsPage from './LogsPage';
 
 /**
- * navSections — Agency Core v5.0 navigation matching the Control Plane design system.
+ * navSections — Autonomous AI Agency navigation matching the Control Plane design system.
  *
  * Sections mirror the design bundle layout:
  *  WORKSPACE   — Control Plane, Tasks
@@ -142,8 +142,8 @@ function SidebarContent({ user, onLogout, onClose }) {
           </div>
           <div>
             <div className="text-[14px] font-bold text-white tracking-tight"
-              style={{ fontFamily: 'var(--font-main)' }}>Agency Core v5.0</div>
-            <div className="text-[10px] text-[var(--text-muted)] font-mono leading-none mt-0.5">Autonomous AI Agency</div>
+              style={{ fontFamily: 'var(--font-main)' }}>Autonomous AI Agency</div>
+            <div className="text-[10px] text-[var(--text-muted)] font-mono leading-none mt-0.5">Control Plane</div>
           </div>
         </div>
       </div>
@@ -247,7 +247,7 @@ export default function DashboardLayout() {
             <Cpu size={14} className="text-white" />
           </div>
           <div className="min-w-0">
-            <div className="text-[0.95rem] font-extrabold tracking-[-0.04em] text-white">Agency Core v5.0</div>
+            <div className="text-[0.95rem] font-extrabold tracking-[-0.04em] text-white">Autonomous AI Agency</div>
             <div className="text-[0.65rem] font-mono uppercase tracking-[0.16em] text-[var(--text-muted)] truncate">
               {user?.name || user?.email || 'Control plane'}
             </div>

--- a/frontend/src/pages/LoginPage.js
+++ b/frontend/src/pages/LoginPage.js
@@ -84,34 +84,34 @@ export default function LoginPage() {
             </div>
             <div>
               <div className="text-[1.35rem] font-extrabold text-[var(--text-primary)] tracking-[-0.04em]"
-                style={{ fontFamily: 'var(--font-main)' }}>Agency Core v5.0</div>
-              <div className="text-[0.8rem] text-[var(--text-muted)] font-mono leading-none mt-1 tracking-[0.16em] uppercase">Autonomous AI Agency</div>
+                style={{ fontFamily: 'var(--font-main)' }}>Autonomous AI Agency</div>
+              <div className="text-[0.8rem] text-[var(--text-muted)] font-mono leading-none mt-1 tracking-[0.16em] uppercase">Your AI-powered workforce</div>
             </div>
           </div>
 
           {/* Features */}
           <div className="app-panel-elevated p-8 space-y-5">
-            <div className="app-kicker">Private by default</div>
+            <div className="app-kicker">Your AI-powered workforce</div>
             <div className="space-y-4">
             <div className="flex items-center gap-3">
               <Bot size={16} className="flex-shrink-0 text-[var(--accent)]" />
               <div className="flex-1">
-                <h3 className="text-[1rem] font-semibold text-[var(--text-primary)] mb-1">CEO-coordinated agency</h3>
-                <p className="text-[0.92rem] text-[var(--text-tertiary)]">LLM-powered CEO agent assesses the codebase every 15 min and dispatches Dev, Security, Reviewer, and Scout specialists across 8 runtimes.</p>
+                <h3 className="text-[1rem] font-semibold text-[var(--text-primary)] mb-1">Multi-agent task execution with provider failover</h3>
+                <p className="text-[0.92rem] text-[var(--text-tertiary)]">A CEO agent plans, dispatches specialists, and verifies the work — automatically routing across providers so a single outage never stops delivery.</p>
               </div>
             </div>
             <div className="flex items-center gap-3">
               <CheckCircle size={16} className="flex-shrink-0 text-[var(--success)]" />
               <div className="flex-1">
-                <h3 className="text-[1rem] font-semibold text-[var(--text-primary)] mb-1">Self-healing & trend watching</h3>
-                <p className="text-[0.92rem] text-[var(--text-tertiary)]">Backend errors auto-create fix tasks. AI trend watcher fetches arXiv, HuggingFace, Ollama releases, and GitHub weekly.</p>
+                <h3 className="text-[1rem] font-semibold text-[var(--text-primary)] mb-1">Technology intelligence across 1,000+ platforms</h3>
+                <p className="text-[0.92rem] text-[var(--text-tertiary)]">Detects your stack, frameworks, and tooling, then provisions specialists that understand your industry out of the box.</p>
               </div>
             </div>
             <div className="flex items-center gap-3">
               <Database size={16} className="flex-shrink-0 text-[var(--role-power-user)]" />
               <div className="flex-1">
-                <h3 className="text-[1rem] font-semibold text-[var(--text-primary)] mb-1">Local-first, private by default</h3>
-                <p className="text-[0.92rem] text-[var(--text-tertiary)]">Route to Ollama, Hermes, Goose, Claude Code, or Aider — all on your own hardware with no data leaving your network.</p>
+                <h3 className="text-[1rem] font-semibold text-[var(--text-primary)] mb-1">Connect any repo, any team, any tool</h3>
+                <p className="text-[0.92rem] text-[var(--text-tertiary)]">Point the Agency at your codebases and workflows — all on your own hardware, with no data leaving your network.</p>
               </div>
             </div>
             </div>
@@ -135,17 +135,17 @@ export default function LoginPage() {
               <Lock size={18} className="text-white" />
             </div>
             <div>
-              <div className="text-[1.1rem] font-extrabold tracking-[-0.04em] text-[var(--text-primary)]">Agency Core v5.0</div>
-              <div className="text-[0.72rem] font-mono uppercase tracking-[0.16em] text-[var(--text-muted)]">Autonomous AI Agency</div>
+              <div className="text-[1.1rem] font-extrabold tracking-[-0.04em] text-[var(--text-primary)]">Autonomous AI Agency</div>
+              <div className="text-[0.72rem] font-mono uppercase tracking-[0.16em] text-[var(--text-muted)]">Your AI-powered workforce</div>
             </div>
           </div>
 
           <div className="app-panel-elevated p-5 sm:p-7 space-y-6">
             <div className="space-y-3">
               <div className="app-kicker">Sign in</div>
-              <h1 className="app-title text-[var(--text-primary)]">Sign in to Control Plane</h1>
+              <h1 className="app-title text-[var(--text-primary)]">Autonomous AI Agency</h1>
               <p className="app-subtitle">
-                Autonomous AI agency that continuously improves your local LLM stack — CEO agent, 8 runtimes, self-healing, and trend intelligence.
+                Your AI-powered workforce — plan, execute, and deliver across any codebase or workflow.
               </p>
             </div>
 

--- a/frontend/src/pages/ObservabilityPage.js
+++ b/frontend/src/pages/ObservabilityPage.js
@@ -1,5 +1,5 @@
 /**
- * ObservabilityPage.js — Cost Insights & Langfuse Integration (LLM Relay v4.0)
+ * ObservabilityPage.js — Cost Insights & Langfuse Integration (Autonomous AI Agency)
  *
  * Shows:
  *   - Total savings vs cloud APIs (this month / week / day)

--- a/frontend/src/pages/SetupWizardPage.js
+++ b/frontend/src/pages/SetupWizardPage.js
@@ -1,5 +1,5 @@
 /**
- * SetupWizardPage.js — Agency Core v5.0 first-run setup wizard (5 steps)
+ * SetupWizardPage.js — Autonomous AI Agency first-run setup wizard (5 steps)
  *
  * Steps:
  *   1 Provider Setup      — select Ollama / cloud providers
@@ -680,7 +680,7 @@ export default function SetupWizardPage({ onComplete }) {
             </div>
           ))}
         </nav>
-        <div className="text-[var(--text-muted)] text-xs mt-6 font-mono uppercase tracking-[0.16em]">Agency Core v5.0 · AI Control Plane</div>
+        <div className="text-[var(--text-muted)] text-xs mt-6 font-mono uppercase tracking-[0.16em]">Autonomous AI Agency · AI Control Plane</div>
       </div>
 
       {/* Main */}
@@ -694,12 +694,12 @@ export default function SetupWizardPage({ onComplete }) {
                 <span>{backendConnected ? '🟢' : '🟡'}</span>
                 {backendConnected
                   ? `Connected to ${backendUrl}`
-                  : 'Connect to your local LLM Server'}
+                  : 'Connect to your Autonomous AI Agency backend'}
               </div>
               {!backendConnected && (
                 <>
                   <p className="text-xs text-gray-600 mb-3">
-                    Enter the URL of your running local-llm-server. Use{' '}
+                    Enter the URL of your running Autonomous AI Agency backend. Use{' '}
                     <code className="bg-white px-1 rounded">http://localhost:8000</code> if
                     running locally, or your ngrok/Cloudflare tunnel URL for remote access.
                   </p>
@@ -846,9 +846,9 @@ export default function SetupWizardPage({ onComplete }) {
                           className="w-full mt-1 border border-gray-300 rounded-lg px-3 py-2 text-base text-gray-900 focus:border-indigo-500 focus:ring-2 focus:ring-indigo-200 focus:outline-none"
                           value={repoPath}
                           onChange={e => setRepoPath(e.target.value)}
-                          placeholder="/path/to/local-llm-server"
+                          placeholder="/path/to/autonomous-ai-agency"
                         />
-                        <p className="text-xs text-gray-400 mt-0.5">Folder where local-llm-server is cloned</p>
+                        <p className="text-xs text-gray-400 mt-0.5">Folder where the Autonomous AI Agency is cloned</p>
                       </div>
                       <div>
                         <label className="text-sm font-medium text-gray-700">Models Folder</label>
@@ -1124,7 +1124,7 @@ export default function SetupWizardPage({ onComplete }) {
                 <p className="text-gray-500 text-sm mb-5">Enable the coding runtimes you have installed on this machine.</p>
                 <div className="space-y-3">
                   {[
-                    { key: 'hermes',   label: 'Hermes',   desc: 'Local LLM relay (built-in) — First Class', val: enableHermes,   set: setEnableHermes,   badge: 'Recommended' },
+                    { key: 'hermes',   label: 'Hermes',   desc: 'Local model relay (built-in) — First Class', val: enableHermes,   set: setEnableHermes,   badge: 'Recommended' },
                     { key: 'opencode', label: 'OpenCode', desc: 'VS Code-style agent runtime',              val: enableOpenCode, set: setEnableOpenCode },
                     { key: 'task-harness', label: 'Task Harness', desc: 'Compatible external harness for long-running, multi-file agent work', val: enableTaskHarness, set: setEnableTaskHarness },
                     { key: 'aider',    label: 'Aider',    desc: 'Git-native coding agent',                  val: enableAider,    set: setEnableAider },

--- a/frontend/src/utils/serviceDetection.js
+++ b/frontend/src/utils/serviceDetection.js
@@ -88,7 +88,7 @@ export async function detectBackend(backendUrl) {
   if (!url) {
     return {
       id: 'backend',
-      name: 'LLM Relay Backend',
+      name: 'Autonomous AI Agency Backend',
       tier: 'remote',
       available: false,
       reason: 'No backend URL configured. Open Setup Wizard to connect.',
@@ -98,7 +98,7 @@ export async function detectBackend(backendUrl) {
   const r = await probeFetch(`${url}/api/health`);
   return {
     id: 'backend',
-    name: 'LLM Relay Backend',
+    name: 'Autonomous AI Agency Backend',
     tier: 'remote',
     available: r.ok,
     reason: r.ok ? '' : `Backend not reachable at ${url}`,

--- a/frontend/src/v5/AppShell.jsx
+++ b/frontend/src/v5/AppShell.jsx
@@ -3,7 +3,7 @@ import { APP_NAME, APP_LABEL } from '../version';
 import { useAuth } from '../AuthContext';
 
 
-// nav.jsx — Agency Core navigation (clean, all screens)
+// nav.jsx — Autonomous AI Agency navigation (clean, all screens)
 
 const NAV_ITEMS = [
   { id:'chat',       label:'Chat',       icon:'MessageSquare',  desc:'Unified assistant',      section:'WORKSPACE' },

--- a/frontend/src/v5/screens/ActivationGate.jsx
+++ b/frontend/src/v5/screens/ActivationGate.jsx
@@ -103,9 +103,9 @@ export default function ActivationGate({ children }) {
 
   const iid = status.instance_id || 'unknown';
   const contactEmail = status.register_email || 'strikersam@gmail.com';
-  const mailtoSubject = encodeURIComponent('LLM Relay Activation Request');
+  const mailtoSubject = encodeURIComponent('Autonomous AI Agency Activation Request');
   const mailtoBody = encodeURIComponent(
-    `Hello,\n\nI'd like to activate my LLM Relay instance.\n\nInstance ID: ${iid}\n\nPlease send me an activation code.\n\nThank you.`
+    `Hello,\n\nI'd like to activate my Autonomous AI Agency instance.\n\nInstance ID: ${iid}\n\nPlease send me an activation code.\n\nThank you.`
   );
 
   return (
@@ -114,12 +114,12 @@ export default function ActivationGate({ children }) {
         {/* Header */}
         <div style={{ textAlign:'center', marginBottom:32 }}>
           <div style={{ fontSize:11, fontFamily:'var(--font-mono, monospace)', color:'rgba(93,162,255,0.7)', letterSpacing:'0.18em', textTransform:'uppercase', marginBottom:10 }}>
-            LLM Relay — Instance Activation
+            Autonomous AI Agency — Instance Activation
           </div>
           <div style={{ width:52, height:52, borderRadius:16, background:'rgba(93,162,255,0.10)', border:'1px solid rgba(93,162,255,0.25)', display:'flex', alignItems:'center', justifyContent:'center', fontSize:24, margin:'0 auto 14px' }}>🔑</div>
           <h1 style={{ fontSize:26, fontWeight:800, color:'#fff', letterSpacing:'-0.04em', margin:'0 0 8px' }}>Activate this instance</h1>
           <p style={{ fontSize:14, color:'rgba(255,255,255,0.5)', lineHeight:1.6, margin:0, maxWidth:400, marginLeft:'auto', marginRight:'auto' }}>
-            This LLM Relay is not yet activated. Follow the three steps below to unlock onboarding and start using the platform.
+            This Autonomous AI Agency instance is not yet activated. Follow the three steps below to unlock onboarding and start using the platform.
           </p>
         </div>
 

--- a/frontend/src/v5/screens/LoginScreen.jsx
+++ b/frontend/src/v5/screens/LoginScreen.jsx
@@ -48,7 +48,7 @@ function HeroPanel({ compact }) {
         color: '#9ecbff', fontFamily: 'var(--font-mono)',
       }}>
         <span style={{ width: 7, height: 7, borderRadius: 99, background: '#5da2ff', boxShadow: '0 0 10px #5da2ff' }} />
-        Agency Core v5 · Self-hosted · Private
+        Autonomous AI Agency · Self-hosted · Private
       </div>
 
       <h1 style={{
@@ -164,7 +164,7 @@ function LoginScreen() {
                 <path d="M15 2v2M15 20v2M9 2v2M9 20v2M2 15h2M2 9h2M20 15h2M20 9h2"/>
               </svg>
             </div>
-            <div style={{ fontSize:20, fontWeight:800, color:'#fff', letterSpacing:'-0.02em' }}>Agency Core</div>
+            <div style={{ fontSize:20, fontWeight:800, color:'#fff', letterSpacing:'-0.02em' }}>Autonomous AI Agency</div>
             <div style={{ fontSize:12, color:'rgba(255,255,255,0.4)', marginTop:3, fontFamily:'var(--font-mono)' }}>Sign in to your agency</div>
           </div>
 

--- a/frontend/src/v5/screens/OnboardingScreen.jsx
+++ b/frontend/src/v5/screens/OnboardingScreen.jsx
@@ -109,9 +109,9 @@ function NonAdminGate() {
 
   const handleSend = () => {
     if (!query.trim()) return;
-    const subject = encodeURIComponent(`LLM Relay V5.0 — Company Setup Request${name?' from '+name:''}`);
+    const subject = encodeURIComponent(`Autonomous AI Agency — Company Setup Request${name?' from '+name:''}`);
     const body    = encodeURIComponent(
-      `Hello Sam,\n\nI'd like to set up a company on LLM Relay V5.0.\n\nName: ${name||'(not provided)'}\nEmail: ${email||'(not provided)'}\n\nWhat I need:\n${query}\n\nPlease help me get started.`
+      `Hello Sam,\n\nI'd like to set up a company on the Autonomous AI Agency.\n\nName: ${name||'(not provided)'}\nEmail: ${email||'(not provided)'}\n\nWhat I need:\n${query}\n\nPlease help me get started.`
     );
     window.open(`mailto:strikersam@gmail.com?subject=${subject}&body=${body}`, '_blank');
     setSent(true);
@@ -161,7 +161,7 @@ function NonAdminGate() {
         <button onClick={handleSend} disabled={!query.trim()} style={{ display:'inline-flex', alignItems:'center', gap:8, padding:'13px 28px', borderRadius:999, background:'linear-gradient(135deg,#6CB0FF,#4F93FF)', color:'#06111f', fontSize:14, fontWeight:800, border:'none', cursor:'pointer', boxShadow:'0 8px 24px rgba(93,162,255,0.25)', opacity:!query.trim()?0.5:1, transition:'all 0.2s' }}>
           ✉️ Send request to admin
         </button>
-        <div style={{ fontSize:11, fontFamily:'var(--font-mono)', color:'var(--text-muted)' }}>Opens your email client with a pre-filled message to the LLM Relay admin.</div>
+        <div style={{ fontSize:11, fontFamily:'var(--font-mono)', color:'var(--text-muted)' }}>Opens your email client with a pre-filled message to the Autonomous AI Agency admin.</div>
       </div>
     </div>
   );
@@ -309,7 +309,7 @@ function DiscoveryStep({ onNext, onCompanyCreated }) {
     <div style={{ animation:'fadeSlideUp 0.35s ease-out' }}>
       <h2 style={{ fontSize:22, fontWeight:800, color:'#fff', letterSpacing:'-0.04em', marginBottom:6 }}>What company are you setting up?</h2>
       <p style={{ fontSize:14, color:'var(--text-tertiary)', lineHeight:1.6, marginBottom:22, maxWidth:440 }}>
-        Enter your production URL. LLM Relay V5.0 will inspect the site, infer your stack, and provision specialists that understand your industry automatically.
+        Enter your production URL. The Autonomous AI Agency will inspect the site, infer your stack, and provision specialists that understand your industry automatically.
       </p>
       <div style={{ marginBottom:14 }}>
         <label style={{ display:'block', fontSize:12, fontWeight:600, color:'var(--text-secondary)', marginBottom:7 }}>Production website URL *</label>
@@ -729,14 +729,14 @@ function OnboardingScreen({ onComplete, isAdmin }) {
 
   if (!isAdmin) return (
     <div style={{ padding:'24px 16px 48px', maxWidth:580, margin:'0 auto' }}>
-      <div style={{ fontSize:11, fontFamily:'var(--font-mono)', color:'var(--accent)', letterSpacing:'0.18em', textTransform:'uppercase', marginBottom:8 }}>Company Onboarding · LLM Relay V5.0</div>
+      <div style={{ fontSize:11, fontFamily:'var(--font-mono)', color:'var(--accent)', letterSpacing:'0.18em', textTransform:'uppercase', marginBottom:8 }}>Company Onboarding · Autonomous AI Agency</div>
       <NonAdminGate/>
     </div>
   );
 
   if (checkingProgress) return (
     <div style={{ padding:'24px 16px 48px', maxWidth:640, margin:'0 auto', textAlign:'center' }}>
-      <div style={{ fontSize:11, fontFamily:'var(--font-mono)', color:'var(--accent)', letterSpacing:'0.18em', textTransform:'uppercase', marginBottom:8 }}>Company Onboarding · LLM Relay V5.0</div>
+      <div style={{ fontSize:11, fontFamily:'var(--font-mono)', color:'var(--accent)', letterSpacing:'0.18em', textTransform:'uppercase', marginBottom:8 }}>Company Onboarding · Autonomous AI Agency</div>
       <div style={{ padding:'40px 0', color:'var(--text-muted)', fontSize:14 }}>Checking onboarding status...</div>
     </div>
   );
@@ -784,7 +784,7 @@ function OnboardingScreen({ onComplete, isAdmin }) {
 
   return (
     <div style={{ padding:'24px 16px 48px', maxWidth:640, margin:'0 auto' }}>
-      <div style={{ fontSize:11, fontFamily:'var(--font-mono)', color:'var(--accent)', letterSpacing:'0.18em', textTransform:'uppercase', marginBottom:8 }}>Company Onboarding · LLM Relay V5.0</div>
+      <div style={{ fontSize:11, fontFamily:'var(--font-mono)', color:'var(--accent)', letterSpacing:'0.18em', textTransform:'uppercase', marginBottom:8 }}>Company Onboarding · Autonomous AI Agency</div>
       <StepIndicator current={step} onStepClick={(s) => {
         // When jumping back to URL step via breadcrumb, reset company state
         // so the old company doesn't linger and cause duplicate creation.

--- a/frontend/src/version.js
+++ b/frontend/src/version.js
@@ -5,8 +5,8 @@
 // version.py and package.json via `python scripts/bump_version.py X.Y.Z`
 // (tests/test_version_consistency.py guards against drift).
 export const APP_VERSION = '5.0.0';
-export const APP_NAME = 'Agency Core';
-export const APP_TAGLINE = 'Autonomous AI Platform';
+export const APP_NAME = 'Autonomous AI Agency';
+export const APP_TAGLINE = 'Your AI-powered workforce';
 
-// Human-facing label, e.g. "Agency Core v5.0".
+// Human-facing label, e.g. "Autonomous AI Agency v5.0".
 export const APP_LABEL = `${APP_NAME} v${APP_VERSION.split('.').slice(0, 2).join('.')}`;

--- a/github-pages-index.html
+++ b/github-pages-index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Autonomous AI Agency v5 — Autonomous AI Agency Platform</title>
+    <title>Autonomous AI Agency v5 — Your AI-powered workforce</title>
     <meta name="description" content="Self-hosted autonomous AI agency. Onboard any company URL, auto-provision specialist agents, and let them work through a typed workflow engine with HITL approvals.">
     <style>
         * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -413,4 +413,9 @@
 
     <!-- ══════════════════════ FOOTER ════════════════════════ -->
     <footer>
-        <p>Autonomous AI Agency v5 · <a href="https://github.com/strikersam/local-llm-server
+        <p>Autonomous AI Agency v5 · <a href="https://github.com/strikersam/local-llm-server">GitHub</a> · <a href="https://github.com/strikersam/local-llm-server/blob/master/docs/README.md">Documentation</a> · <a href="https://github.com/strikersam/local-llm-server/blob/master/docs/changelog.md">Changelog</a></p>
+        <p style="margin-top: 8px;">Self-hosted autonomous AI agency for any onboarded company URL.</p>
+    </footer>
+
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Autonomous AI Agency v5 - Autonomous AI Agency Platform | StrikerSam</title>
+    <title>Autonomous AI Agency v5 - Your AI-powered workforce | StrikerSam</title>
 
     <!-- Schema.org structured data for the platform -->
     <script type="application/ld+json">

--- a/models/README.md
+++ b/models/README.md
@@ -1,1 +1,1 @@
-# Agency Core v5 — Company Graph
+# Autonomous AI Agency — Company Graph

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -1,5 +1,5 @@
 """
-Company Graph Models for Autonomous AI Agency v5
+Company Graph Models for the Autonomous AI Agency
 """
 from .company_graph import (
     # Enums

--- a/models/company_graph.py
+++ b/models/company_graph.py
@@ -1,5 +1,5 @@
 """
-Company Graph - Canonical Core Model for Autonomous AI Agency v5
+Company Graph - Canonical Core Model for the Autonomous AI Agency
 
 This module defines the typed, serializable models for the Company Graph,
 which serves as the single source of truth for company context, systems,
@@ -49,7 +49,7 @@ SpecialistFamily = Literal[
     "operations", "agile", "portfolio", "security", "devops",
     "data", "ml", "frontend", "backend", "fullstack", "mobile",
     "cloud", "infra", "architecture", "product", "design", "ux",
-    # Business / domain specialists (Autonomous AI Agency v5 — full domain coverage)
+    # Business / domain specialists (Autonomous AI Agency — full domain coverage)
     "seo", "content", "marketing", "merchandising", "pim", "oms",
     "dam", "crm", "support", "trading", "research", "platform"
 ]
@@ -1189,7 +1189,7 @@ class Company(BaseModel):
 
 class CompanyGraph(BaseModel):
     """
-    The complete Company Graph - canonical core model for Autonomous AI Agency v5.
+    The complete Company Graph - canonical core model for the Autonomous AI Agency.
     
     This model represents the entire knowledge graph for a company, including
     all websites, repositories, systems, specialists, workflows, and knowledge.

--- a/remote-admin/setup-wizard.html
+++ b/remote-admin/setup-wizard.html
@@ -395,8 +395,8 @@
 
                 <div class="form-group">
                     <label for="repoPath">📁 Repository Folder</label>
-                    <input type="text" id="repoPath" placeholder="/Users/username/Desktop/local-llm-server">
-                    <div class="path-hint">Path to your local-llm-server directory</div>
+                    <input type="text" id="repoPath" placeholder="/Users/username/Desktop/autonomous-ai-agency">
+                    <div class="path-hint">Path to your Autonomous AI Agency directory</div>
                 </div>
 
                 <div class="form-group">
@@ -725,4 +725,27 @@
                 if (status.public_url) {
                     document.getElementById("finalPublicUrl").textContent = status.public_url;
                 }
-            } catc
+            } catch (e) {
+                console.error("Error:", e);
+            }
+        }
+
+        // Initialize
+        checkDaemon();
+        setInterval(checkDaemon, 2000);
+
+        // Update services when step 3 is shown
+        const observer = new MutationObserver(() => {
+            if (document.getElementById("step3").classList.contains("active")) {
+                updateServices();
+            }
+        });
+
+        observer.observe(document.getElementById("step3"), { attributes: true });
+
+        // Set default paths
+        document.getElementById("repoPath").value = "/path/to/autonomous-ai-agency";
+        document.getElementById("modelsPath").value = "/path/to/local-models";
+    </script>
+</body>
+</html>

--- a/scripts/doctor.py
+++ b/scripts/doctor.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Agency Core doctor — fast environment & CI-parity diagnostics.
+"""Autonomous AI Agency doctor — fast environment & CI-parity diagnostics.
 
 Answers the operator questions "why didn't this run?" and "why did CI fail but
 local pass?" by checking the things that actually differ between a laptop and the

--- a/scripts/gen_v4_screenshots.py
+++ b/scripts/gen_v4_screenshots.py
@@ -1402,7 +1402,7 @@ body{{min-height:100vh;display:flex;flex-direction:column;align-items:center;jus
 </head><body>
 <div class="wizard-wrap">
   <div style="text-align:center;margin-bottom:28px;">
-    <div style="font-size:22px;font-weight:800;color:var(--text-primary);margin-bottom:4px;">Set up Autonomous AI Agency</div>
+    <div style="font-size:22px;font-weight:800;color:var(--text-primary);margin-bottom:4px;">Set up the Autonomous AI Agency</div>
     <div style="font-size:13px;color:var(--text-muted);">Step 1 of 5 · Choose your AI providers</div>
   </div>
   <!-- Steps -->

--- a/scripts/setup-autostart.sh
+++ b/scripts/setup-autostart.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# setup-autostart.sh — Install the LLM Relay systemd service so the entire
+# setup-autostart.sh — Install the Autonomous AI Agency systemd service so the entire
 # docker-compose stack (proxy, MCP server, runtimes, Ollama, MongoDB) starts
 # automatically on boot with no manual intervention.
 #

--- a/setup_local_models.py
+++ b/setup_local_models.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-Setup wizard for local-llm-server.
+Setup wizard for the Autonomous AI Agency.
 Scans local models, configures services, and starts the proxy.
 """
 

--- a/start_tunnel.py
+++ b/start_tunnel.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-Start an ngrok tunnel for local-llm-server with public access.
+Start an ngrok tunnel for the Autonomous AI Agency with public access.
 Requires pyngrok to be installed: pip install pyngrok
 """
 

--- a/tests/test_version_consistency.py
+++ b/tests/test_version_consistency.py
@@ -35,6 +35,7 @@ def test_readme_badge_matches() -> None:
 def test_index_html_has_no_stale_version() -> None:
     text = (_ROOT / "frontend/public/index.html").read_text()
     minor = ".".join(__version__.split(".")[:2])
-    assert f"Agency Core v{minor}" in text
+    assert f"Autonomous AI Agency v{minor}" in text
     # The old brand/version must be gone.
     assert "LLM Relay v4.1" not in text
+    assert "Agency Core v" not in text


### PR DESCRIPTION
Renames LLM Relay / Agency Core / Local LLM Server to **Autonomous AI Agency** throughout all user-visible strings (frontend screens, marketing/landing HTML, admin templates, web UI, README, CLI banners, brand constants). Updates login copy with high-value messaging (headline, subheadline, 3 value bullets, Sign in CTA).

Deliberately **not** changed: GitHub repo URLs, deployment URLs, env-var names, logger names, package names.

Version-consistency test + bump_version.py updated to track the new brand label. `version_consistency` tests pass; all touched Python compiles.

Closes brand inconsistency.