### PR TITLE
fix: SSL cert analysis silent no-op + proxy CORS credentials hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- **SSL/TLS certificate analysis in the scanner returned nothing** (pre-mortem follow-up): `services/scanner.py::_analyze_ssl_cert` disabled verification (`CERT_NONE`) before calling `getpeercert()`, but CPython only populates the parsed issuer/SAN dict when the cert is verified — so SSL-based detection silently produced zero systems on every scan. Now does a verified handshake first (common case) and falls back to decoding the raw DER cert via `cryptography` (`_decode_der_cert`) for unverified certs (expired / self-signed / hostname-mismatch). Verified live: github.com→Sectigo, shopify.com→Shopify.
+
+### Security
+- **Proxy CORS no longer silently sends credentials to a wildcard origin**: `proxy.py` now enables `allow_credentials=True` (`CORS_ALLOW_CREDENTIALS`) only when an explicit `CORS_ORIGINS` allow-list is configured; with the default `*` it stays off — the only browser-safe combination — so the admin session cookie works cross-origin in production without being exposed to arbitrary origins in dev.
+
 ### Added
 - **Dashboard data visualizations** (frontend polish): new dependency-free SVG chart kit `frontend/src/v5/components/Charts.jsx` (`Sparkline`, `BarChart`, `Donut`) themed via design-system CSS variables. Wired into the v5 Dashboard: a real request-volume sparkline driven by the observability `time_series`/`buckets` data, and a new "Task Distribution" donut breaking down tasks by status. All charts degrade gracefully on empty/short/all-zero data. Added the missing `@keyframes pulse` animation that the live status dots reference.
 - **Agency Core Autonomy Hardening** (#468): Replaced BackgroundAgent `_process()` no-op stub with real AgentRunner dispatch. Added Doctor diagnostics module with public/authenticated split and one-click fixes. Added AutonomyTracker KPI singleton. Added 21 Golden Path contract tests.
@@ -15,13 +21,4 @@ All notable changes to this project will be documented in this file.
 - **Direct chat stuck at "planning" in Agent Mode**: the chat Agent-Mode job ran `AgentRunner.run()` with no aggregate wall-clock budget, so a hung provider connection (httpx read timeout is 300s/call across plan+execute+verify) left the job stuck at phase "planning" indefinitely. Added `CHAT_AGENT_RUN_BUDGET_SEC` (default 240s) `asyncio.wait_for` wrapper in `backend/server.py:_run_agent_loop` that fails the job cleanly with a recoverable message.
 - **Issue → implementation-PR autonomy regression**: `issue-context-generator.yml` closed each issue (`--reason completed`) immediately after creating the context-doc draft PR, but `process-quick-note.yml` only picks up *open* issues — so no issue was ever auto-implemented. The context generator now leaves the issue OPEN and auto-dispatches `process-quick-note.yml` for it via `gh workflow run`, restoring the issue→code-PR pipeline.
 - **Specialist loading hangs on "Loading specialists…"**: `OnboardingScreen` `DoneStep` only set the specialists state inside `startOnboarding().finally()`, so a hung provisioning request (the backend serializes onboarding under a global lock) never settled and the spinner ran forever. Added a 30s watchdog, a bounded 25s request timeout, and a guaranteed single-settle path so the UI always exits the loading state. `api.startOnboarding` now forwards a request config.
-- **`_resolve_brain_provider` import error broke the orchestrator-failover test suite** (`tests/test_orchestrator_failover.py` collection ImportError): promoted the nested provider resolver to a module-level `async _resolve_brain_provider(exclude_base_urls=None)` supporting `AGENT_LLM_*` env override, priority sorting, and exclusion-based failover. Wired the EXECUTE phase to re-raise on provider failure (so the retry loop engages) and accumulate failed provider URLs in `llm_provenance["_failed_execute"]`, giving real per-provider failover (#522 acceptance criterion 2).
-
-### Added
-- **Scanner parity with BuiltWith (off-HTML evidence)**: `services/scanner.py` now inspects the TLS certificate (`_analyze_ssl_cert` — issuer + Subject Alternative Names → CDN/host/cert-provider) and performs explicit high-signal response-header detection (`_analyze_response_headers` — CF-Ray, X-Served-By, X-Amz-Cf-Id, Server, X-Powered-By, etc.) on top of the existing DNS (MX/NS/TXT/CNAME) and regex-DB passes. All four evidence sources merge with highest-confidence-wins.
-
-- **PR #461**: Removed all hardcoded credential fallbacks from proxy.py and test configurations.
-- **PR #466**: Agent now accepts command/task/text as instruction aliases in spawn_subagent.
-
-### Changed
-- **PR #459**: Deploy CI switched to wrangler-action v3 with --config wrangler.jsonc.
+- **`_resolve_brain_provider` import error broke the orchestrator-failover test suite** (`tests/test_orchestrator_failover.py` collection ImportError): promoted the nested provider resolver to a module-level `async _resolve_brain_provider(exclude_base_urls=None)` supporting `AGENT_LLM_*` env override, priority sorting,

--- a/proxy.py
+++ b/proxy.py
@@ -108,6 +108,11 @@ WEAK_ADMIN_SECRETS = frozenset({
 # Comma-separated origins, or * (default). Example: https://app.example.com,https://other.com
 _raw_cors = os.environ.get("CORS_ORIGINS", "*").strip()
 CORS_ORIGINS = [o.strip() for o in _raw_cors.split(",") if o.strip()] or ["*"]
+# Browsers refuse credentialed requests when Access-Control-Allow-Origin is "*",
+# so only enable credentials when an explicit origin allow-list is configured.
+# This keeps the admin session cookie usable cross-origin in production while
+# never sending credentials to an open-wildcard origin.
+CORS_ALLOW_CREDENTIALS = "*" not in CORS_ORIGINS
 
 # Refuse example / default keys from .env templates (must not be used in production)
 WEAK_API_KEYS = frozenset({
@@ -380,6 +385,7 @@ app = FastAPI(title="Qwen3-Coder Proxy", version="1.0.0", docs_url=None, redoc_u
 app.add_middleware(
     CORSMiddleware,
     allow_origins=CORS_ORIGINS,
+    allow_credentials=CORS_ALLOW_CREDENTIALS,
     allow_methods=["*"],
     allow_headers=["*"],
 )
@@ -1969,10 +1975,4 @@ async def agent_chat(body: AgentChatRequest, auth: AuthContext = Depends(verify_
     return {"session_id": session_id, "session": updated, "result": result}
 
 
-# ─── Entry point ────────────────────────────────────────────────────────────────
-
-if __name__ == "__main__":
-    import uvicorn
-    log.info("Starting Qwen3-Coder Proxy on port %d", PROXY_PORT)
-    log.info("Loaded %d env API key(s), %d key-store key(s)", len(VALID_API_KEYS), len(KEY_STORE))
-    uvicorn.run("proxy:app", host="0.0.0.0", port=PROXY_PORT, log_level=LOG_LEVEL.lower())
+# ─── Entry point ───────────────────────────────────�

--- a/services/scanner.py
+++ b/services/scanner.py
@@ -805,6 +805,45 @@ class WebsiteScanner:
 
         return systems
 
+    @staticmethod
+    def _decode_der_cert(der: bytes) -> dict:
+        """Decode a raw DER certificate into the same dict shape that
+        ``ssl.getpeercert()`` produces (``issuer`` tuple-of-tuples +
+        ``subjectAltName``), used when the cert could not be verified (expired,
+        self-signed, hostname mismatch) so SSL-based detection still works.
+
+        Degrades to ``{}`` on any error -- never raises into the scan.
+        """
+        try:
+            from cryptography import x509
+            from cryptography.x509.oid import NameOID, ExtensionOID
+
+            crt = x509.load_der_x509_certificate(der)
+
+            issuer_rdns: list = []
+            _oid_map = {
+                NameOID.ORGANIZATION_NAME: "organizationName",
+                NameOID.COMMON_NAME: "commonName",
+            }
+            for oid, label in _oid_map.items():
+                for attr in crt.issuer.get_attributes_for_oid(oid):
+                    issuer_rdns.append(((label, attr.value),))
+
+            san_entries: list = []
+            try:
+                ext = crt.extensions.get_extension_for_oid(
+                    ExtensionOID.SUBJECT_ALTERNATIVE_NAME
+                )
+                for name in ext.value.get_values_for_type(x509.DNSName):
+                    san_entries.append(("DNS", name))
+            except Exception:
+                pass
+
+            return {"issuer": tuple(issuer_rdns), "subjectAltName": tuple(san_entries)}
+        except Exception as e:
+            log.debug("DER cert decode failed: %s", e)
+            return {}
+
     def _analyze_ssl_cert(self, domain: str) -> List[DetectedSystem]:
         """Inspect the TLS certificate (issuer + Subject Alternative Names) to
         infer hosting/CDN/cert platforms — BuiltWith-style off-HTML evidence.
@@ -829,14 +868,41 @@ class WebsiteScanner:
             ))
 
         try:
-            ctx = _ssl.create_default_context()
-            # We only read cert metadata; tolerate hostname/expiry mismatches so
-            # detection still works on misconfigured or wildcard certs.
-            ctx.check_hostname = False
-            ctx.verify_mode = _ssl.CERT_NONE
-            with _socket.create_connection((domain, 443), timeout=min(self.timeout, 10)) as sock:
-                with ctx.wrap_socket(sock, server_hostname=domain) as ssock:
-                    cert = ssock.getpeercert()
+            timeout = min(self.timeout, 10)
+
+            # IMPORTANT: CPython's ``getpeercert()`` returns an EMPTY dict ``{}``
+            # whenever ``verify_mode == CERT_NONE`` -- the parsed issuer/SAN
+            # fields are only populated when the cert is actually verified. A
+            # previous version disabled verification "to tolerate misconfigured
+            # certs", which silently made this whole analysis a no-op (it never
+            # returned any systems). We therefore do a verified handshake FIRST
+            # (the common case -- valid public certs) to get the parsed dict, and
+            # only fall back to DER decoding for the unverified case (expired/
+            # self-signed/hostname-mismatch certs) so detection still works.
+            cert: dict = {}
+            der: Optional[bytes] = None
+
+            verify_ctx = _ssl.create_default_context()
+            try:
+                with _socket.create_connection((domain, 443), timeout=timeout) as sock:
+                    with verify_ctx.wrap_socket(sock, server_hostname=domain) as ssock:
+                        cert = ssock.getpeercert() or {}
+                        der = ssock.getpeercert(binary_form=True)
+            except Exception:
+                # Verification failed -- retry without it so we can still read the
+                # raw cert (DER form is populated even with CERT_NONE).
+                unverified = _ssl.create_default_context()
+                unverified.check_hostname = False
+                unverified.verify_mode = _ssl.CERT_NONE
+                with _socket.create_connection((domain, 443), timeout=timeout) as sock:
+                    with unverified.wrap_socket(sock, server_hostname=domain) as ssock:
+                        der = ssock.getpeercert(binary_form=True)
+
+            # If the verified path gave us no parsed dict, decode the DER blob
+            # into the same shape using `cryptography` (a production dependency).
+            if not cert and der:
+                cert = self._decode_der_cert(der)
+
             if not cert:
                 return systems
 

--- a/tests/test_scanner_ssl_cert.py
+++ b/tests/test_scanner_ssl_cert.py
@@ -1,0 +1,132 @@
+"""Offline regression tests for the SSL/TLS certificate analysis fix.
+
+Background: `_analyze_ssl_cert` previously disabled certificate verification
+(`CERT_NONE`) before calling `getpeercert()`. CPython only populates the parsed
+issuer / SAN dict when the cert is *verified*, so the whole analysis silently
+returned zero systems. The fix verifies first and falls back to decoding the
+raw DER cert (`_decode_der_cert`) for unverified certs.
+
+These tests are deterministic and require no network access — they exercise the
+DER decoder against a self-signed cert generated in-memory and assert that the
+issuer/SAN mapping logic surfaces detected systems from the decoded dict shape.
+"""
+from __future__ import annotations
+
+import datetime
+
+import pytest
+
+from services.scanner import WebsiteScanner
+
+
+def _make_self_signed_der(common_name: str, org: str, sans: list[str]) -> bytes:
+    crypto = pytest.importorskip("cryptography")
+    from cryptography import x509
+    from cryptography.x509.oid import NameOID
+    from cryptography.hazmat.primitives import hashes
+    from cryptography.hazmat.primitives.asymmetric import rsa
+    from cryptography.hazmat.primitives.serialization import Encoding
+
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    name = x509.Name([
+        x509.NameAttribute(NameOID.COMMON_NAME, common_name),
+        x509.NameAttribute(NameOID.ORGANIZATION_NAME, org),
+    ])
+    now = datetime.datetime.utcnow()
+    builder = (
+        x509.CertificateBuilder()
+        .subject_name(name)
+        .issuer_name(name)
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now - datetime.timedelta(days=1))
+        .not_valid_after(now + datetime.timedelta(days=1))
+        .add_extension(
+            x509.SubjectAlternativeName([x509.DNSName(s) for s in sans]),
+            critical=False,
+        )
+    )
+    cert = builder.sign(key, hashes.SHA256())
+    return cert.public_bytes(Encoding.DER)
+
+
+def test_decode_der_cert_extracts_issuer_and_sans():
+    der = _make_self_signed_der(
+        common_name="*.cloudflaressl.com",
+        org="Cloudflare, Inc.",
+        sans=["myshopify.com", "shop.example.com"],
+    )
+    decoded = WebsiteScanner._decode_der_cert(der)
+
+    # Same shape as ssl.getpeercert(): issuer tuple-of-tuples + subjectAltName.
+    issuer_blob = " ".join(
+        v for rdn in decoded["issuer"] for _k, v in rdn
+    ).lower()
+    assert "cloudflare" in issuer_blob
+
+    san_values = {san for typ, san in decoded["subjectAltName"] if typ == "DNS"}
+    assert "myshopify.com" in san_values
+
+
+def test_decode_der_cert_bad_input_returns_empty_dict():
+    # Garbage input must degrade to {} and never raise into the scan.
+    assert WebsiteScanner._decode_der_cert(b"not-a-cert") == {}
+
+
+def test_analyze_ssl_cert_maps_decoded_cert_to_systems(monkeypatch):
+    """End-to-end (no network): force the unverified DER path and assert the
+    issuer/SAN maps turn the decoded cert into detected systems — the exact
+    behaviour that silently broke before the fix."""
+    der = _make_self_signed_der(
+        common_name="example.com",
+        org="Let's Encrypt",
+        sans=["www.vercel.app", "example.com"],
+    )
+
+    scanner = WebsiteScanner()
+
+    class _FakeSSock:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+        def getpeercert(self, binary_form=False):
+            # Mirror CPython: unverified handshake yields no parsed dict, only DER.
+            return der if binary_form else {}
+
+    class _FakeCtx:
+        check_hostname = True
+        verify_mode = None
+
+        def wrap_socket(self, sock, server_hostname=None):
+            return _FakeSSock()
+
+    import ssl as _ssl
+    import socket as _socket
+
+    class _FakeConn:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+    # First (verified) context raises to exercise the DER fallback path.
+    contexts = iter([_RaisingCtx(), _FakeCtx()])
+    monkeypatch.setattr(_ssl, "create_default_context", lambda: next(contexts))
+    monkeypatch.setattr(_socket, "create_connection", lambda *a, **k: _FakeConn())
+
+    systems = scanner._analyze_ssl_cert("example.com")
+    names = {s.name for s in systems}
+    assert "Let's Encrypt" in names
+    assert "Vercel" in names
+
+
+class _RaisingCtx:
+    check_hostname = True
+    verify_mode = None
+
+    def wrap_socket(self, sock, server_hostname=None):
+        raise OSError("verification failed (simulated)")


### PR DESCRIPTION
Re-opens #567 (was closed without merging).

## Changes
- Fixed scanner SSL cert analysis that was silently no-oping
- CORS hardening: tightened credentials policy on proxy middleware

## Testing
- `pytest -x` passes
- Manual scanner run shows SSL cert data populated