### PR TITLE
feat: dashboard AgentActivityWidget (Charts.jsx) + systems tab category grouping with confidence scores

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -86,6 +86,10 @@
 
 ## [Unreleased]
 
+### Added
+- **Dashboard: AgentActivityWidget with Charts.jsx integration.** New widget on the dashboard shows a task status Donut chart (done/running/pending/failed distribution) and a 7-day activity sparkline built from `/api/activity` events. Uses the zero-dependency `Charts.jsx` SVG components (Donut + Sparkline) added in a prior pass. Widget fetches `/api/agents/` for live active-agent count badge. Wired into the resilient `useSafeData` pattern so a failed agents endpoint never blanks the whole widget.
+- **CompanyScreen: Systems tab — category grouping, confidence scores, detection method badges.** Previously the systems tab showed a flat list. Now systems are grouped by category (CMS, CRM, analytics, payment_gateway, etc.) with a color-coded category header. Each detected system shows: version if available, detection method badges (html/dns/ssl/headers/script/cookie in distinct colours), and a confidence mini-bar + percentage score. Summary counts at top: "N systems detected across M categories", with separate counters for auto-detected vs connected systems. Empty state message directs users to run a scan.
+
 ### Changed
 - **Mobile-first CSS hardening.** Added a global mobile baseline so the dashboard and chat UIs never overflow horizontally on small screens: `max-width: 100vw` on the `html, body, #root` root containers and a `img, video, iframe { max-width: 100%; height: auto; }` rule in both `frontend/src/index.css` and `webui/frontend/src/styles.css` (the latter also gains `overflow-x: hidden` on `html, body`). Wrapped the three previously-unwrapped data tables in horizontally scrollable containers so wide tables scroll instead of clipping on phones: `frontend/src/pages/LogsPage.js` (Provider Performance) and both tables in `frontend/src/v5/screens/AdminOnboardingPanel.jsx` (user-onboarding and audit-log).
 

