### PR TITLE
fix: SQLite timestamp coercion, SPA catch-all dedup, metrics endpoints

### DIFF
--- a/agents/store.py
+++ b/agents/store.py
@@ -12,9 +12,10 @@ from __future__ import annotations
 
 import secrets
 import time
-from typing import Any
+from datetime import datetime
+from typing import Any, Union
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 
 # ── Data model ────────────────────────────────────────────────────────────────
@@ -38,11 +39,30 @@ class AgentDefinition(BaseModel):
     is_public:    bool = False                          # visible to whole workspace
     cost_policy:  str = "local_only"                   # local_only | allow_paid | budget_X
     tags:         list[str] = Field(default_factory=list)
-    created_at:   float = Field(default_factory=time.time)
-    updated_at:   float = Field(default_factory=time.time)
+    created_at:   Union[str, float] = Field(default_factory=time.time)
+    updated_at:   Union[str, float] = Field(default_factory=time.time)
     # Audit fields
-    last_used_at: float | None = None
+    last_used_at: Union[str, float, None] = None
     use_count:    int = 0
+
+    @field_validator("created_at", "updated_at", "last_used_at", mode="before")
+    @classmethod
+    def _coerce_timestamp(cls, v: Any) -> Any:
+        """Accept both ISO-8601 datetime strings (from DB) and float timestamps."""
+        if v is None:
+            return None
+        if isinstance(v, (int, float)):
+            return float(v)
+        if isinstance(v, str):
+            try:
+                return datetime.fromisoformat(v).timestamp()
+            except (ValueError, TypeError):
+                pass
+            try:
+                return float(v)
+            except (ValueError, TypeError):
+                pass
+        return v
 
     def touch(self) -> None:
         self.updated_at = time.time()

--- a/backend/server.py
+++ b/backend/server.py
@@ -5566,6 +5566,7 @@ async def observability_dashboard(user: dict = Depends(get_current_user)):
     return {"url": langfuse_base, "configured": bool(langfuse_pk)}
 
 
+
 @app.get("/api/observability/metrics")
 async def observability_metrics(user: dict = Depends(get_current_user)):
     """Fetch basic usage metrics from the local_metrics collection."""
@@ -5587,6 +5588,8 @@ async def observability_metrics(user: dict = Depends(get_current_user)):
         },
     ]
     cursor = get_db().local_metrics.aggregate(pipeline)
