### PR TITLE
test: fix flaky Test (Python 3.13) — skip background loops under TestClient

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,6 +44,18 @@ if not os.environ.get("ADMIN_PASSWORD"):
 # process-wide; tests that exercise the loop itself call _start_ceo_agency directly.
 os.environ.setdefault("AGENCY_CEO_ENABLED", "false")
 
+# ── Keep the web lifespan from starting the background service stack ──────────
+# `TestClient(app)` runs the FastAPI lifespan, which (when RUN_BACKGROUND_IN_WEB
+# is not "false") calls start_background_services() → TaskDispatcher + the 24×7
+# autonomy loops (improvement / self-heal / log-monitor / trend-watcher). Those
+# spawn asyncio tasks and daemon threads that outlive the per-test event loop and
+# race its teardown, producing intermittent "RuntimeError: Event loop is closed"
+# / "coroutine AgentScheduler.hydrate was never awaited" failures in the e2e
+# tests (flaky "Test (Python 3.13)"). Tests that exercise these services start
+# them directly (e.g. test_background_services / test_autonomy_bootstrap) or set
+# the flag explicitly, so disabling the lifespan auto-start here is safe.
+os.environ.setdefault("RUN_BACKGROUND_IN_WEB", "false")
+
 # ── Now safe to import backend modules that read ADMIN_PASSWORD ──────────────
 
 import pytest


### PR DESCRIPTION
## Fix the recurring flaky `Test (Python 3.13)` at its source

Every recent PR has been hit by intermittent `Test (Python 3.13)` failures — the *same commit* passing on one run and failing on a parallel/re-run. The failure signature in the logs is `RuntimeError: Event loop is closed` and `coroutine 'AgentScheduler.hydrate' was never awaited` in the e2e suite.

### Root cause
`TestClient(app)` runs the FastAPI **lifespan**, which calls `start_background_services()` whenever `RUN_BACKGROUND_IN_WEB` isn't `false` (it defaults to `true`). Once the 24×7 autonomy loops were activated (#683), that means every e2e test using the app client now spins up the **TaskDispatcher + improvement / self-heal / log-monitor / trend-watcher** loops. Those schedule `asyncio` tasks and daemon threads that **outlive the per-test event loop** and race its teardown → intermittent "Event loop is closed" failures. Because the loops start non-deterministically relative to teardown, it's flaky, not consistent.

### Fix
`tests/conftest.py` already disables the CEO loop (`AGENCY_CEO_ENABLED=false`) for exactly this hermeticity reason. This adds the parallel `RUN_BACKGROUND_IN_WEB=false` default so the lifespan skips the background stack during tests.

- Tests that actually exercise these services start them directly or set the flag explicitly — verified green: `test_backend_runtime_bootstrap`, `test_background_services`, `test_autonomy_bootstrap` (12 passed).
- Production behaviour unchanged (`RUN_BACKGROUND_IN_WEB` defaults to `true` outside tests; `render.yaml` controls it for the live deploy).

This should end the per-PR CI thrash that's required repeated re-runs to merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01K5w3NvpNyN4Umq3rGKFEVA)_