--- a/frontend/src/v5/components/Charts.jsx
+++ b/frontend/src/v5/components/Charts.jsx
@@ -161,12 +161,4 @@ export function Donut({ data = [], size = 116, thickness = 14, centerLabel }) {
           <div key={d.label ?? i} style={{ display: 'flex', alignItems: 'center', gap: 7 }}>
             <span style={{ width: 9, height: 9, borderRadius: 3, background: d.color || ACCENT, flexShrink: 0 }} />
             <span style={{ fontSize: 11, color: 'var(--text-secondary)', flex: 1 }}>{d.label}</span>
-            <span style={{ fontSize: 11, fontFamily: 'var(--font-mono)', color: 'var(--text-muted)' }}>{d.value}</span>
-          </div>
-        ))}
-      </div>
-    </div>
-  );
-}
-
-export default { Sparkline, BarChart, Donut };
+            <span style={{ fontSize: 11, fontFamily: 'var(--font-

--- a/frontend/src/v5/screens/CompanyScreen.jsx
+++ b/frontend/src/v5/screens/CompanyScreen.jsx
@@ -387,6 +387,10 @@ function CompanyScreen() {
         category: ds.system_type || 'Platform',
         status: ds.is_active ? 'connected' : 'inactive',
         icon: '🔍',
+        confidence: ds.confidence ?? null,
+        detectionMethods: (ds.evidence || []).map(e => e.type).filter(Boolean),
+        version: ds.version || null,
+        isDetected: true,
       })),
     ],
     repos: (graph?.repos || company.repos || []).map(r => ({
@@ -600,30 +604,116 @@ function CompanyScreen() {
         </div>
       )}
 
-      {!loadingCompany && activeTab === 'systems' && (
-        <div style={{ display: 'flex', flexDirection: 'column', gap: 10, animation: 'fadeSlideUp 0.3s ease-out' }}>
-          {(d.systems || []).map(sys => (
-            <div key={sys.id} style={{
-              borderRadius: 14, border: '1px solid rgba(255,255,255,0.09)',
-              background: 'rgba(255,255,255,0.03)', padding: '14px 16px',
-              display: 'flex', alignItems: 'center', gap: 12,
-            }}>
-              <span style={{ fontSize: 24, flexShrink: 0 }}>{sys.icon || '⚙'}</span>
-              <div style={{ flex: 1, minWidth: 0 }}>
-                <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap', marginBottom: 3 }}>
-                  <span style={{ fontSize: 14, fontWeight: 700, color: '#fff' }}>{sys.name}</span>
-                  <span style={{ fontSize: 10, fontFamily: 'var(--font-mono)', letterSpacing: '0.12em', textTransform: 'uppercase', padding: '2px 7px', borderRadius: 999, color: 'var(--text-muted)', background: 'rgba(255,255,255,0.06)', border: '1px solid rgba(255,255,255,0.10)' }}>{sys.category}</span>
-                </div>
-                <div style={{ fontSize: 12, color: 'var(--text-muted)' }}>{sys.status === 'inactive' ? 'Inactive' : 'Connected'} · Last synced: 5 min ago</div>
-              </div>
-              <div style={{ display: 'flex', alignItems: 'center', gap: 6, flexShrink: 0 }}>
-                <StatusDotC status={sys.status}/>
-                <span style={{ fontSize: 11, color: sys.status === 'inactive' ? '#ff6b7d' : '#46d9a4' }}>{sys.status === 'inactive' ? 'Inactive' : 'Connected'}</span>
-              </div>
+      {!loadingCompany && activeTab === 'systems' && (() => {
+        const allSystems = d.systems || [];
+        // Group by category
+        const grouped = {};
+        allSystems.forEach(sys => {
+          const cat = sys.category || 'Other';
+          if (!grouped[cat]) grouped[cat] = [];
+          grouped[cat].push(sys);
+        });
+        const cats = Object.keys(grouped).sort();
+        const totalDetected = allSystems.filter(s => s.isDetected).length;
+        const totalConnected = allSystems.filter(s => !s.isDetected).length;
+        const catColorMap = {
+          CMS: '#c4b5fd', CRM: '#5da2ff', analytics: '#46d9a4',
+          payment_gateway: '#ffbd66', email_service: '#ff6b7d',
+          marketing_automation: '#f97316', search: '#7c9dff',
+          auth: '#46d9a4', api_gateway: '#5da2ff', shipping: '#ffbd66',
+          OMS: '#c4b5fd', PIM: '#f97316', DAM: '#5da2ff',
+          ERP: '#ffbd66', HRM: '#ff6b7d', LMS: '#7c9dff',
+          support: '#46d9a4', chat: '#c4b5fd', ai_ml: '#5da2ff',
+          database: '#ffbd66', cache: '#ff6b7d', billing: '#f97316',
+        };
+        function confidenceColor(c) {
+          if (c == null) return 'var(--text-muted)';
+          if (c >= 0.8) return '#46d9a4';
+          if (c >= 0.5) return '#ffbd66';
+          return '#ff6b7d';
+        }
+        function methodBadge(method) {
+          const colors = { html: '#5da2ff', dns: '#46d9a4', ssl: '#c4b5fd', headers: '#ffbd66', script: '#f97316', cookie: '#ff6b7d', meta: '#7c9dff' };
+          const c = colors[method] || 'var(--text-muted)';
+          return (
+            <span key={method} style={{ fontSize: 9, fontFamily: 'var(--font-mono)', letterSpacing: '0.08em', textTransform: 'uppercase', padding: '1px 5px', borderRadius: 4, color: c, background: `${c}18`, border: `1px solid ${c}30` }}>{method}</span>
+          );
+        }
+        return (
+          <div style={{ animation: 'fadeSlideUp 0.3s ease-out' }}>
+            {/* Summary bar */}
+            <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 14, flexWrap: 'wrap' }}>
+              <span style={{ fontSize: 13, fontWeight: 700, color: '#fff' }}>{allSystems.length} systems detected</span>
+              <span style={{ fontSize: 11, color: 'var(--text-muted)' }}>across {cats.length} categories</span>
+              {totalDetected > 0 && (
+                <span style={{ fontSize: 10, fontFamily: 'var(--font-mono)', padding: '2px 8px', borderRadius: 999, color: '#c4b5fd', background: 'rgba(196,181,253,0.10)', border: '1px solid rgba(196,181,253,0.20)' }}>
+                  {totalDetected} auto-detected
+                </span>
+              )}
+              {totalConnected > 0 && (
+                <span style={{ fontSize: 10, fontFamily: 'var(--font-mono)', padding: '2px 8px', borderRadius: 999, color: '#46d9a4', background: 'rgba(70,217,164,0.10)', border: '1px solid rgba(70,217,164,0.20)' }}>
+                  {totalConnected} connected
+                </span>
+              )}
             </div>
-          ))}
-        </div>
-      )}
+            {/* Per-category groups */}
+            {cats.map(cat => {
+              const catColor = catColorMap[cat] || 'var(--accent)';
+              const items = grouped[cat];
+              return (
+                <div key={cat} style={{ marginBottom: 16 }}>
+                  <div style={{ display: 'flex', alignItems: 'center', gap: 7, marginBottom: 8 }}>
+                    <span style={{ width: 8, height: 8, borderRadius: 2, background: catColor, flexShrink: 0 }}/>
+                    <span style={{ fontSize: 10, fontFamily: 'var(--font-mono)', color: catColor, letterSpacing: '0.16em', textTransform: 'uppercase' }}>{cat.replace(/_/g, ' ')}</span>
+                    <span style={{ fontSize: 10, color: 'var(--text-muted)' }}>({items.length})</span>
+                  </div>
+                  <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+                    {items.map(sys => (
+                      <div key={sys.id} style={{
+                        borderRadius: 12, border: '1px solid rgba(255,255,255,0.08)',
+                        background: 'rgba(255,255,255,0.025)', padding: '10px 14px',
+                        display: 'flex', alignItems: 'center', gap: 10,
+                      }}>
+                        <span style={{ fontSize: 18, flexShrink: 0 }}>{sys.icon || '⚙'}</span>
+                        <div style={{ flex: 1, minWidth: 0 }}>
+                          <div style={{ display: 'flex', alignItems: 'center', gap: 6, flexWrap: 'wrap', marginBottom: 3 }}>
+                            <span style={{ fontSize: 13, fontWeight: 700, color: '#fff' }}>{sys.name}</span>
+                            {sys.version && <span style={{ fontSize: 10, color: 'var(--text-muted)', fontFamily: 'var(--font-mono)' }}>v{sys.version}</span>}
+                          </div>
+                          {sys.isDetected && (sys.detectionMethods || []).length > 0 && (
+                            <div style={{ display: 'flex', gap: 4, flexWrap: 'wrap' }}>
+                              {[...new Set(sys.detectionMethods)].slice(0, 5).map(m => methodBadge(m))}
+                            </div>
+                          )}
+                        </div>
+                        <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'flex-end', gap: 4, flexShrink: 0 }}>
+                          {sys.confidence != null && (
+                            <div style={{ display: 'flex', alignItems: 'center', gap: 5 }}>
+                              <div style={{ width: 40, height: 3, borderRadius: 999, background: 'rgba(255,255,255,0.08)', overflow: 'hidden' }}>
+                                <div style={{ width: `${Math.round(sys.confidence * 100)}%`, height: '100%', background: confidenceColor(sys.confidence), borderRadius: 999 }}/>
+                              </div>
+                              <span style={{ fontSize: 10, fontFamily: 'var(--font-mono)', color: confidenceColor(sys.confidence) }}>{Math.round(sys.confidence * 100)}%</span>
+                            </div>
+                          )}
+                          <div style={{ display: 'flex', alignItems: 'center', gap: 5 }}>
+                            <StatusDotC status={sys.status}/>
+                            <span style={{ fontSize: 10, color: sys.status === 'inactive' ? '#ff6b7d' : '#46d9a4' }}>{sys.status === 'inactive' ? 'Inactive' : sys.isDetected ? 'Detected' : 'Connected'}</span>
+                          </div>
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              );
+            })}
+            {allSystems.length === 0 && (
+              <div style={{ padding: '32px 0', textAlign: 'center', color: 'var(--text-muted)', fontSize: 13 }}>
+                No systems detected. Run a scan from the company header to discover your tech stack.
+              </div>
+            )}
+          </div>
+        );
+      })()}
 
       {!loadingCompany && activeTab === 'priorities' && (
         <div style={{ maxWidth: 560, animation: 'fadeSlideUp 0.3s ease-out' }}>

--- a/frontend/src/v5/screens/DashboardScreen.jsx
+++ b/frontend/src/v5/screens/DashboardScreen.jsx
@@ -2,7 +2,7 @@
 import React from 'react';
 import { useSafeData } from '../hooks/useSafeData';
 import { ErrorBoundary } from '../components/ErrorBoundary';
-import { Sparkline, Donut } from '../components/Charts';
+import { Donut, BarChart, Sparkline } from '../components/Charts';
 
 // dashboard.jsx — Resilient Dashboard wired to the real backend
 // Each widget fetches independently via useSafeData (Promise.allSettled) so a
@@ -345,6 +345,32 @@ function SystemHealthWidget({ health, loading, error, onRetry }) {
   );
 }
 
+
+// ─── AgentActivityWidget ─────────────────────────────────────────────────────
+function AgentActivityWidget({ donutData, sparklineData, totalTasks, activeAgents, loading, error, onRetry }) {
+  return (
+    <Widget title="Agent Activity" loading={loading} error={error} errorSeverity="warning" onRetry={onRetry}>
+      {!loading && !error && (
+        <div>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 10, flexWrap: 'wrap' }}>
+            <span style={{ fontSize: 11, color: 'var(--text-muted)' }}>{totalTasks} total tasks</span>
+            {activeAgents > 0 && (
+              <span style={{ fontSize: 10, fontFamily: 'var(--font-mono)', padding: '2px 8px', borderRadius: 999, color: '#46d9a4', background: 'rgba(70,217,164,0.10)', border: '1px solid rgba(70,217,164,0.20)' }}>
+                {activeAgents} agent{activeAgents === 1 ? '' : 's'} running
+              </span>
+            )}
+          </div>
+          <Donut data={donutData} size={100} thickness={12} centerLabel="tasks" />
+          <div style={{ marginTop: 14 }}>
+            <div style={{ fontSize: 10, fontFamily: 'var(--font-mono)', color: 'var(--text-muted)', letterSpacing: '0.14em', textTransform: 'uppercase', marginBottom: 6 }}>7-day activity</div>
+            <Sparkline values={sparklineData} height={44} />
+          </div>
+        </div>
+      )}
+    </Widget>
+  );
+}
+
 function DashboardScreen() {
   const [data, states, fetchAll] = useSafeData(null, {
     health:    '/api/health',
@@ -353,6 +379,7 @@ function DashboardScreen() {
     metrics:   '/api/observability/metrics',
     providers: '/api/providers',
     tasks:     '/api/tasks/',
+    agents:    '/api/agents/',
   }, { refreshMs: 30000 });
 
   // Map /api/tasks/ to the Open Tasks widget (exclude finished/failed)
@@ -363,6 +390,42 @@ function DashboardScreen() {
       .slice(0, 6)
       .map(t => ({ id: t.task_id || t.id, title: t.title, status: t.status, priority: t.priority }));
   }, [data.tasks]);
+
+  // Build task status distribution for Donut chart
+  const taskDonutData = React.useMemo(() => {
+    const all = data.tasks?.tasks || [];
+    const STATUS_COLORS = {
+      done: '#46d9a4',
+      running: '#5da2ff',
+      pending: '#ffbd66',
+      failed: '#ff6b7d',
+    };
+    const counts = { done: 0, running: 0, pending: 0, failed: 0 };
+    all.forEach(t => {
+      const s = t.status || 'pending';
+      if (s in counts) counts[s]++;
+      else counts.pending++;
+    });
+    return Object.entries(counts)
+      .filter(([, v]) => v > 0)
+      .map(([k, v]) => ({ label: k, value: v, color: STATUS_COLORS[k] || 'var(--accent)' }));
+  }, [data.tasks]);
+
+  // Build last-7-day agent activity sparkline from /api/activity
+  const agentActivitySparkline = React.useMemo(() => {
+    const logs = data.activity?.logs || data.activity?.events || [];
+    // Bucket activity entries into 7 day slots (most recent last)
+    const buckets = Array(7).fill(0);
+    const now = Date.now();
+    logs.forEach(log => {
+      const ts = log.created_at || log.timestamp;
+      if (!ts) return;
+      const age = now - Date.parse(ts);
+      const dayIdx = Math.floor(age / 86400000);
+      if (dayIdx >= 0 && dayIdx < 7) buckets[6 - dayIdx]++;
+    });
+    return buckets;
+  }, [data.activity]);
 
   // Map /api/health + /api/providers into ProviderHealthWidget shape
   const providerData = React.useMemo(() => {
@@ -405,6 +468,12 @@ function DashboardScreen() {
       pr: null,
     }));
   }, [data.activity]);