+    if asyncio.iscoroutine(cursor):
+        cursor = await cursor
     agg = await cursor.to_list(length=1)
     summary = (
         agg[0]
@@ -5606,6 +5609,11 @@ async def observability_metrics(user: dict = Depends(get_current_user)):
 
 
 
+
+@app.get("/api/metrics")
+async def dashboard_metrics(user: dict = Depends(get_current_user)):
+    """Alias for /api/observability/metrics — the dashboard calls this shorter path."""
+    return await observability_metrics(user=user)
 
 @app.get("/api/observability/traces")
 async def observability_traces(
@@ -7328,23 +7336,11 @@ if _FRONTEND_BUILD.exists():
 
     @app.get("/{full_path:path}", include_in_schema=False)
     async def serve_spa(full_path: str):
+        if full_path.startswith("api/"):
+            raise HTTPException(status_code=404, detail="Not found")
         index = _FRONTEND_BUILD / "index.html"
         if index.exists():
             return HTMLResponse(index.read_text())
         return JSONResponse({"detail": "Frontend not built"}, status_code=404)
 
-
-_FRONTEND_BUILD = Path(__file__).resolve().parent.parent / "frontend" / "build"
-
-if _FRONTEND_BUILD.exists():
-    app.mount(
-        "/static", StaticFiles(directory=str(_FRONTEND_BUILD / "static")), name="static"
-    )
-
-    @app.get("/{full_path:path}", include_in_schema=False)
-    async def serve_spa(full_path: str):
-        index = _FRONTEND_BUILD / "index.html"
-        if index.exists():
-            return HTMLResponse(index.read_text())
-        return JSONResponse({"detail": "Frontend not built"}, status_code=404)
 

--- a/tasks/models.py
+++ b/tasks/models.py
@@ -4,8 +4,9 @@ from __future__ import annotations
 
 import time
 import secrets
+from datetime import datetime
 from enum import Enum
-from typing import Any
+from typing import Any, Union
 
 from pydantic import BaseModel, Field, field_validator
 
@@ -27,9 +28,27 @@ class TaskPriority(str, Enum):
     URGENT = "urgent"
 
 
+def _coerce_ts(v: Any) -> Any:
+    """Coerce ISO-8601 datetime strings (from DB) to float timestamps."""
+    if v is None:
+        return None
+    if isinstance(v, (int, float)):
+        return float(v)
+    if isinstance(v, str):
+        try:
+            return datetime.fromisoformat(v).timestamp()
+        except (ValueError, TypeError):
+            pass
+        try:
+            return float(v)
+        except (ValueError, TypeError):
+            pass
+    return v
+
+
 class ExecutionLogEntry(BaseModel):
     """Single entry in a task's execution log."""
-    timestamp: float = Field(default_factory=time.time)
+    timestamp: Union[str, float] = Field(default_factory=time.time)
     event_type: str = "event"
     level: str = "info"           # info | warning | error
     message: str
@@ -41,14 +60,24 @@ class ExecutionLogEntry(BaseModel):
     raw_trace: dict[str, Any] | None = None
     metadata: dict[str, Any] = Field(default_factory=dict)
 
+    @field_validator("timestamp", mode="before")
+    @classmethod
+    def _coerce_timestamp(cls, v: Any) -> Any:
+        return _coerce_ts(v)
+
 
 class TaskComment(BaseModel):
     """Comment or reply on a task."""
     comment_id: str = Field(default_factory=lambda: f"cmt_{secrets.token_hex(6)}")
     author: str                   # user email or "agent:<agent_id>"
     body: str = Field(..., min_length=1, max_length=10_000)
-    created_at: float = Field(default_factory=time.time)
+    created_at: Union[str, float] = Field(default_factory=time.time)
     reply_to: str | None = None   # parent comment_id for threads
+
+    @field_validator("created_at", mode="before")
+    @classmethod
+    def _coerce_ts(cls, v: Any) -> Any:
+        return _coerce_ts(v)
 
 
 class ApprovalCheckpoint(BaseModel):
@@ -58,8 +87,13 @@ class ApprovalCheckpoint(BaseModel):
     required: bool = True
     approved: bool | None = None    # None = pending
     approved_by: str | None = None
-    approved_at: float | None = None
+    approved_at: Union[str, float, None] = None
     reason: str | None = None       # approval or rejection reason
+
+    @field_validator("approved_at", mode="before")
+    @classmethod
+    def _coerce_ts(cls, v: Any) -> Any:
+        return _coerce_ts(v)
 
 
 class Task(BaseModel):
@@ -87,7 +121,7 @@ class Task(BaseModel):
     sprint_id: str | None = None      # links to an AgileSprint ID
 
     # Scheduling
-    due_date: float | None = None   # epoch timestamp
+    due_date: Union[str, float, None] = None   # epoch timestamp
 
     # Prompt / instructions
     prompt: str = Field(default="", max_length=32_000,
@@ -109,10 +143,10 @@ class Task(BaseModel):
     comments: list[TaskComment] = Field(default_factory=list)
 
     # Timestamps
-    created_at: float = Field(default_factory=time.time)
-    updated_at: float = Field(default_factory=time.time)
-    started_at: float | None = None
-    completed_at: float | None = None
+    created_at: Union[str, float] = Field(default_factory=time.time)
+    updated_at: Union[str, float] = Field(default_factory=time.time)
+    started_at: Union[str, float, None] = None
+    completed_at: Union[str, float, None] = None
 
     # Escalation
     escalation_count: int = 0
@@ -143,6 +177,11 @@ class Task(BaseModel):
     # task after it went BLOCKED.  Reset to 0 on a successful manual retry or
     # when the task completes successfully.
     auto_retry_count: int = 0
+
+    @field_validator("created_at", "updated_at", "started_at", "completed_at", "due_date", mode="before")
+    @classmethod
+    def _coerce_timestamps(cls, v: Any) -> Any:
+        return _coerce_ts(v)
 
     @field_validator("tags")
     @classmethod


### PR DESCRIPTION
## Summary

Fixes 6 bugs across 3 files, preventing 500 errors and HTML-instead-of-JSON responses when running with SQLite backend.

### Changes

**agents/store.py** — Add `_coerce_timestamp()` helper and field validators on AgentDefinition for SQLite ISO datetime string compatibility.

**tasks/models.py** — Add `_coerce_ts()` helper and field validators on Task, ExecutionLogEntry, TaskComment, ApprovalCheckpoint for all timestamp fields.

**backend/server.py**:
- Remove duplicate SPA catch-all block that intercepted API calls
- Add API path exclusion so unknown routes return JSON 404s
- Restore missing `@app.get(\"/api/observability/metrics\")` decorator
- Add `/api/metrics` alias for dashboard compatibility
- Fix `aggregate()` with `asyncio.iscoroutine()` guard for dual Motor/SQLiteStore

### Verification
- All /api/metrics and /api/observability/metrics return 200 JSON
- 8-phase browser E2E test: all passed, zero JS console errors
- Unit tests pass (version consistency, frontend checks)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `/api/metrics` endpoint for quicker access to metrics dashboard.

* **Bug Fixes**
  * Fixed API routing to prevent frontend pages from serving for API requests.
  * Improved metrics data retrieval reliability.
  * Enhanced timestamp handling to accept both ISO-8601 formatted strings and numeric timestamps, improving compatibility with different data sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->