### PR TITLE
ci: keep-alive workflow for free-tier 24/7 autonomy (no paid worker)

### DIFF
--- a/.github/workflows/keepalive.yml
+++ b/.github/workflows/keepalive.yml
@@ -28,7 +28,7 @@ concurrency:
 jobs:
   ping:
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 10
     steps:
       - name: Ping health + autonomy status (warm the dyno)
         env:

--- a/.github/workflows/keepalive.yml
+++ b/.github/workflows/keepalive.yml
@@ -1,0 +1,58 @@
+name: Keep-alive (prevent free-tier spin-down)
+
+# Render's free web tier sleeps after ~15 min without inbound HTTP. The 24×7
+# autonomy loops (improvement / self-heal / log-monitor / trend-watcher) run
+# INSIDE the web service (render.yaml: RUN_BACKGROUND_IN_WEB=true), so keeping
+# the web service awake keeps the loops running — no paid worker required.
+#
+# This pings the public health endpoint every ~10 min from GitHub's runners
+# (which have open internet, unlike the dev sandbox). Override the target with a
+# repo variable KEEPALIVE_URL if the service URL changes.
+#
+# NOTE: GitHub cron is best-effort and can be delayed under load. For hard 24×7
+# uptime, also point a free external monitor (UptimeRobot / cron-job.org) at the
+# same /api/health URL on a 5-minute interval.
+
+on:
+  schedule:
+    - cron: "*/10 * * * *"
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+concurrency:
+  group: keepalive
+  cancel-in-progress: false
+
+jobs:
+  ping:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Ping health + autonomy status (warm the dyno)
+        env:
+          BASE_URL: ${{ vars.KEEPALIVE_URL || 'https://local-llm-server.onrender.com' }}
+        run: |
+          set -u
+          # Free dynos can take 30-60s to cold-start; retry with backoff and
+          # treat a wake-up as success even if the first probes are slow.
+          ok=0
+          for attempt in 1 2 3 4 5 6; do
+            code=$(curl -s -o /tmp/health.txt -w '%{http_code}' --max-time 60 "$BASE_URL/api/health" || echo "000")
+            echo "attempt $attempt: GET /api/health -> $code"
+            if [ "$code" = "200" ]; then ok=1; break; fi
+            sleep 15
+          done
+
+          # Best-effort: surface the autonomy readiness so the run log doubles as
+          # a live status check. Non-fatal.
+          echo "--- /api/autonomy/status ---"
+          curl -s --max-time 60 "$BASE_URL/api/autonomy/status" || true
+          echo ""
+
+          if [ "$ok" != "1" ]; then
+            echo "::warning::Health endpoint did not return 200 after retries — the service may be cold-starting or down."
+            # Do not fail the scheduled job on a single missed wake-up; the next
+            # run retries. Flip to 'exit 1' if you want failure notifications.
+          fi


### PR DESCRIPTION
## Keep the free-tier web service (and the autonomy loops) awake 24/7

You don't want to pay for an always-on worker. This achieves continuous autonomy on the free tier instead.

**Why it works:** the 24×7 autonomy loops (improvement / self-heal / log-monitor / trend-watcher) run **inside the web service** (`render.yaml`: `RUN_BACKGROUND_IN_WEB=true`), not only in the worker. Render's free web tier sleeps after ~15 min of no inbound HTTP, which stops the loops. A periodic ping keeps the web service warm → the loops keep running.

**What it does:** a GitHub Actions cron (every 10 min) pings `/api/health` from GitHub's runners (open internet) with cold-start retries, and logs `/api/autonomy/status` so each run doubles as a live readiness check. Target is overridable via a `KEEPALIVE_URL` repo variable.

**Caveats (documented in the workflow):**
- GitHub cron is best-effort and can be delayed; for hard uptime, also point a free external monitor (UptimeRobot / cron-job.org) at the same `/api/health` URL on a 5-min interval.
- Keeping a free web service always-on consumes Render's ~750 free instance-hours/month — fine for one always-on service.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01K5w3NvpNyN4Umq3rGKFEVA)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Implemented automated service health monitoring that performs regular checks to maintain consistent uptime and ensure the service remains available and responsive without unexpected interruptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->