+
+  // Active agents count
+  const activeAgents = React.useMemo(() => {
+    const agentList = data.agents?.agents || (Array.isArray(data.agents) ? data.agents : []);
+    return agentList.filter(a => a.status === 'running' || a.status === 'active').length;
+  }, [data.agents]);
 
   // Map /api/observability/metrics to CostWidget shape.
   // Backend exposes a 24h window only (total_requests/tokens/savings); there is
@@ -552,6 +621,17 @@ function DashboardScreen() {
             loading={states.health?.loading || states.stats?.loading}
             error={states.health?.error || states.stats?.error}
             errorSeverity="warning"
+            onRetry={fetchAll}
+          />
+        </ErrorBoundary>
+        <ErrorBoundary onRetry={fetchAll} resetKey={String(states.tasks?.error || states.activity?.error || '')}>
+          <AgentActivityWidget
+            donutData={taskDonutData}
+            sparklineData={agentActivitySparkline}
+            totalTasks={(data.tasks?.tasks || []).length}
+            activeAgents={activeAgents}
+            loading={states.tasks?.loading || states.activity?.loading}
+            error={states.tasks?.error || states.activity?.error}
             onRetry={fetchAll}
           />
         </ErrorBoundary>

--- a/tests/e2e/test_critical_flows.py
+++ b/tests/e2e/test_critical_flows.py
@@ -313,9 +313,4 @@ def test_admin_dashboard_loads():
             body = page.locator("body").inner_text().lower()
             assert any(k in body for k in ("admin", "key", "user", "health", "portal", "manage")), \
                 "Admin portal did not render expected content"
-            # Ignore benign network-abort console noise; fail only on real JS errors.
-            fatal = [e for e in console_errors if "Failed to load resource" not in e and "net::" not in e]
-            assert len(fatal) == 0, f"Admin dashboard logged JS errors: {fatal[:3]}"
-        finally:
-            ctx.close()
-            browser.close()
+            # Ignore benign netw

--- a/tests/test_orchestrator_failover.py
+++ b/tests/test_orchestrator_failover.py
@@ -1,0 +1,335 @@
+"""tests/test_orchestrator_failover.py — Provider failover, brain resolution, llm_provenance.
+
+Verifies that when a provider fails during execution, the orchestrator's retry
+loop (via _run_phase_with_timeout) picks the next-highest-priority provider and
+llm_provenance records the change (#522).
+"""
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from services.workflow_orchestrator import (
+    ExecutionRequest,
+    WorkflowOrchestrator,
+    _resolve_brain_provider,
+    reset_orchestrator,
+)
+
+
+# ── Helpers ────────────────────────────────────────────────────────────────────
+
+def _mock_provider_records(*providers: dict) -> AsyncMock:
+    """Return an AsyncMock that returns the given provider list."""
+    return AsyncMock(return_value=list(providers))
+
+
+# ── _resolve_brain_provider (module-level) ────────────────────────────────────
+
+
+class TestResolveBrainProvider:
+    """Unit tests for the module-level _resolve_brain_provider function."""
+
+    async def test_env_override_wins(self, monkeypatch):
+        """AGENT_LLM_BASE_URL overrides all configured providers."""
+        monkeypatch.setenv("AGENT_LLM_BASE_URL", "http://env-provider.local")
+        monkeypatch.setenv("AGENT_LLM_API_KEY", "env-key-123")
+        monkeypatch.setenv("AGENT_LLM_MODEL", "env-model")
+
+        base, headers, model = await _resolve_brain_provider()
+
+        assert base == "http://env-provider.local"
+        assert headers == {"Authorization": "Bearer env-key-123"}
+        assert model == "env-model"
+
+    async def test_env_override_no_key_returns_no_headers(self, monkeypatch):
+        """AGENT_LLM_BASE_URL without key still works (headers=None)."""
+        monkeypatch.setenv("AGENT_LLM_BASE_URL", "http://env-no-key.local")
+
+        base, headers, model = await _resolve_brain_provider()
+
+        assert base == "http://env-no-key.local"
+        assert headers is None
+
+    async def test_highest_priority_selected_first(self, monkeypatch):
+        """The provider with the highest priority value is selected."""
+        records = _mock_provider_records(
+            {"provider_id": "low", "base_url": "http://low.local", "type": "openai", "api_key": "k1", "default_model": "low-model", "priority": 1},
+            {"provider_id": "high", "base_url": "http://high.local", "type": "openai", "api_key": "k2", "default_model": "high-model", "priority": 10},
+            {"provider_id": "mid", "base_url": "http://mid.local", "type": "openai", "api_key": "k3", "default_model": "mid-model", "priority": 5},
+        )
+        with patch("backend.server._list_configured_provider_records", records):
+            base, headers, model = await _resolve_brain_provider()
+
+        assert base == "http://high.local/v1"
+        assert model == "high-model"
+
+    async def test_excluded_url_is_skipped(self, monkeypatch):
+        """When a base URL is excluded, the next-highest-priority provider is picked."""
+        records = _mock_provider_records(
+            {"provider_id": "primary", "base_url": "http://primary.local", "type": "openai", "api_key": "k1", "default_model": "primary-model", "priority": 10},
+            {"provider_id": "fallback", "base_url": "http://fallback.local", "type": "openai", "api_key": "k2", "default_model": "fallback-model", "priority": 5},
+        )
+        with patch("backend.server._list_configured_provider_records", records):
+            base, headers, model = await _resolve_brain_provider(
+                exclude_base_urls={"http://primary.local/v1"}
+            )
+
+        assert base == "http://fallback.local/v1"
+        assert model == "fallback-model"
+
+    async def test_multiple_excluded_urls(self, monkeypatch):
+        """Multiple excluded URLs are all skipped."""
+        records = _mock_provider_records(
+            {"provider_id": "first", "base_url": "http://first.local", "type": "openai", "api_key": "k1", "default_model": "first-model", "priority": 10},
+            {"provider_id": "second", "base_url": "http://second.local", "type": "openai", "api_key": "k2", "default_model": "second-model", "priority": 8},
+            {"provider_id": "third", "base_url": "http://third.local", "type": "openai", "api_key": "k3", "default_model": "third-model", "priority": 5},
+        )
+        with patch("backend.server._list_configured_provider_records", records):
+            base, headers, model = await _resolve_brain_provider(
+                exclude_base_urls={"http://first.local/v1", "http://second.local/v1"}
+            )
+
+        assert base == "http://third.local/v1"
+        assert model == "third-model"
+
+    async def test_exclude_set_is_empty_by_default(self, monkeypatch):
+        """Without exclude_base_urls, the highest-priority provider is always selected."""
+        records = _mock_provider_records(
+            {"provider_id": "only", "base_url": "http://only.local", "type": "openai", "api_key": "k1", "default_model": "only-model", "priority": 1},
+        )
+        with patch("backend.server._list_configured_provider_records", records):
+            base, headers, model = await _resolve_brain_provider()
+            assert base == "http://only.local/v1"
+
+            # Calling without exclude should still return the same provider.
+            base2, _, model2 = await _resolve_brain_provider()
+            assert base2 == "http://only.local/v1"
+
+    async def test_providers_without_key_are_skipped(self, monkeypatch):
+        """Non-Ollama providers without an API key are skipped."""
+        records = _mock_provider_records(
+            {"provider_id": "no-key", "base_url": "http://no-key.local", "type": "openai", "api_key": "", "default_model": "bad", "priority": 10},
+            {"provider_id": "has-key", "base_url": "http://has-key.local", "type": "openai", "api_key": "k1", "default_model": "good", "priority": 5},
+        )
+        with patch("backend.server._list_configured_provider_records", records):
+            base, _, model = await _resolve_brain_provider()
+
+        assert base == "http://has-key.local/v1"
+        assert model == "good"
+
+    async def test_ollama_type_does_not_require_key(self, monkeypatch):
+        """Ollama-type providers don't need an API key."""
+        records = _mock_provider_records(
+            {"provider_id": "local-ollama", "base_url": "http://ollama.local", "type": "ollama", "api_key": "", "default_model": "llama3", "priority": 10},
+        )
+        with patch("backend.server._list_configured_provider_records", records):
+            base, headers, model = await _resolve_brain_provider()
+
+        assert base == "http://ollama.local/v1"
+        assert headers is None
+        assert model == "llama3"
+
+    async def test_records_list_failure_falls_back_to_ollama_env(self, monkeypatch):
+        """When _list_configured_provider_records raises, falls back to OLLAMA_BASE."""
+        monkeypatch.setenv("OLLAMA_BASE", "http://my-ollama:11434")
+
+        async def _fail():
+            raise RuntimeError("DB offline")
+
+        with patch("backend.server._list_configured_provider_records", _fail):
+            base, headers, model = await _resolve_brain_provider()
+
+        assert base == "http://my-ollama:11434"
+        assert headers is None
+        assert model is None
+
+    async def test_excluded_url_with_fallback_to_ollama(self, monkeypatch):
+        """When all configured providers are excluded, falls back to Ollama."""
+        monkeypatch.setenv("OLLAMA_BASE", "http://ollama-fallback:11434")
+        records = _mock_provider_records(
+            {"provider_id": "only", "base_url": "http://only.local", "type": "openai", "api_key": "k1", "default_model": "only-model", "priority": 10},
+        )
+        with patch("backend.server._list_configured_provider_records", records):
+            base, _, model = await _resolve_brain_provider(
+                exclude_base_urls={"http://only.local/v1"}
+            )
+
+        # No non-excluded provider found → falls back to Ollama.
+        assert base == "http://ollama-fallback:11434"
+
+
+# ── Full orchestrator failover flow ────────────────────────────────────────────
+
+
+class TestOrchestratorProviderFailover:
+    """End-to-end provider failover through the WorkflowOrchestrator."""
+
+    @pytest.fixture(autouse=True)
+    def _reset(self):
+        reset_orchestrator()
+        yield
+        reset_orchestrator()
+
+    async def test_failover_records_correct_provenance(self, monkeypatch):
+        """First provider fails → retry picks next → llm_provenance tracks the winner."""
+        call_count = 0
+
+        async def _runner_run(self, instruction, history, requested_model, auto_commit, max_steps, user_id, session_id):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise ConnectionError("provider A unreachable")
+            return {"summary": "success on fallback", "steps": [], "judge": {}}
+
+        records = _mock_provider_records(
+            {"provider_id": "primary", "base_url": "http://primary-fail.local", "type": "openai", "api_key": "k1", "default_model": "primary-model", "priority": 10},
+            {"provider_id": "fallback", "base_url": "http://fallback-ok.local", "type": "openai", "api_key": "k2", "default_model": "fallback-model", "priority": 5},
+        )
+
+        orchestrator = WorkflowOrchestrator()
+        req = ExecutionRequest(request="test failover", auto_approve=True)
+
+        with patch("agent.loop.AgentRunner.run", _runner_run):
+            with patch("backend.server._list_configured_provider_records", records):
+                run = await orchestrator.execute(req)
+
+        assert run.llm_provenance["execute"] == "fallback-model"
+        assert run.phase_attempts.get("execute", 0) == 2
+        assert call_count == 2
+
+    async def test_failover_tracks_failed_providers(self, monkeypatch):
+        """The _failed_execute key in llm_provenance records the URLs that failed."""
+        call_count = 0
+
+        async def _runner_run(self, instruction, history, requested_model, auto_commit, max_steps, user_id, session_id):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise ConnectionError("first failure")
+            if call_count == 2:
+                raise ConnectionError("second failure")
+            return {"summary": "third time's a charm", "steps": [], "judge": {}}
+
+        records = _mock_provider_records(
+            {"provider_id": "a", "base_url": "http://a.local", "type": "openai", "api_key": "k1", "default_model": "a-model", "priority": 30},
+            {"provider_id": "b", "base_url": "http://b.local", "type": "openai", "api_key": "k2", "default_model": "b-model", "priority": 20},
+            {"provider_id": "c", "base_url": "http://c.local", "type": "openai", "api_key": "k3", "default_model": "c-model", "priority": 10},
+        )
+
+        orchestrator = WorkflowOrchestrator()
+        req = ExecutionRequest(request="triple failover", auto_approve=True)
+
+        with patch("agent.loop.AgentRunner.run", _runner_run):
+            with patch("backend.server._list_configured_provider_records", records):
+                run = await orchestrator.execute(req)
+
+        assert run.llm_provenance["execute"] == "c-model"
+        assert run.phase_attempts.get("execute", 0) == 3
+        assert call_count == 3
+        # _failed_execute tracks the two that failed.
+        # URLs are stored in the normalized /v1 form that _resolve_brain_provider
+        # compares against during exclusion.
+        failed = run.llm_provenance.get("_failed_execute", "")
+        failed_set = set(failed.split(",")) if failed else set()
+        assert "http://a.local/v1" in failed_set
+        assert "http://b.local/v1" in failed_set
+
+    async def test_non_retryable_error_does_not_failover(self, monkeypatch):
+        """A non-retryable error (e.g. ValueError) does not trigger failover."""
+        call_count = 0
+
+        async def _runner_run(self, instruction, history, requested_model, auto_commit, max_steps, user_id, session_id):
+            nonlocal call_count
+            call_count += 1
+            raise ValueError("this is not retryable")
+
+        records = _mock_provider_records(
+            {"provider_id": "only", "base_url": "http://only.local", "type": "openai", "api_key": "k1", "default_model": "only-model", "priority": 10},
+            {"provider_id": "backup", "base_url": "http://backup.local", "type": "openai", "api_key": "k2", "default_model": "backup-model", "priority": 5},
+        )
+
+        orchestrator = WorkflowOrchestrator()
+        req = ExecutionRequest(request="non-retryable", auto_approve=True)
+
+        with patch("agent.loop.AgentRunner.run", _runner_run):
+            with patch("backend.server._list_configured_provider_records", records):
+                run = await orchestrator.execute(req)
+
+        # Non-retryable error — run fails immediately with only 1 attempt.
+        assert run.status == "failed"
+        assert call_count == 1
+        assert run.phase_attempts.get("execute", 0) == 1
+
+    async def test_timeout_triggers_failover(self, monkeypatch):
+        """A TimeoutError is retryable and should trigger provider failover."""
+        call_count = 0
+
+        async def _runner_run(self, instruction, history, requested_model, auto_commit, max_steps, user_id, session_id):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise asyncio.TimeoutError("provider A timed out")
+            return {"summary": "fallback worked", "steps": [], "judge": {}}
+
+        records = _mock_provider_records(
+            {"provider_id": "slow", "base_url": "http://slow.local", "type": "openai", "api_key": "k1", "default_model": "slow-model", "priority": 10},
+            {"provider_id": "fast", "base_url": "http://fast.local", "type": "openai", "api_key": "k2", "default_model": "fast-model", "priority": 5},
+        )
+
+        orchestrator = WorkflowOrchestrator()
+        req = ExecutionRequest(request="timeout failover", auto_approve=True)
+
+        with patch("agent.loop.AgentRunner.run", _runner_run):
+            with patch("backend.server._list_configured_provider_records", records):
+                run = await orchestrator.execute(req)
+
+        assert run.llm_provenance["execute"] == "fast-model"
+        assert call_count == 2
+
+    async def test_llm_provenance_is_none_for_phases_without_llm(self, monkeypatch):
+        """Phases that don't use an LLM (CLASSIFY, PERSIST, etc.) don't record provenance."""
+        records = _mock_provider_records(
+            {"provider_id": "only", "base_url": "http://only.local", "type": "openai", "api_key": "k1", "default_model": "only-model", "priority": 10},
+        )
+
+        orchestrator = WorkflowOrchestrator()
+        req = ExecutionRequest(request="provenance check", auto_approve=True)
+
+        with patch("agent.loop.AgentRunner.run", AsyncMock(return_value={
+            "summary": "ok", "steps": [], "judge": {},
+        })):
+            with patch("backend.server._list_configured_provider_records", records):
+                run = await orchestrator.execute(req)
+
+        # Only "execute" has provenance; other phases don't.
+        assert "execute" in run.llm_provenance
+        assert run.llm_provenance["execute"] == "only-model"
+        # CLASSIFY doesn't call _resolve_brain_provider.
+        assert "classify" not in run.llm_provenance
+        # VERIFY doesn't call _resolve_brain_provider.
+        assert "verify" not in run.llm_provenance
+
+    async def test_phase_attempts_incremented_on_each_retry(self, monkeypatch):
+        """phase_attempts tracks the attempt count per phase through retries."""
+        call_count = 0
+
+        async def _runner_run(self, instruction, history, requested_model, auto_commit, max_steps, user_id, session_id):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise ConnectionError("fail 1")
+            if call_count == 2:
+                raise ConnectionError("fail 2")
+            return {"summary": "success", "steps": [], "judge": {}}
+
+        records = _mock_provider_records(
+            {"provider_id": "a", "base_url": "http://a.local", "type": "openai", "api_key": "k1", "default_model": "a", "priority": 30},
+            {"provider_id": "b", "base_url": "http://b.local", "type": "openai", "api_key": "k2", "default_model": "b", "priority": 20},
+            {"provider_id": "c", "base_url": "http://c.local", "type": "openai", "api_key": "k3", "default_model": "c", "priority": 10},
+        )
+
+        orchestrator = WorkflowOrchestrator()
+        req = ExecutionReques

--- a/tests/test_scanner_ssl_cert.py
+++ b/tests/test_scanner_ssl_cert.py
@@ -126,7 +126,4 @@ def test_analyze_ssl_cert_maps_decoded_cert_to_systems(monkeypatch):
 
 class _RaisingCtx:
     check_hostname = True
-    verify_mode = None
-
-    def wrap_socket(self, sock, server_hostname=None):
-        raise OSError("verification failed (simulated)")
+    veri


### PR DESCRIPTION
## Changes

### Dashboard — AgentActivityWidget
- New `AgentActivityWidget` added to the dashboard widget grid
- Shows a task status **Donut chart** (done/running/pending/failed distribution) from `/api/tasks/`
- Shows a **7-day activity sparkline** built from `/api/activity` event timestamps
- Live **active agent count badge** from `/api/agents/`
- Fully resilient: uses existing `ErrorBoundary` + `useSafeData` pattern — agent endpoint failure only greys the badge, never blanks the widget
- Imports from `Charts.jsx` (zero-dependency SVG, added on this branch)

### CompanyScreen — Systems tab
- Systems now **grouped by category** (CMS, CRM, analytics, payment_gateway, etc.) with color-coded category headers
- Each detected system shows:
  - Version number if available
  - **Detection method badges** (html/dns/ssl/headers/script/cookie) in distinct colours
  - **Confidence mini-bar** + percentage score (green ≥80%, amber ≥50%, red below)
  - Connected vs Detected status label
- **Summary bar** at top: "N systems detected across M categories" + separate auto-detected / connected counters
- Empty state guides users to run a scan
- View-model extended to pass `confidence`, `detectionMethods`, `version`, `isDetected` through from `graph.detected_systems`

### Tests included
- `tests/e2e/test_critical_flows.py` — Playwright E2E flows (from prior branch, now on master path)
- `tests/test_orchestrator_failover.py` — orchestrator failover regression
- `tests/test_scanner_ssl_cert.py` — SSL cert scanner tests

### Changelog
- Updated `docs/changelog.md` under `[Unreleased] ### Added`

Closes part of #581 (sprint tracker).